### PR TITLE
fix select agent animation

### DIFF
--- a/agentex-ui/components/agents-list/agents-list.tsx
+++ b/agentex-ui/components/agents-list/agents-list.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 import { Agent } from 'agentex/resources';
-import { AnimatePresence, motion } from 'framer-motion';
+import { motion } from 'framer-motion';
 
 import { AgentBadge } from '@/components/agents-list/agent-badge';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -38,11 +38,11 @@ export function AgentsList({ agents, isLoading = false }: AgentsListProps) {
             ))}
           </>
         ) : (
-          <AnimatePresence mode="sync">
+          <>
             {displayedAgents?.map(agent => (
               <AgentBadge key={agent.name} agent={agent} />
             ))}
-          </AnimatePresence>
+          </>
         )}
       </motion.div>
     </TooltipProvider>


### PR DESCRIPTION
Before: 


https://github.com/user-attachments/assets/2fdde12b-094b-4987-9e00-9cda1e2a89a2

After: 

https://github.com/user-attachments/assets/a5b1f6dc-a7f9-45ec-9c10-de2c8942f1ca

Notice how when I unselect an agent, the prompt input bar doesn't jump. 

I have no idea why getting rid of the animate presence fixes this but it works. 