### PR TITLE
Order tasks desc by default

### DIFF
--- a/agentex/src/domain/repositories/task_repository.py
+++ b/agentex/src/domain/repositories/task_repository.py
@@ -30,7 +30,7 @@ class TaskRepository(PostgresCRUDRepository[TaskORM, TaskEntity]):
         agent_id: str | None = None,
         agent_name: str | None = None,
         order_by: str | None = None,
-        order_direction: Literal["asc", "desc"] = "asc",
+        order_direction: Literal["asc", "desc"] = "desc",
         limit: int | None = None,
         page_number: int | None = None,
     ) -> list[TaskEntity]:


### PR DESCRIPTION
Changes the TaskRespository's list tasks method to order by desc, by default. This makes the most recently created tasks appear at the beginning of the list, which is more intuitive imo and more convenient for the frontend. 

Ideally, we would expose this as a parameter in the `/tasks` endpoint, but then we should do that change across all bulk get endpoints, and that would require an SDK change. I think this is okay for now 