### PR TITLE
Fix use infinite tasks hook

### DIFF
--- a/agentex-ui/hooks/use-tasks.ts
+++ b/agentex-ui/hooks/use-tasks.ts
@@ -20,29 +20,6 @@ export const tasksKeys = {
 };
 
 /**
- * Fetches the list of tasks, optionally filtered by agent name
- */
-export function useTasks(
-  agentexClient: AgentexSDK,
-  options?: { agentName?: string }
-) {
-  const { agentName } = options || {};
-
-  return useQuery({
-    queryKey: tasksKeys.byAgentName(agentName),
-    queryFn: async (): Promise<TaskListResponse> => {
-      const params: TaskListParams = {
-        relationships: ['agents'],
-        ...(agentName ? { agent_name: agentName } : {}),
-      };
-      return agentexClient.tasks.list(params);
-    },
-    staleTime: 30 * 1000, // 30 seconds
-    refetchOnWindowFocus: true,
-  });
-}
-
-/**
  * Fetches a single task by ID
  */
 export function useTask({


### PR DESCRIPTION
Removes the useTasks hook (was not in use) and fixes the useCreateTask hook to respect the InfiniteData type that is returned from the useInfiniteQuery hook 

This caused a bug on the frontend where trying to create a task after fetching all tasks would cause an error 