### PR TITLE
Add order by and order direction field to mongodb stores

### DIFF
--- a/agentex/src/api/routes/messages.py
+++ b/agentex/src/api/routes/messages.py
@@ -115,9 +115,15 @@ async def list_messages(
     message_use_case: DMessageUseCase,
     limit: int = 50,
     page_number: int = 1,
+    order_by: str | None = None,
+    order_direction: str = "desc",
 ) -> list[TaskMessage]:
     task_message_entities = await message_use_case.list_messages(
-        task_id=task_id, limit=limit, page_number=page_number
+        task_id=task_id,
+        limit=limit,
+        page_number=page_number,
+        order_by=order_by,
+        order_direction=order_direction,
     )
 
     return [

--- a/agentex/src/api/routes/states.py
+++ b/agentex/src/api/routes/states.py
@@ -62,9 +62,16 @@ async def filter_states(
     agent_id: str | None = Query(None, description="Agent ID"),
     limit: int = Query(50, description="Limit", ge=1),
     page_number: int = Query(1, description="Page number", ge=1),
+    order_by: str | None = Query(None, description="Field to order by"),
+    order_direction: str = Query("desc", description="Order direction (asc or desc)"),
 ) -> list[State]:
     state_entities = await states_use_case.list(
-        task_id=task_id, agent_id=agent_id, limit=limit, page_number=page_number
+        task_id=task_id,
+        agent_id=agent_id,
+        limit=limit,
+        page_number=page_number,
+        order_by=order_by,
+        order_direction=order_direction,
     )
     logger.info(f"Listing states: {state_entities}")
     return [State.model_validate(state_entity) for state_entity in state_entities]

--- a/agentex/src/domain/services/task_message_service.py
+++ b/agentex/src/domain/services/task_message_service.py
@@ -43,7 +43,12 @@ class TaskMessageService:
         return await self.repository.get(id=message_id)
 
     async def get_messages(
-        self, task_id: str, limit: int, page_number: int
+        self,
+        task_id: str,
+        limit: int,
+        page_number: int,
+        order_by: str | None = None,
+        order_direction: str = "desc",
     ) -> list[TaskMessageEntity]:
         """
         Get all messages for a specific task.
@@ -51,18 +56,22 @@ class TaskMessageService:
         Args:
             task_id: The task ID
             limit: Optional limit on the number of messages to return
+            order_by: Optional field name to order by (defaults to created_at)
+            order_direction: Optional direction to order by ("asc" or "desc", defaults to "desc")
 
         Returns:
             List of TaskMessageEntity objects for the task
         """
-        # Sort by created_at in ascending order (oldest first)
-        # This is typically what we want for conversation history
+        # Default to created_at descending (newest first)
+        sort_field = order_by or "created_at"
+        sort_direction = 1 if order_direction.lower() == "asc" else -1
+
         return await self.repository.find_by_field(
             "task_id",
             task_id,
             limit=limit,
             page_number=page_number,
-            sort_by={"created_at": 1},
+            sort_by={sort_field: sort_direction},
         )
 
     async def append_message(

--- a/agentex/src/domain/use_cases/messages_use_case.py
+++ b/agentex/src/domain/use_cases/messages_use_case.py
@@ -105,7 +105,12 @@ class MessagesUseCase:
         return await self.task_message_service.get_message(message_id=message_id)
 
     async def list_messages(
-        self, task_id: str, limit: int, page_number: int
+        self,
+        task_id: str,
+        limit: int,
+        page_number: int,
+        order_by: str | None = None,
+        order_direction: str = "desc",
     ) -> list[TaskMessageEntity]:
         """
         Get all messages for a task.
@@ -113,12 +118,18 @@ class MessagesUseCase:
         Args:
             task_id: The task ID
             limit: Optional limit on the number of messages to return
+            order_by: Optional field name to order by (defaults to created_at)
+            order_direction: Optional direction to order by ("asc" or "desc", defaults to "desc")
 
         Returns:
             List of TaskMessageEntity objects for the task
         """
         return await self.task_message_service.get_messages(
-            task_id=task_id, limit=limit, page_number=page_number
+            task_id=task_id,
+            limit=limit,
+            page_number=page_number,
+            order_by=order_by,
+            order_direction=order_direction,
         )
 
 

--- a/agentex/src/domain/use_cases/states_use_case.py
+++ b/agentex/src/domain/use_cases/states_use_case.py
@@ -35,25 +35,22 @@ class StatesUseCase:
         page_number: int,
         task_id: str | None = None,
         agent_id: str | None = None,
+        order_by: str | None = None,
+        order_direction: str = "desc",
     ) -> list[StateEntity]:
-        if task_id and agent_id:
-            return await self.task_state_repository.list(
-                filters={"task_id": task_id, "agent_id": agent_id},
-                limit=limit,
-                page_number=page_number,
-            )
-        elif task_id:
-            return await self.task_state_repository.list(
-                filters={"task_id": task_id}, limit=limit, page_number=page_number
-            )
-        elif agent_id:
-            return await self.task_state_repository.list(
-                filters={"agent_id": agent_id}, limit=limit, page_number=page_number
-            )
-        else:
-            return await self.task_state_repository.list(
-                limit=limit, page_number=page_number
-            )
+        filters = {}
+        if task_id:
+            filters["task_id"] = task_id
+        if agent_id:
+            filters["agent_id"] = agent_id
+
+        return await self.task_state_repository.list(
+            filters=filters if filters else None,
+            limit=limit,
+            page_number=page_number,
+            order_by=order_by,
+            order_direction=order_direction,
+        )
 
     async def update(self, id: str, task_id: str, state: dict[str, Any]) -> StateEntity:
         task_state = await self.task_state_repository.get(id=id)

--- a/agentex/tests/unit/services/test_task_message_service.py
+++ b/agentex/tests/unit/services/test_task_message_service.py
@@ -62,7 +62,7 @@ def sample_task_messages(sample_task_id):
         message = TaskMessageEntity(
             id=str(uuid4()),
             task_id=sample_task_id,
-            content=TextContent(content=f"Message {i+1}", author=MessageAuthor.USER),
+            content=TextContent(content=f"Message {i + 1}", author=MessageAuthor.USER),
             streaming_status="DONE",
             created_at=base_time + timedelta(seconds=i),
             updated_at=base_time + timedelta(seconds=i),
@@ -130,7 +130,7 @@ class TestTaskMessageService:
 
         # When
         result = await task_message_service.get_messages(
-            sample_task_id, limit=100, page_number=1
+            sample_task_id, limit=100, page_number=1, order_direction="asc"
         )
 
         # Then
@@ -156,7 +156,7 @@ class TestTaskMessageService:
 
         # When
         result = await task_message_service.get_messages(
-            sample_task_id, limit=2, page_number=1
+            sample_task_id, limit=2, page_number=1, order_direction="asc"
         )
 
         # Then


### PR DESCRIPTION
Adds the order by and order direction fields to the messages and states objects, along with some tests. 