### PR TITLE
fix: adding RO session maker to Temporal healthcheck

### DIFF
--- a/agentex/src/temporal/run_healthcheck_workflow.py
+++ b/agentex/src/temporal/run_healthcheck_workflow.py
@@ -7,6 +7,7 @@ from src.adapters.temporal.exceptions import (
 )
 from src.config.dependencies import (
     GlobalDependencies,
+    database_async_read_only_session_maker,
     database_async_read_write_engine,
     database_async_read_write_session_maker,
 )
@@ -47,7 +48,8 @@ async def main() -> None:
     # Initialize repository and list agents
     engine = database_async_read_write_engine()
     session_maker = database_async_read_write_session_maker(engine)
-    agent_repo = AgentRepository(session_maker)
+    read_only_session_maker = database_async_read_only_session_maker(engine)
+    agent_repo = AgentRepository(session_maker, read_only_session_maker)
     agents = await agent_repo.list()
 
     adapter = TemporalAdapter(temporal_client=global_dependencies.temporal_client)

--- a/agentex/src/temporal/run_worker.py
+++ b/agentex/src/temporal/run_worker.py
@@ -14,6 +14,7 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from src.adapters.temporal.client_factory import TemporalClientFactory
 from src.config.dependencies import (
+    database_async_read_only_session_maker,
     database_async_read_write_engine,
     database_async_read_write_session_maker,
     httpx_client,
@@ -166,7 +167,8 @@ async def main() -> None:
         # Create session maker
         engine = database_async_read_write_engine()
         session_maker = database_async_read_write_session_maker(engine)
-        agent_repo = AgentRepository(session_maker)
+        read_only_session_maker = database_async_read_only_session_maker(engine)
+        agent_repo = AgentRepository(session_maker, read_only_session_maker)
         health_check_worker_task = create_health_check_worker(
             agent_repo=agent_repo,
             http_client=httpx_client(),


### PR DESCRIPTION
This was an oversight from https://github.com/scaleapi/scale-agentex/pull/109 and means the local agentex won't start up since it tries to kick off the healthcheck workflow.