### PR TITLE
Fix message order in agentex UI

### DIFF
--- a/agentex-ui/hooks/custom-subscribe-task-state.tsx
+++ b/agentex-ui/hooks/custom-subscribe-task-state.tsx
@@ -142,9 +142,10 @@ export async function subscribeTaskState(
                     return res;
                   }),
                 client.messages
-                  .list({ task_id: taskID, limit: 1000 }, { signal })
+                  .list({ task_id: taskID }, { signal })
                   .then(res => {
-                    eventListener.onMessagesChange(res);
+                    const chronologicalMessages = res.slice().reverse();
+                    eventListener.onMessagesChange(chronologicalMessages);
                     return res;
                   }),
               ]);

--- a/agentex-ui/hooks/use-task-messages.ts
+++ b/agentex-ui/hooks/use-task-messages.ts
@@ -53,8 +53,10 @@ export function useTaskMessages({
         task_id: taskId,
       });
 
+      // API returns messages in descending order (newest first),
+      // reverse to chronological order (oldest first) for display
       return {
-        messages,
+        messages: messages.slice().reverse(),
         deltaAccumulator: null,
         rpcStatus: 'idle',
       };
@@ -205,14 +207,18 @@ export function useSendMessage({
             task_id: taskId,
           });
 
+          // API returns messages in descending order (newest first),
+          // reverse to chronological order (oldest first) for display
+          const chronologicalMessages = finalMessages.slice().reverse();
+
           queryClient.setQueryData<TaskMessagesData>(queryKey, {
-            messages: finalMessages,
+            messages: chronologicalMessages,
             deltaAccumulator: null,
             rpcStatus: 'success',
           });
 
           return {
-            messages: finalMessages,
+            messages: chronologicalMessages,
             deltaAccumulator: null,
           };
         }


### PR DESCRIPTION
Follow up change to [this PR](https://github.com/scaleapi/scale-agentex/pull/85) — as a result of making sorting the messages by DESC by default, the UI will need to handle reversing the order of the messages upon arrival. 

