### PR TITLE
Update local allowed_origins

### DIFF
--- a/agentex/docker-compose.yml
+++ b/agentex/docker-compose.yml
@@ -151,6 +151,7 @@ services:
       - WATCHFILES_FORCE_POLLING=true
       - ENABLE_HEALTH_CHECK_WORKFLOW=true
       - AGENTEX_SERVER_TASK_QUEUE=agentex-server
+      - ALLOWED_ORIGINS=http://localhost:3000
     ports:
       - "5003:5003"
     volumes:


### PR DESCRIPTION
  Root Cause: The ALLOWED_ORIGINS environment variable is not set, so the backend defaults to ["*"] (wildcard). Combined with allow_credentials=True at src/api/app.py:101, browsers reject this configuration.

  The Fix: Set the ALLOWED_ORIGINS environment variable before starting the backend: