### PR TITLE
Increase default sidebar width to 250

### DIFF
--- a/agentex-ui/components/ui/resizable-sidebar.tsx
+++ b/agentex-ui/components/ui/resizable-sidebar.tsx
@@ -9,7 +9,7 @@ import { useLocalStorageState } from '@/hooks/use-local-storage-state';
 import useResizable from '@/hooks/use-resizable';
 import { cn } from '@/lib/utils';
 
-export const DEFAULT_SIDEBAR_WIDTH = 150;
+export const DEFAULT_SIDEBAR_WIDTH = 250;
 export const MIN_SIDEBAR_WIDTH = 120;
 export const MAX_SIDEBAR_WIDTH = 500;
 export const DEFAULT_COLLAPSED_WIDTH = 60;


### PR DESCRIPTION
Increases the deafult sidebar width to 250 to better accommodate the new elements we've been adding to the task sidebar
 
<img width="280" height="203" alt="image" src="https://github.com/user-attachments/assets/182ff7af-9260-4578-9d74-36daee818e07" />
