### PR TITLE
feat: Add memory sidebar for agent memory visualization

### DIFF
--- a/agentex-ui/components/agentex-ui-root.tsx
+++ b/agentex-ui/components/agentex-ui-root.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { ToastContainer } from 'react-toastify';
 
+import { MemorySidebar } from '@/components/memory-sidebar/memory-sidebar';
 import { PrimaryContent } from '@/components/primary-content/primary-content';
 import { useAgentexClient } from '@/components/providers';
 import { TaskSidebar } from '@/components/task-sidebar/task-sidebar';
@@ -18,6 +19,7 @@ import {
 export function AgentexUIRoot() {
   const { agentName, taskID, updateParams } = useSafeSearchParams();
   const [isTracesSidebarOpen, setIsTracesSidebarOpen] = useState(false);
+  const [isMemorySidebarOpen, setIsMemorySidebarOpen] = useState(false);
   const { agentexClient } = useAgentexClient();
   const { data: agents = [], isLoading } = useAgents(agentexClient);
   const [localAgentName, setLocalAgentName] = useLocalStorageState<
@@ -82,8 +84,13 @@ export function AgentexUIRoot() {
           toggleTracesSidebar={() =>
             setIsTracesSidebarOpen(!isTracesSidebarOpen)
           }
+          isMemorySidebarOpen={isMemorySidebarOpen}
+          toggleMemorySidebar={() =>
+            setIsMemorySidebarOpen(!isMemorySidebarOpen)
+          }
         />
         <TracesSidebar isOpen={isTracesSidebarOpen} />
+        <MemorySidebar isOpen={isMemorySidebarOpen} />
       </div>
       <ToastContainer />
     </>

--- a/agentex-ui/components/memory-sidebar/memory-sidebar.tsx
+++ b/agentex-ui/components/memory-sidebar/memory-sidebar.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useState } from 'react';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { Brain, Eye, Loader2, RefreshCw } from 'lucide-react';
+
+import { MemoryStrategyItem } from '@/components/memory-sidebar/memory-strategy-item';
+import { Button } from '@/components/ui/button';
+import { ResizableSidebar } from '@/components/ui/resizable-sidebar';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import {
+  useDeleteStrategy,
+  useExtractStrategies,
+  useMemory,
+  useMemoryPreview,
+} from '@/hooks/use-memory';
+import { useSafeSearchParams } from '@/hooks/use-safe-search-params';
+
+const MIN_SIDEBAR_WIDTH = 350;
+const DEFAULT_SIDEBAR_WIDTH = 380;
+
+type MemorySidebarProps = {
+  isOpen: boolean;
+};
+
+export function MemorySidebar({ isOpen }: MemorySidebarProps) {
+  const { agentName } = useSafeSearchParams();
+  const [showPreview, setShowPreview] = useState(false);
+
+  const {
+    agentStrategies,
+    userStrategies,
+    isLoading,
+    error,
+  } = useMemory(agentName, 'default');
+
+  const {
+    preview,
+    isLoading: previewLoading,
+  } = useMemoryPreview(agentName, 'default');
+
+  const deleteStrategy = useDeleteStrategy();
+  const extractStrategies = useExtractStrategies();
+
+  const totalStrategies = agentStrategies.length + userStrategies.length;
+
+  const handleDelete = (strategyId: string) => {
+    if (agentName) {
+      deleteStrategy.mutate({ strategyId, agentId: agentName });
+    }
+  };
+
+  const handleExtract = () => {
+    if (agentName) {
+      extractStrategies.mutate({ agentId: agentName, hours: 24 });
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {agentName && (
+        <motion.div
+          key="memory-sidebar"
+          initial={{ opacity: 0, x: 20, width: 0 }}
+          animate={{ opacity: 1, x: 0, width: 'auto' }}
+          exit={{ opacity: 0, x: 20, width: 0 }}
+          transition={{ duration: 0.25, ease: 'easeInOut' }}
+        >
+          <ResizableSidebar
+            side="right"
+            storageKey="memorySidebarWidth"
+            defaultWidth={DEFAULT_SIDEBAR_WIDTH}
+            minWidth={MIN_SIDEBAR_WIDTH}
+            isCollapsed={!isOpen}
+            collapsedWidth={0}
+          >
+            <TooltipProvider>
+              <div className="flex h-full flex-col">
+                {/* Header */}
+                <div className="border-border border-b px-4 py-4">
+                  <div className="flex items-center gap-2">
+                    <Brain className="text-foreground h-5 w-5" />
+                    <h2 className="text-foreground text-lg font-semibold">
+                      Agent Memory
+                    </h2>
+                  </div>
+                  <p className="text-muted-foreground mt-1 text-sm">
+                    {totalStrategies} learned strategies
+                  </p>
+                </div>
+
+                {/* Content */}
+                <div className="flex-1 space-y-4 overflow-y-auto p-4">
+                  {isLoading && (
+                    <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Loading memory...
+                    </div>
+                  )}
+
+                  {error && (
+                    <div className="text-destructive text-sm">
+                      Error: {error}
+                    </div>
+                  )}
+
+                  {!isLoading && !error && totalStrategies === 0 && (
+                    <div className="text-muted-foreground text-sm">
+                      No strategies learned yet. Run extract to analyze traces.
+                    </div>
+                  )}
+
+                  {/* Preview Mode */}
+                  {showPreview && preview && (
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-foreground text-sm font-medium">
+                          Prompt Preview
+                        </span>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setShowPreview(false)}
+                        >
+                          Back to list
+                        </Button>
+                      </div>
+                      <pre className="bg-muted text-foreground max-h-96 overflow-auto rounded-lg p-3 text-xs whitespace-pre-wrap">
+                        {preview.content}
+                      </pre>
+                    </div>
+                  )}
+
+                  {/* Strategy Lists */}
+                  {!showPreview && (
+                    <>
+                      {/* Agent-level strategies */}
+                      {agentStrategies.length > 0 && (
+                        <div className="space-y-2">
+                          <h3 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                            Agent Memory ({agentStrategies.length})
+                          </h3>
+                          <div className="space-y-2">
+                            {agentStrategies.map(strategy => (
+                              <MemoryStrategyItem
+                                key={strategy.id}
+                                strategy={strategy}
+                                onDelete={handleDelete}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* User-level strategies */}
+                      {userStrategies.length > 0 && (
+                        <div className="space-y-2">
+                          <h3 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                            User Memory ({userStrategies.length})
+                          </h3>
+                          <div className="space-y-2">
+                            {userStrategies.map(strategy => (
+                              <MemoryStrategyItem
+                                key={strategy.id}
+                                strategy={strategy}
+                                onDelete={handleDelete}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+
+                {/* Actions */}
+                <div className="border-border space-y-2 border-t p-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    onClick={handleExtract}
+                    disabled={extractStrategies.isPending}
+                  >
+                    {extractStrategies.isPending ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <RefreshCw className="mr-2 h-4 w-4" />
+                    )}
+                    Extract from Recent Traces
+                  </Button>
+
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="w-full"
+                    onClick={() => setShowPreview(!showPreview)}
+                    disabled={previewLoading || totalStrategies === 0}
+                  >
+                    <Eye className="mr-2 h-4 w-4" />
+                    {showPreview ? 'Hide Preview' : 'Preview Prompt'}
+                  </Button>
+                </div>
+              </div>
+            </TooltipProvider>
+          </ResizableSidebar>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/agentex-ui/components/memory-sidebar/memory-strategy-item.tsx
+++ b/agentex-ui/components/memory-sidebar/memory-strategy-item.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { ChevronRight, Minus, Plus, Trash2 } from 'lucide-react';
+
+import { IconButton } from '@/components/ui/icon-button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+import type { StrategyItem } from '@/lib/memory-types';
+
+type MemoryStrategyItemProps = {
+  strategy: StrategyItem;
+  onDelete?: (strategyId: string) => void;
+};
+
+export function MemoryStrategyItem({
+  strategy,
+  onDelete,
+}: MemoryStrategyItemProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const isSuccess = strategy.source_outcome === 'success';
+  const SourceIcon = isSuccess ? Plus : Minus;
+  const sourceColor = isSuccess ? 'text-green-500' : 'text-red-500';
+
+  return (
+    <div className="border-border rounded-lg border">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="hover:bg-muted/50 flex w-full items-center gap-2 rounded-lg p-3 text-left transition-colors"
+      >
+        <motion.div
+          animate={{ rotate: isExpanded ? 90 : 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          <ChevronRight className="text-muted-foreground h-4 w-4" />
+        </motion.div>
+
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger asChild>
+            <SourceIcon className={`h-4 w-4 flex-shrink-0 ${sourceColor}`} />
+          </TooltipTrigger>
+          <TooltipContent>
+            Learned from {isSuccess ? 'success' : 'failure'}
+          </TooltipContent>
+        </Tooltip>
+
+        <span className="text-foreground flex-1 truncate text-sm font-medium">
+          {strategy.title}
+        </span>
+
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger asChild>
+            <span className="text-muted-foreground text-xs">
+              {strategy.usage_count}×
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>Used {strategy.usage_count} times</TooltipContent>
+        </Tooltip>
+      </button>
+
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="border-border space-y-3 border-t px-3 py-3">
+              <p className="text-muted-foreground text-sm">
+                {strategy.description}
+              </p>
+
+              <div className="space-y-1">
+                <span className="text-foreground text-xs font-medium">
+                  Principles:
+                </span>
+                <ul className="space-y-1">
+                  {strategy.principles.map((principle, index) => (
+                    <li
+                      key={index}
+                      className="text-muted-foreground flex items-start gap-2 text-xs"
+                    >
+                      <span className="mt-1 h-1 w-1 flex-shrink-0 rounded-full bg-current" />
+                      {principle}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="flex items-center justify-between pt-2">
+                <div className="flex items-center gap-2">
+                  {strategy.domain && (
+                    <span className="bg-muted text-muted-foreground rounded px-2 py-0.5 text-xs">
+                      {strategy.domain}
+                    </span>
+                  )}
+                  <span className="text-muted-foreground text-xs">
+                    {Math.round(strategy.confidence * 100)}% confidence
+                  </span>
+                </div>
+
+                {onDelete && (
+                  <IconButton
+                    variant="ghost"
+                    iconSize="sm"
+                    onClick={e => {
+                      e.stopPropagation();
+                      onDelete(strategy.id);
+                    }}
+                    aria-label="Delete strategy"
+                    icon={Trash2}
+                    className="text-destructive hover:text-destructive h-6 w-6"
+                  />
+                )}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/agentex-ui/components/primary-content/chat-view.tsx
+++ b/agentex-ui/components/primary-content/chat-view.tsx
@@ -16,6 +16,8 @@ type ChatViewProps = {
   taskID: string;
   isTracesSidebarOpen: boolean;
   toggleTracesSidebar: () => void;
+  isMemorySidebarOpen?: boolean | undefined;
+  toggleMemorySidebar?: (() => void) | undefined;
   setPrompt: (prompt: string) => void;
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
 };
@@ -24,6 +26,8 @@ export function ChatView({
   taskID,
   isTracesSidebarOpen,
   toggleTracesSidebar,
+  isMemorySidebarOpen,
+  toggleMemorySidebar,
   setPrompt,
   scrollContainerRef,
 }: ChatViewProps) {
@@ -58,6 +62,8 @@ export function ChatView({
         taskId={taskID}
         isTracesSidebarOpen={isTracesSidebarOpen}
         toggleTracesSidebar={toggleTracesSidebar}
+        isMemorySidebarOpen={isMemorySidebarOpen}
+        toggleMemorySidebar={toggleMemorySidebar}
         agents={agents}
         onAgentChange={handleSelectAgent}
         ref={headerRef}

--- a/agentex-ui/components/primary-content/primary-content.tsx
+++ b/agentex-ui/components/primary-content/primary-content.tsx
@@ -12,11 +12,15 @@ import { useSafeSearchParams } from '@/hooks/use-safe-search-params';
 type ContentAreaProps = {
   isTracesSidebarOpen: boolean;
   toggleTracesSidebar: () => void;
+  isMemorySidebarOpen?: boolean;
+  toggleMemorySidebar?: () => void;
 };
 
 export function PrimaryContent({
   isTracesSidebarOpen,
   toggleTracesSidebar,
+  isMemorySidebarOpen,
+  toggleMemorySidebar,
 }: ContentAreaProps) {
   const { taskID } = useSafeSearchParams();
 
@@ -74,6 +78,8 @@ export function PrimaryContent({
           taskID={taskID}
           isTracesSidebarOpen={isTracesSidebarOpen}
           toggleTracesSidebar={toggleTracesSidebar}
+          isMemorySidebarOpen={isMemorySidebarOpen}
+          toggleMemorySidebar={toggleMemorySidebar}
           scrollContainerRef={scrollContainerRef}
           setPrompt={setPrompt}
         />

--- a/agentex-ui/components/task-header/task-header.tsx
+++ b/agentex-ui/components/task-header/task-header.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { Activity, Bot } from 'lucide-react';
+import { Activity, Bot, Brain } from 'lucide-react';
 
 import { InvestigateTracesButton } from '@/components/task-header/investigate-traces-button';
 import { ThemeToggle } from '@/components/task-header/theme-toggle';
@@ -18,8 +18,10 @@ import type { Agent } from 'agentex/resources';
 
 type TaskHeaderProps = {
   taskId: string | null;
-  isTracesSidebarOpen?: boolean;
-  toggleTracesSidebar?: () => void;
+  isTracesSidebarOpen?: boolean | undefined;
+  toggleTracesSidebar?: (() => void) | undefined;
+  isMemorySidebarOpen?: boolean | undefined;
+  toggleMemorySidebar?: (() => void) | undefined;
   agents?: Agent[];
   selectedAgentName?: string;
   onAgentChange?: (agentName: string | undefined) => void;
@@ -30,6 +32,8 @@ export function TaskHeader({
   taskId,
   isTracesSidebarOpen,
   toggleTracesSidebar,
+  isMemorySidebarOpen,
+  toggleMemorySidebar,
   agents = [],
   onAgentChange,
   ref,
@@ -97,6 +101,18 @@ export function TaskHeader({
           className={`flex items-center gap-2 ${!taskId && 'pointer-events-none invisible'}`}
         >
           <ThemeToggle />
+          {toggleMemorySidebar && (
+            <IconButton
+              variant="ghost"
+              onClick={toggleMemorySidebar}
+              aria-label={
+                isMemorySidebarOpen
+                  ? 'Close memory sidebar'
+                  : 'Open memory sidebar'
+              }
+              icon={Brain}
+            />
+          )}
           {toggleTracesSidebar && (
             <IconButton
               variant="ghost"

--- a/agentex-ui/hooks/use-memory.ts
+++ b/agentex-ui/hooks/use-memory.ts
@@ -1,0 +1,238 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  MemoryPreview,
+  MemoryState,
+  StrategyItem,
+} from '@/lib/memory-types';
+
+// Memory server URL - defaults to local development server
+const MEMORY_SERVER_URL =
+  process.env.NEXT_PUBLIC_MEMORY_SERVER_URL || 'http://localhost:8765';
+
+export const memoryKeys = {
+  all: ['memory'] as const,
+  byAgent: (agentId: string | null) =>
+    agentId ? ([...memoryKeys.all, agentId] as const) : memoryKeys.all,
+  preview: (agentId: string | null, userId: string | null) =>
+    agentId
+      ? ([...memoryKeys.all, agentId, userId, 'preview'] as const)
+      : memoryKeys.all,
+};
+
+/**
+ * Fetches agent memory strategies from the standalone memory server.
+ */
+export function useMemory(
+  agentId: string | null,
+  userId: string | null = 'default'
+): MemoryState {
+  const { data, isLoading, error } = useQuery<
+    { agentStrategies: StrategyItem[]; userStrategies: StrategyItem[] },
+    Error
+  >({
+    queryKey: memoryKeys.byAgent(agentId),
+    queryFn: async () => {
+      if (!agentId) {
+        return { agentStrategies: [], userStrategies: [] };
+      }
+
+      const response = await fetch(
+        `${MEMORY_SERVER_URL}/api/memory/${encodeURIComponent(agentId)}?user_id=${encodeURIComponent(userId || 'default')}`
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch memory: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      return {
+        agentStrategies: data.agent_strategies || [],
+        userStrategies: data.user_strategies || [],
+      };
+    },
+    enabled: agentId !== null,
+    retry: 1,
+    staleTime: 30000, // Cache for 30 seconds
+  });
+
+  return {
+    agentStrategies: data?.agentStrategies ?? [],
+    userStrategies: data?.userStrategies ?? [],
+    isLoading,
+    error: error?.message ?? null,
+  };
+}
+
+/**
+ * Fetches preview of what gets injected into the prompt.
+ */
+export function useMemoryPreview(
+  agentId: string | null,
+  userId: string | null = 'default'
+): { preview: MemoryPreview | null; isLoading: boolean; error: string | null } {
+  const { data, isLoading, error } = useQuery<MemoryPreview, Error>({
+    queryKey: memoryKeys.preview(agentId, userId),
+    queryFn: async () => {
+      if (!agentId) {
+        return { content: '', strategyCount: 0 };
+      }
+
+      const response = await fetch(
+        `${MEMORY_SERVER_URL}/api/memory/${encodeURIComponent(agentId)}/preview?user_id=${encodeURIComponent(userId || 'default')}`
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch preview: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      return {
+        content: data.content,
+        strategyCount: data.strategy_count,
+      };
+    },
+    enabled: agentId !== null,
+    retry: 1,
+    staleTime: 30000,
+  });
+
+  return {
+    preview: data ?? null,
+    isLoading,
+    error: error?.message ?? null,
+  };
+}
+
+/**
+ * Hook to delete a strategy.
+ */
+export function useDeleteStrategy() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      strategyId,
+      agentId,
+    }: {
+      strategyId: string;
+      agentId: string;
+    }) => {
+      const response = await fetch(
+        `${MEMORY_SERVER_URL}/api/memory/strategy/${encodeURIComponent(strategyId)}?agent_id=${encodeURIComponent(agentId)}`,
+        { method: 'DELETE' }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to delete strategy: ${response.statusText}`);
+      }
+
+      return response.json();
+    },
+    onSuccess: (_, { agentId }) => {
+      queryClient.invalidateQueries({ queryKey: memoryKeys.byAgent(agentId) });
+      queryClient.invalidateQueries({
+        queryKey: memoryKeys.preview(agentId, null),
+      });
+    },
+  });
+}
+
+/**
+ * Hook to trigger strategy extraction.
+ */
+export function useExtractStrategies() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      agentId,
+      hours = 24,
+      userId = 'default',
+    }: {
+      agentId: string;
+      hours?: number;
+      userId?: string;
+    }) => {
+      const response = await fetch(
+        `${MEMORY_SERVER_URL}/api/memory/${encodeURIComponent(agentId)}/extract`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ hours, user_id: userId }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to extract strategies: ${response.statusText}`);
+      }
+
+      return response.json();
+    },
+    onSuccess: (_, { agentId }) => {
+      queryClient.invalidateQueries({ queryKey: memoryKeys.byAgent(agentId) });
+      queryClient.invalidateQueries({
+        queryKey: memoryKeys.preview(agentId, null),
+      });
+    },
+  });
+}
+
+/**
+ * Hook to manually add a strategy.
+ */
+export function useAddStrategy() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      agentId,
+      title,
+      description,
+      principles,
+      outcome = 'success',
+      domain,
+      level = 'agent',
+      userId = 'default',
+    }: {
+      agentId: string;
+      title: string;
+      description: string;
+      principles: string[];
+      outcome?: string;
+      domain?: string;
+      level?: string;
+      userId?: string;
+    }) => {
+      const response = await fetch(
+        `${MEMORY_SERVER_URL}/api/memory/${encodeURIComponent(agentId)}/add?user_id=${encodeURIComponent(userId)}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title,
+            description,
+            principles,
+            outcome,
+            domain,
+            level,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to add strategy: ${response.statusText}`);
+      }
+
+      return response.json();
+    },
+    onSuccess: (_, { agentId }) => {
+      queryClient.invalidateQueries({ queryKey: memoryKeys.byAgent(agentId) });
+      queryClient.invalidateQueries({
+        queryKey: memoryKeys.preview(agentId, null),
+      });
+    },
+  });
+}

--- a/agentex-ui/lib/memory-types.ts
+++ b/agentex-ui/lib/memory-types.ts
@@ -1,0 +1,32 @@
+/**
+ * Types for agent memory system.
+ * These mirror the types in agent_memory package.
+ */
+
+export type MemoryLevel = 'user' | 'agent';
+
+export type SessionOutcome = 'success' | 'failure' | 'partial';
+
+export interface StrategyItem {
+  id: string;
+  title: string;
+  description: string;
+  principles: string[];
+  source_outcome: SessionOutcome;
+  domain: string | null;
+  confidence: number;
+  created_at: string;
+  usage_count: number;
+}
+
+export interface MemoryState {
+  agentStrategies: StrategyItem[];
+  userStrategies: StrategyItem[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export interface MemoryPreview {
+  content: string;
+  strategyCount: number;
+}


### PR DESCRIPTION
## Summary

- Add Memory Sidebar component to visualize and manage agent memory strategies
- React Query hooks to connect to standalone memory server
- Brain icon toggle in task header

## Components

### New Files
- `components/memory-sidebar/memory-sidebar.tsx` - Main sidebar with strategy list
- `components/memory-sidebar/memory-strategy-item.tsx` - Collapsible strategy card
- `hooks/use-memory.ts` - React Query hooks for memory operations
- `lib/memory-types.ts` - TypeScript types for memory data

### Modified Files
- `components/task-header/task-header.tsx` - Added Brain icon toggle
- `components/agentex-ui-root.tsx` - Added MemorySidebar and state
- `components/primary-content/*.tsx` - Passed memory sidebar props

## How to Use

The UI connects to a standalone FastAPI server via `NEXT_PUBLIC_MEMORY_SERVER_URL`:

```bash
# Start memory server (in agentex-agents repo)
cd teams/sgpml/shared/agent_memory
uv pip install -e ".[server]"
python -m agent_memory.server

# Start UI
NEXT_PUBLIC_MEMORY_SERVER_URL=http://localhost:8765 npm run dev
```

## Related PR
- Backend/Package: https://github.com/scaleapi/agentex-agents/pull/910

## Test plan
- [x] TypeScript compilation passed
- [x] Components render correctly
- [x] Hooks connect to memory server

🤖 Generated with [Claude Code](https://claude.com/claude-code)