### PR TITLE
Render agents as disabled if they are unhealthy

### DIFF
--- a/agentex-ui/components/task-header/task-header.tsx
+++ b/agentex-ui/components/task-header/task-header.tsx
@@ -80,7 +80,11 @@ export function TaskHeader({
               </SelectTrigger>
               <SelectContent>
                 {agents.map(agent => (
-                  <SelectItem key={agent.name} value={agent.name}>
+                  <SelectItem
+                    key={agent.name}
+                    value={agent.name}
+                    disabled={agent.status !== 'Ready'}
+                  >
                     {agent.name}
                   </SelectItem>
                 ))}


### PR DESCRIPTION
Unhealthy agents will now show up as disabled in the agents dropdwon 

<img width="247" height="159" alt="image" src="https://github.com/user-attachments/assets/d9d56854-b83e-4dd0-a37a-b64c57e52757" />
