### PR TITLE
nit: Add pagination bounds to prevent DoS via unbounded queries

### DIFF
--- a/agentex/src/api/routes/agent_api_keys.py
+++ b/agentex/src/api/routes/agent_api_keys.py
@@ -1,6 +1,6 @@
 import secrets
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
 from src.api.schemas.agent_api_keys import (
     AgentAPIKey,
@@ -79,8 +79,8 @@ async def list_agent_api_keys(
     agent_use_case: DAgentsUseCase,
     agent_id: str | None = None,
     agent_name: str | None = None,
-    limit: int = 50,
-    page_number: int = 1,
+    limit: int = Query(default=50, ge=1, le=1000),
+    page_number: int = Query(default=1, ge=1),
 ) -> list[AgentAPIKey]:
     if not agent_id and not agent_name:
         raise HTTPException(

--- a/agentex/src/api/routes/spans.py
+++ b/agentex/src/api/routes/spans.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 
 from src.api.schemas.spans import CreateSpanRequest, Span, UpdateSpanRequest
 from src.domain.use_cases.spans_use_case import DSpanUseCase
@@ -80,8 +80,8 @@ async def get_span(
 async def list_spans(
     span_use_case: DSpanUseCase,
     trace_id: str | None = None,
-    limit: int = 50,
-    page_number: int = 1,
+    limit: int = Query(default=50, ge=1, le=1000),
+    page_number: int = Query(default=1, ge=1),
     order_by: str | None = None,
     order_direction: str = "desc",
 ) -> list[Span]:


### PR DESCRIPTION
## Summary
- Add `Query` validation to `spans.py`: limit (1-1000), page_number (>= 1)
- Add `Query` validation to `agent_api_keys.py`: limit (1-1000), page_number (>= 1)

## Problem
Endpoints accepted unbounded `limit` parameters, allowing requests like `?limit=10000000` that could exhaust server memory.

## Test Results

| Test | Result |
|------|--------|
| `limit=10000` | ❌ Rejected (422): "Input should be less than or equal to 1000" |
| `limit=0` | ❌ Rejected (422): "Input should be greater than or equal to 1" |
| `page_number=0` | ❌ Rejected (422): "Input should be greater than or equal to 1" |
| `limit=100` | ✅ Success |

## How to Verify
```bash
# Should return 422 error
curl "http://localhost:5003/spans?limit=10000"

# Should succeed
curl "http://localhost:5003/spans?limit=100"
```

## Files Changed
- `src/api/routes/spans.py`
- `src/api/routes/agent_api_keys.py`