### PR TITLE
Fix alembic migration path resolution

### DIFF
--- a/agentex/database/migrations/alembic/env.py
+++ b/agentex/database/migrations/alembic/env.py
@@ -5,7 +5,7 @@ from logging.config import fileConfig
 
 # Add the project root directory to the Python path
 # This will help Python find the agentex module
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
 sys.path.insert(0, project_root)
 print(f"Added {project_root} to Python path")
 


### PR DESCRIPTION
## Summary
- Fix `env.py` project root path from `../../../..` (resolves to `/`) to `../../..` (resolves to `/app`)
- This was causing `ModuleNotFoundError: No module named 'src'` at pod startup, preventing `alembic upgrade head` from running
- As a result, the `checkpoints` table (from migration `d1a6cde41b3f`) was never created on AWS dev, breaking LangGraph agents

## Context
The OTel auto-instrumentation init container overrides `PYTHONPATH` to `/otel-auto-instrumentation-python/...`, so the Dockerfile's `ENV PYTHONPATH=/app` is lost. `env.py` compensates by explicitly adding the project root to `sys.path`, but was resolving 4 levels up (`/`) instead of 3 (`/app`).

## Test plan
- [ ] Verify `alembic upgrade head` runs successfully on pod startup (check logs for `Added /app to Python path` and `Migration completed successfully`)
- [ ] Verify `checkpoints` table exists after deployment
- [ ] Verify LangGraph agents can use the checkpoint endpoint without 500 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)