### PR TITLE
fix import sorting, remove sgp-app references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,9 +11,10 @@ repos:
 
   - repo: local
     hooks:
-      - id: agentex-sgp-app-lint-fix
-        name: Agentex SGP App Linting
-        entry: bash -c 'cd agentex-sgp-app && npx eslint --fix --no-warn-ignored --max-warnings=0 $(echo "$@" | sed "s|agentex-sgp-app/||g")' --
+      - id: agentex-ui-lint-fix
+        name: Agentex UI Linting
+        entry: bash -c 'cd agentex-ui && npx eslint --fix --no-warn-ignored --max-warnings=0 $(echo "$@" | sed "s|agentex-ui/||g")' --
         language: system
-        files: ^agentex-sgp-app/.*\.(ts|tsx|js|jsx)$
+        files: ^agentex-ui/.*\.(ts|tsx|js|jsx)$
         pass_filenames: true
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,6 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": "explicit",
             "source.fixAll.eslint": "explicit"
         }
     },
@@ -30,7 +29,6 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": "explicit",
             "source.fixAll.eslint": "explicit"
         }
     },
@@ -57,7 +55,7 @@
     "eslint.useFlatConfig": true,
     "eslint.workingDirectories": [
         {
-            "pattern": "agentex-sgp-app"
+            "pattern": "agentex-ui"
         }
     ],
     "prettier.documentSelectors": ["**/*.{ts,tsx,js,jsx}"],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Agentex is a comprehensive platform for building and deploying intelligent agents. This repository contains:
 
 - **agentex/** - Backend services (FastAPI + Temporal workflows)
-- **agentex-sgp-app/** - Developer UI for interacting with agents
+- **agentex-ui/** - Developer UI for interacting with agents
 
 The platform integrates with the separate [agentex-python SDK](https://github.com/scaleapi/scale-agentex-python) for creating and running agents.
 
@@ -30,7 +30,7 @@ make dev                    # Starts Docker services and backend
 
 **Terminal 2 - Frontend:**
 ```bash
-cd agentex-sgp-app/
+cd agentex-ui/
 npm install
 npm run dev                 # Starts Next.js dev server
 ```
@@ -94,7 +94,7 @@ make build-docs           # Build documentation
 make docker-build         # Build production Docker image
 ```
 
-### Frontend (agentex-sgp-app/)
+### Frontend (agentex-ui/)
 
 ```bash
 npm install               # Install npm dependencies
@@ -219,7 +219,7 @@ Tests are organized by type and use different strategies:
 - **States**: Key-value state storage for agents
 - **Deployment History**: Track agent deployment versions and changes
 
-### Frontend Architecture (agentex-sgp-app/)
+### Frontend Architecture (agentex-ui/)
 
 - **Framework**: Next.js 15 with React 19 and App Router
 - **Styling**: Tailwind CSS with Radix UI components
@@ -310,4 +310,4 @@ sudo systemctl stop redis-server
 
 This repository contains two main components:
 - **Backend**: `agentex/src/`, `agentex/database/`, `agentex/tests/`
-- **Frontend**: `agentex-sgp-app/`
+- **Frontend**: `agentex-ui/`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The installation was successful if you see help output after you run `agentex -h
 
 Before you share your agents with other people (or your company), you'll want a fully isolated developer sandbox. This allows you to freely develop agents without affecting anyone else or be affected by anyone else.
 
-To do this, you just need to spin up the [Agentex Server](https://github.com/scaleapi/scale-agentex/tree/main/agentex) and a [Developer UI](https://github.com/scaleapi/scale-agentex/tree/main/agentex-sgp-app) which allows you to interact with your agent nicely. This way you'll know how your agent feels in a simple UI.
+To do this, you just need to spin up the [Agentex Server](https://github.com/scaleapi/scale-agentex/tree/main/agentex) and a [Developer UI](https://github.com/scaleapi/scale-agentex/tree/main/agentex-ui) which allows you to interact with your agent nicely. This way you'll know how your agent feels in a simple UI.
 
 > Each agent also ships with a `dev.ipynb` notebook for those uninterested in a UI, but more on that later
 
@@ -116,7 +116,7 @@ Then, open up a second terminal. Then run the following commands.
 *Note: you should run these commands at the root of this repository.*
 
 ```bash
-cd agentex-sgp-app/
+cd agentex-ui/
 # Install dependencies (see Makefile for details)
 make install
 # Starts web interface on localhost (default port 3000)

--- a/agentex-ui/.vscode/settings.json
+++ b/agentex-ui/.vscode/settings.json
@@ -1,3 +1,17 @@
 {
-  "cSpell.words": ["Agentex"]
+  "cSpell.words": ["Agentex"],
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit"
+    }
+  }
 }

--- a/agentex-ui/components/agentex/task-messages.tsx
+++ b/agentex-ui/components/agentex/task-messages.tsx
@@ -10,13 +10,13 @@ import { useAgentexClient } from '@/components/providers';
 import { useTaskMessages } from '@/hooks/use-task-messages';
 
 import { TaskMessageToolPairComponent } from './task-message-tool-pair';
+import { ShimmeringText } from '../ui/shimmering-text';
 
 import type {
   TaskMessage,
   ToolRequestContent,
   ToolResponseContent,
 } from 'agentex/resources';
-import { ShimmeringText } from '../ui/shimmering-text';
 
 type TaskMessagesComponentProps = {
   taskId: string;
@@ -199,15 +199,15 @@ function MemoizedTaskMessagesComponentImpl({
               ))}
             </AnimatePresence>
             <AnimatePresence>
-            {pair.agentMessages.length === 0 && (
+              {pair.agentMessages.length === 0 && (
                 <motion.div
-                  initial={{ opacity: 0 , y: 10 }}
+                  initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 10 }}
                   exit={{ opacity: 0, y: -10 }}
                   transition={{ duration: 0.3 }}
                   className="px-4 py-2"
                 >
-                  <ShimmeringText text='Thinking ...' enabled={true} />
+                  <ShimmeringText text="Thinking ..." enabled={true} />
                 </motion.div>
               )}
             </AnimatePresence>

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,10 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 
 [manifest]
 members = [
     "agentex",
-    "agentex-auth",
     "agentex-backend",
 ]
 
@@ -41,41 +40,6 @@ dev = [
     { name = "ruff", specifier = ">=0.3.4" },
 ]
 docs = [{ name = "agentex", extras = ["docs"] }]
-
-[[package]]
-name = "agentex-auth"
-version = "0.1.0"
-source = { virtual = "agentex-auth" }
-dependencies = [
-    { name = "ddtrace" },
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pre-commit" },
-    { name = "ruff" },
-    { name = "rust-just" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "ddtrace", specifier = ">=3.13.0" },
-    { name = "fastapi", specifier = ">=0.115.14" },
-    { name = "httpx", specifier = ">=0.27.2" },
-    { name = "pydantic", specifier = ">=2.11.7" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.31.1" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "ruff", specifier = ">=0.12.2" },
-    { name = "rust-just", specifier = ">=1.41.0" },
-]
 
 [[package]]
 name = "agentex-backend"
@@ -2237,28 +2201,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/00/e7f1501e81e8ec290e79527827af1d88f541d8d26151751b46108978dade/ruff-0.13.2-py3-none-win32.whl", hash = "sha256:7c2a0b7c1e87795fec3404a485096bcd790216c7c146a922d121d8b9c8f1aaac", size = 12245990, upload-time = "2025-09-25T14:54:03.647Z" },
     { url = "https://files.pythonhosted.org/packages/ee/bd/d9f33a73de84fafd0146c6fba4f497c4565fe8fa8b46874b8e438869abc2/ruff-0.13.2-py3-none-win_amd64.whl", hash = "sha256:17d95fb32218357c89355f6f6f9a804133e404fc1f65694372e02a557edf8585", size = 13324004, upload-time = "2025-09-25T14:54:06.05Z" },
     { url = "https://files.pythonhosted.org/packages/c3/12/28fa2f597a605884deb0f65c1b1ae05111051b2a7030f5d8a4ff7f4599ba/ruff-0.13.2-py3-none-win_arm64.whl", hash = "sha256:da711b14c530412c827219312b7d7fbb4877fb31150083add7e8c5336549cea7", size = 12484437, upload-time = "2025-09-25T14:54:08.022Z" },
-]
-
-[[package]]
-name = "rust-just"
-version = "1.43.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/38/6a/c3a30e58cee6c10c70736076f07291757ad6e69dc932b73b85a3840da672/rust_just-1.43.0.tar.gz", hash = "sha256:13802293226aa10371c9253484cfaa0326ee91cf941716cd21c4603fc5ad95be", size = 1427974, upload-time = "2025-09-28T01:58:49.087Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6c/81f0e898dada1a1d0a09d11a8e79063f252e659fa89236be300bcc8d09f7/rust_just-1.43.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1da5ed623e3f06a5e1a9c6224131cf8cf2fc525e30433cfcb36c47c58867a39", size = 1637483, upload-time = "2025-09-28T01:58:09.682Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/c0/5c4d25706ca3e15f9c2f15ccbc67eb05994c2bebe91cc2b53d03a73bc172/rust_just-1.43.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:220e02d2e4f96391c570f5f0512a07aecb1e821a79d891b49143447e84623df1", size = 1501043, upload-time = "2025-09-28T01:58:12.474Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/53/dd02e206826377bf4828665dfb85d7cf4160450e036e0d2935319ad52c2b/rust_just-1.43.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b68813174921b1ddbdd9f7580054e351f7873c145c45143d2209f876e60f9928", size = 1579751, upload-time = "2025-09-28T01:58:15.728Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/1c/f5bfb7bbe719d4937f0bb9cf3a49c6a01b007324fa386feb6a65c63ad425/rust_just-1.43.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b43f3baf5171ffd87ee0d44b1163d145e2dacb0f0768476104c66a6ac147a896", size = 1564994, upload-time = "2025-09-28T01:58:18.597Z" },
-    { url = "https://files.pythonhosted.org/packages/88/61/e3403f35ebb8f160bcb5c7f205f97f1f95618bded3f7d1b3a1614557864a/rust_just-1.43.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:10ef97e6eb822dfeec8f9cfcbfe04ffcaac0f2debef2ab36fb64fea6d805e4b2", size = 1736602, upload-time = "2025-09-28T01:58:21.429Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c8/d282def394a98b3f02c24d60dec6cb4fe92fedd6e625386a52fb8361fd52/rust_just-1.43.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:19eba7954b25c4f9b458324c31b48dd3acf610657b45a2f1a14224f68a95bfea", size = 1815227, upload-time = "2025-09-28T01:58:24.249Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/1f/fcd2c1134406a4bb5dc92289402be17c6b9c4646231316462664360b9648/rust_just-1.43.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:670a30f9754f21433baeaf414991ffd8313232c2267c7f29da4c775819ae9ea6", size = 1851551, upload-time = "2025-09-28T01:58:27.134Z" },
-    { url = "https://files.pythonhosted.org/packages/50/c1/0df8e7bc69663d330892554a7cd3b0a3748918e9362d011bed0851e39942/rust_just-1.43.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1d89a734f74fbda49c1be8c916ec090d9ece7a81cec3b884d140a025c125c5a", size = 1722046, upload-time = "2025-09-28T01:58:29.949Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/eb/b4a7701b4d29adb79fd8079ee0c19b5704ec1d55f4bfdec5ad69b76d43e2/rust_just-1.43.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bda375fd508d0cdd1326c48f6e9929244c77db203c328b94d475b3767de8234c", size = 1594521, upload-time = "2025-09-28T01:58:33.094Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/27/201d6364ff76df3cafaf1ecc77e0b6216703558b33b141145476a198d22c/rust_just-1.43.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8013cbc6fed0edefc5e465acf7e4d30021e97dd63a0230de57ba4c4ca1b58480", size = 1583098, upload-time = "2025-09-28T01:58:36.003Z" },
-    { url = "https://files.pythonhosted.org/packages/28/11/fbf1274e8b253856fc8ca9182ee1a735a1c60affc5f499df5cc71dc73f9f/rust_just-1.43.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c45cf5f81de76ccb53069e247657cfb4a54b915799fdc79376ae6b395c3c5c7a", size = 1725363, upload-time = "2025-09-28T01:58:38.514Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/4e/c548a8054a4e4eccb139ff20616f20963f3285086adfc77b6d8508ef06d7/rust_just-1.43.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d9755908c74b54479a60284663d3eb6a15f980ecdbe23a25a87b68294a38798a", size = 1789152, upload-time = "2025-09-28T01:58:41.105Z" },
-    { url = "https://files.pythonhosted.org/packages/02/fe/6915aec2576c8e417089be715688e6483c1f4022da345b6a86016db6474d/rust_just-1.43.0-py3-none-win32.whl", hash = "sha256:70cd83bf6dcbca3f3fd8fd886e00a83fc75355c13443430b7cd642fee03de3b4", size = 1528946, upload-time = "2025-09-28T01:58:43.98Z" },
-    { url = "https://files.pythonhosted.org/packages/37/c9/b7bce617fe77201494d751d02c9a16b27730fde9016256984dd7da1c32a5/rust_just-1.43.0-py3-none-win_amd64.whl", hash = "sha256:e7f98c68078f0cc129fdcd68e721fd6afc9dc55dda080bf29f6101ba097fd8a4", size = 1662346, upload-time = "2025-09-28T01:58:46.39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes a couple things:

* Linting pre-commit step was broken cuz it referenced sgp-app 
* Vscode auto-sort imports settings were conflicting with eslint's auto import sorting 
* A couple references to sgp-app in docs 
* `agentex-auth` was referenced as a package in the uv lock 