### PR TITLE
expose container networks

### DIFF
--- a/agentex/docker-compose.host-access.yml
+++ b/agentex/docker-compose.host-access.yml
@@ -1,0 +1,8 @@
+# docker-compose.host-access.yml
+# Override file to add host access when needed
+# Usage: docker-compose -f docker-compose.yml -f docker-compose.host-access.yml up
+services:
+  agentex:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+

--- a/agentex/docker-compose.yml
+++ b/agentex/docker-compose.yml
@@ -140,8 +140,6 @@ services:
       context: ..
       dockerfile: agentex/Dockerfile
       target: dev
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     environment:
       - ENVIRONMENT=development
       - UVICORN_PORT=5003


### PR DESCRIPTION
This is needed to run the integration tests in scale-agentex-python. The reason is that the agentex server that is running in its own container cannot access the agent directly within the CI/CD pipeline if this is not set. 

Tested that running `make dev` with an agent still works as expected