### PR TITLE
Redirect if agent name is invalid

### DIFF
--- a/agentex-ui/app/page.tsx
+++ b/agentex-ui/app/page.tsx
@@ -1,6 +1,7 @@
 import { connection } from 'next/server';
 
 import { AgentexUIRoot } from '@/components/agentex-ui-root';
+import { AgentexProvider } from '@/components/providers';
 
 export default async function RootPage() {
   await connection();
@@ -19,9 +20,11 @@ export default async function RootPage() {
   }
 
   return (
-    <AgentexUIRoot
+    <AgentexProvider
       sgpAppURL={sgpAppURL}
       agentexAPIBaseURL={agentexAPIBaseURL}
-    />
+    >
+      <AgentexUIRoot />
+    </AgentexProvider>
   );
 }


### PR DESCRIPTION

After merging this PR,  loading the agentex-ui with the `agent_name` search param populated with an invalid or unhealthy agent will redirect you to / 



https://github.com/user-attachments/assets/ffc45ea6-6427-487c-8eba-fcf6569eed83

