### PR TITLE
Don't require auth for options routes

### DIFF
--- a/agentex/src/api/authentication_middleware.py
+++ b/agentex/src/api/authentication_middleware.py
@@ -52,6 +52,10 @@ class AgentexAuthMiddleware(BaseHTTPMiddleware):
         request.state.principal_context = None
         request.state.agent_identity = None
 
+        # Skip authentication for OPTIONS requests (CORS preflight)
+        if request.method == "OPTIONS":
+            return await call_next(request)
+
         # Skip authentication for whitelisted routes
         if is_whitelisted_route(request.url.path):
             logger.info(


### PR DESCRIPTION
This allows options to be passed back and allows for cross-origin access if the origin is a part of ALLOWED_ORIGINS.