### PR TITLE
Add feedback button to sidebar bottom

### DIFF
--- a/agentex-ui/components/agentex/task-sidebar.tsx
+++ b/agentex-ui/components/agentex/task-sidebar.tsx
@@ -7,6 +7,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
   Loader2,
+  MessageSquare,
   MessageSquarePlus,
   PanelLeftClose,
   PanelLeftOpen,
@@ -176,6 +177,14 @@ export function TaskSidebar() {
     setIsCollapsed(prev => !prev);
   }, []);
 
+  const handleFeedback = useCallback(() => {
+    window.open(
+      'https://github.com/scaleapi/scale-agentex/issues/new',
+      '_blank',
+      'noopener,noreferrer'
+    );
+  }, []);
+
   return (
     <ResizableSidebar
       side="left"
@@ -231,6 +240,17 @@ export function TaskSidebar() {
               )}
             </>
           )}
+        </div>
+        <div className="mt-auto px-2 pt-2">
+          <Separator className="mb-2" />
+          <Button
+            onClick={handleFeedback}
+            variant="ghost"
+            className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-primary-foreground flex w-full items-center justify-start gap-2"
+          >
+            <MessageSquare className="size-4" />
+            Give Feedback
+          </Button>
         </div>
       </div>
     </ResizableSidebar>


### PR DESCRIPTION
Adds a stickyt feedback button to the bottom of the task sidebar: 

<img width="809" height="192" alt="image" src="https://github.com/user-attachments/assets/70511ac3-c884-4690-aa5f-ff43d5cf667a" />


redirects to the [new issue page](https://github.com/scaleapi/scale-agentex/issues/new) for this repository 