### PR TITLE
Add configurable timeout for webhook requests

### DIFF
--- a/agentex/src/config/environment_variables.py
+++ b/agentex/src/config/environment_variables.py
@@ -51,6 +51,7 @@ class EnvVarKeys(str, Enum):
     SSE_KEEPALIVE_PING_INTERVAL = "SSE_KEEPALIVE_PING_INTERVAL"
     AGENTEX_SERVER_TASK_QUEUE = "AGENTEX_SERVER_TASK_QUEUE"
     ENABLE_HEALTH_CHECK_WORKFLOW = "ENABLE_HEALTH_CHECK_WORKFLOW"
+    WEBHOOK_REQUEST_TIMEOUT = "WEBHOOK_REQUEST_TIMEOUT"
 
 
 class Environment(str, Enum):
@@ -96,6 +97,7 @@ class EnvironmentVariables(BaseModel):
     SSE_KEEPALIVE_PING_INTERVAL: int = 15  # SSE keepalive ping interval in seconds
     AGENTEX_SERVER_TASK_QUEUE: str | None = None
     ENABLE_HEALTH_CHECK_WORKFLOW: bool = False
+    WEBHOOK_REQUEST_TIMEOUT: float = 15.0  # Webhook request timeout in seconds
 
     @classmethod
     def refresh(cls, force_refresh: bool = False) -> EnvironmentVariables | None:
@@ -167,6 +169,9 @@ class EnvironmentVariables(BaseModel):
             ENABLE_HEALTH_CHECK_WORKFLOW=(
                 os.environ.get(EnvVarKeys.ENABLE_HEALTH_CHECK_WORKFLOW, "false")
                 == "true"
+            ),
+            WEBHOOK_REQUEST_TIMEOUT=float(
+                os.environ.get(EnvVarKeys.WEBHOOK_REQUEST_TIMEOUT, "15.0")
             ),
         )
         refreshed_environment_variables = environment_variables

--- a/agentex/src/domain/use_cases/agent_api_keys_use_case.py
+++ b/agentex/src/domain/use_cases/agent_api_keys_use_case.py
@@ -52,6 +52,9 @@ class AgentAPIKeysUseCase:
             ),
             environment=resolve_environment_variable_dependency(EnvVarKeys.ENVIRONMENT),
         )
+        self.webhook_request_timeout = resolve_environment_variable_dependency(
+            EnvVarKeys.WEBHOOK_REQUEST_TIMEOUT
+        )
 
     async def get_agent(
         self, agent_id: str | None = None, agent_name: str | None = None
@@ -198,6 +201,7 @@ class AgentAPIKeysUseCase:
             agent_url,
             headers=get_request_headers_to_forward(request),
             content=content,
+            timeout=self.webhook_request_timeout,
         )
         r = await self.client.send(req, stream=False)
         return Response(


### PR DESCRIPTION
Right now this defaults to five seconds, which isn't enough for centipede use cases.
Making it configurable in case other customers have different requirements