### PR TITLE
Axe next dev indicator

### DIFF
--- a/agentex-ui/next.config.ts
+++ b/agentex-ui/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  devIndicators: false,
 };
 
 export default nextConfig;


### PR DESCRIPTION
Removes this stupid thing: 

<img width="226" height="65" alt="image" src="https://github.com/user-attachments/assets/9299c085-ba53-440a-953c-7339146d5a42" />


next config does expose a way to reposition it to any corner, but it doesn't work and idk why