### PR TITLE
(feat): temporal agent works with the agentex ui

### DIFF
--- a/agentex/tests/fixtures/services.py
+++ b/agentex/tests/fixtures/services.py
@@ -12,11 +12,14 @@ import pytest
 # =============================================================================
 
 
-def create_task_message_service(task_message_repository):
+def create_task_message_service(task_message_repository, stream_repository):
     """Factory function to create TaskMessageService with given repository"""
     from src.domain.services.task_message_service import TaskMessageService
 
-    return TaskMessageService(task_message_repository=task_message_repository)
+    return TaskMessageService(
+        message_repository=task_message_repository,
+        stream_repository=stream_repository,
+    )
 
 
 def create_agent_acp_service(http_gateway, agent_repository, agent_api_key_repository):
@@ -110,9 +113,9 @@ def mock_environment_variables():
 
 
 @pytest.fixture
-def task_message_service(task_message_repository):
+def task_message_service(task_message_repository, redis_stream_repository):
     """Task message service for unit tests"""
-    return create_task_message_service(task_message_repository)
+    return create_task_message_service(task_message_repository, redis_stream_repository)
 
 
 @pytest.fixture

--- a/agentex/tests/integration/fixtures/integration_client.py
+++ b/agentex/tests/integration/fixtures/integration_client.py
@@ -455,7 +455,8 @@ async def isolated_integration_app(
         from src.domain.services.task_message_service import TaskMessageService
 
         task_message_service = TaskMessageService(
-            message_repository=isolated_repositories["task_message_repository"]
+            message_repository=isolated_repositories["task_message_repository"],
+            stream_repository=isolated_repositories["redis_stream_repository"],
         )
 
         return MessagesUseCase(task_message_service=task_message_service)

--- a/agentex/tests/unit/services/test_task_message_service.py
+++ b/agentex/tests/unit/services/test_task_message_service.py
@@ -20,9 +20,12 @@ def task_message_repository(mongodb_database):
 
 
 @pytest.fixture
-def task_message_service(task_message_repository):
+def task_message_service(task_message_repository, redis_stream_repository):
     """Create TaskMessageService instance with real repository"""
-    return TaskMessageService(message_repository=task_message_repository)
+    return TaskMessageService(
+        message_repository=task_message_repository,
+        stream_repository=redis_stream_repository,
+    )
 
 
 @pytest.fixture

--- a/agentex/tests/unit/use_cases/test_agents_acp_use_case.py
+++ b/agentex/tests/unit/use_cases/test_agents_acp_use_case.py
@@ -131,10 +131,11 @@ def task_service(
 
 
 @pytest.fixture
-def task_message_service(task_message_repository):
+def task_message_service(task_message_repository, redis_stream_repository):
     """Real TaskMessageService instance"""
     return TaskMessageService(
         message_repository=task_message_repository,
+        stream_repository=redis_stream_repository,
     )
 
 


### PR DESCRIPTION
When creating a temporal chatbot updates are not streamed to the UI. that requires constant refreshing of the UI to see new messages. This fix aligns these and ensures that the temporal-based chatbots will work in the agentex UI.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables real-time UI updates for temporal-based chatbots by publishing Redis stream events whenever task messages are created or updated. Previously, the `TaskMessageService` only persisted messages to MongoDB without notifying subscribed UI clients, requiring manual page refreshes to see new messages.

- **`TaskMessageService` now publishes `StreamTaskMessageFull` events to Redis** on every `append_message`, `append_messages`, `update_message`, and `update_messages` call, using the same `task:{task_id}` topic that the SSE stream endpoint reads from.
- **New `stream_repository` dependency** injected into `TaskMessageService`, following the same pattern already used by `AgentTaskService`.
- **Error handling** in `_publish_message_full_event` catches and logs exceptions without disrupting the core message CRUD operations.
- **All test fixtures updated** across unit and integration tests to pass the new `stream_repository` parameter.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with low risk — it adds fire-and-forget Redis publishing with proper error handling.
- The changes are well-scoped and follow established patterns from AgentTaskService. The error handling in `_publish_message_full_event` prevents stream failures from breaking message operations. All test fixtures are properly updated. The only consideration is potential duplicate Redis events when the ACP streaming path (which already yields NDJSON) also triggers these new Redis publishes, but this is harmless and actually beneficial for SSE subscribers.
- `agentex/src/domain/services/task_message_service.py` — core logic change with new Redis stream publishing on all message mutation paths
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| agentex/src/domain/services/task_message_service.py | Core change: adds Redis stream publishing via `_publish_message_full_event` to all message create/update paths. New `stream_repository` dependency injected. Exception handling prevents stream failures from breaking message operations. Hardcoded `index=0` is acceptable for standalone full events. |
| agentex/tests/fixtures/services.py | Updated factory and fixture to pass `stream_repository`/`redis_stream_repository` to `TaskMessageService`. Keyword argument names corrected to match the constructor. |
| agentex/tests/integration/fixtures/integration_client.py | Integration fixture updated to pass `stream_repository` from isolated repositories when constructing `TaskMessageService`. Aligns with the new constructor signature. |
| agentex/tests/unit/services/test_task_message_service.py | Test fixture updated to pass `redis_stream_repository` to `TaskMessageService`. No test logic changes needed since stream publishing is fire-and-forget with error swallowing. |
| agentex/tests/unit/use_cases/test_agents_acp_use_case.py | Test fixture updated to pass `redis_stream_repository` to `TaskMessageService` constructor. No test logic changes required. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Temporal as Temporal Agent
    participant TMS as TaskMessageService
    participant MongoDB as MongoDB
    participant Redis as Redis Stream
    participant SSE as SSE Endpoint
    participant UI as Agentex UI

    Temporal->>TMS: append_message(task_id, content)
    TMS->>MongoDB: create(task_message)
    MongoDB-->>TMS: created_message
    TMS->>Redis: send_data(task:{task_id}, StreamTaskMessageFull)
    Note over Redis: New! Previously missing
    TMS-->>Temporal: created_message

    UI->>SSE: GET /tasks/{task_id}/stream
    SSE->>Redis: read_messages(task:{task_id})
    Redis-->>SSE: StreamTaskMessageFull event
    SSE-->>UI: SSE event (real-time update)
```
</details>


<sub>Last reviewed commit: bcd22b3</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->