### PR TITLE
perf: Optimize single-result queries and add HTTP client cleanup

### DIFF
--- a/agentex/src/adapters/http/adapter_httpx.py
+++ b/agentex/src/adapters/http/adapter_httpx.py
@@ -79,8 +79,7 @@ class HttpxGateway(HttpPort):
 
     @classmethod
     async def close_clients(cls) -> None:
-        # TODO: Call this method
-        """Close and cleanup the shared clients. Call this during app shutdown for proper cleanup."""
+        """Close and cleanup the shared clients. Called during app shutdown for proper cleanup."""
         if cls._regular_client:
             await cls._regular_client.aclose()
             cls._regular_client = None

--- a/agentex/src/api/app.py
+++ b/agentex/src/api/app.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from src.adapters.crud_store.exceptions import ItemDoesNotExist
+from src.adapters.http.adapter_httpx import HttpxGateway
 from src.api.authentication_middleware import AgentexAuthMiddleware
 from src.api.health_interceptor import HealthCheckInterceptor
 from src.api.logged_api_route import LoggedAPIRoute
@@ -68,6 +69,8 @@ async def lifespan(_: FastAPI):
     await dependencies.startup_global_dependencies()
     configure_statsd()
     yield
+    # Clean up HTTP clients before other shutdown tasks
+    await HttpxGateway.close_clients()
     await dependencies.async_shutdown()
     dependencies.shutdown()
 

--- a/agentex/src/domain/repositories/agent_api_key_repository.py
+++ b/agentex/src/domain/repositories/agent_api_key_repository.py
@@ -80,8 +80,8 @@ class AgentAPIKeyRepository(PostgresCRUDRepository[AgentAPIKeyORM, AgentAPIKeyEn
             )
 
             result = await session.execute(query)
-            agents = result.scalars().all()
-            return AgentAPIKeyEntity.model_validate(agents[0]) if agents else None
+            row = result.scalars().first()
+            return AgentAPIKeyEntity.model_validate(row) if row else None
 
     async def get_by_agent_id_and_name(
         self, agent_id: str, name: str, api_key_type: AgentAPIKeyType
@@ -109,8 +109,8 @@ class AgentAPIKeyRepository(PostgresCRUDRepository[AgentAPIKeyORM, AgentAPIKeyEn
             )
 
             result = await session.execute(query)
-            agents = result.scalars().all()
-            return AgentAPIKeyEntity.model_validate(agents[0]) if agents else None
+            row = result.scalars().first()
+            return AgentAPIKeyEntity.model_validate(row) if row else None
 
     async def get_by_agent_name_and_key_name(
         self, agent_name: str, key_name: str, api_key_type: AgentAPIKeyType
@@ -138,8 +138,8 @@ class AgentAPIKeyRepository(PostgresCRUDRepository[AgentAPIKeyORM, AgentAPIKeyEn
             )
 
             result = await session.execute(query)
-            agents = result.scalars().all()
-            return AgentAPIKeyEntity.model_validate(agents[0]) if agents else None
+            row = result.scalars().first()
+            return AgentAPIKeyEntity.model_validate(row) if row else None
 
     async def get_external_by_agent_id_and_key(
         self, agent_id: str, api_key: str
@@ -167,8 +167,8 @@ class AgentAPIKeyRepository(PostgresCRUDRepository[AgentAPIKeyORM, AgentAPIKeyEn
             )
 
             result = await session.execute(query)
-            agents = result.scalars().all()
-            return AgentAPIKeyEntity.model_validate(agents[0]) if agents else None
+            row = result.scalars().first()
+            return AgentAPIKeyEntity.model_validate(row) if row else None
 
     async def delete_by_agent_name_and_key_name(
         self, agent_name: str, key_name: str, api_key_type: AgentAPIKeyType


### PR DESCRIPTION
## Summary
Two quick performance/reliability fixes:

### Issue #7: Inefficient single-result queries
- Replaced `.scalars().all()[0]` with `.scalars().first()` in 4 methods in `agent_api_key_repository.py`
- **Before**: Fetches ALL matching rows into memory, then accesses `[0]`
- **After**: `.first()` stops after fetching one row

Methods fixed:
- `get_internal_api_key_by_agent_id`
- `get_by_agent_id_and_name`
- `get_by_agent_name_and_key_name`
- `get_external_by_agent_id_and_key`

### Issue #8: HTTP client not closed on shutdown
- Added `HttpxGateway.close_clients()` call to FastAPI lifespan shutdown
- Ensures proper cleanup of TCP connections during graceful restarts
- Removed TODO comment since it's now implemented

## Test plan
- [x] Unit tests pass (184/184)
- [x] Lint passes