### PR TITLE
Always focus prompt input when new chat is clicked

### DIFF
--- a/agentex-ui/components/agentex/prompt-input.tsx
+++ b/agentex-ui/components/agentex/prompt-input.tsx
@@ -69,13 +69,13 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
   // Focus the prompt input when taskID is cleared
   useEffect(() => {
     if (!taskID && isClient) {
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         if (isSendingJSON) {
           codeMirrorViewRef.current?.focus();
         } else {
           textInputRef.current?.focus();
         }
-      }, 0);
+      });
     }
   }, [taskID, isClient, isSendingJSON]);
 


### PR DESCRIPTION
Minor QOL thing — focuses the prompt input whenever a new chat is initiated. Works if you hit the button or hit cmd+k