### PR TITLE
Infinite scroll for chat messages with pagination

### DIFF
--- a/agentex-ui/components/primary-content/chat-view.tsx
+++ b/agentex-ui/components/primary-content/chat-view.tsx
@@ -66,7 +66,11 @@ export function ChatView({
       <div className="flex w-full flex-col items-center px-4 sm:px-6 md:px-8">
         <div className="w-full max-w-3xl">
           <TaskProvider taskId={taskID}>
-            <TaskMessages taskId={taskID} headerRef={headerRef} />
+            <TaskMessages
+              taskId={taskID}
+              headerRef={headerRef}
+              scrollContainerRef={scrollContainerRef}
+            />
           </TaskProvider>
         </div>
       </div>

--- a/agentex-ui/components/task-messages/task-message-reasoning-content.tsx
+++ b/agentex-ui/components/task-messages/task-message-reasoning-content.tsx
@@ -28,12 +28,13 @@ function TaskMessageReasoningImpl({ message }: TaskMessageReasoningProps) {
   const { taskID } = useSafeSearchParams();
   const { agentexClient } = useAgentexClient();
 
-  const { data: queryData } = useTaskMessages({
+  const { messages } = useTaskMessages({
     agentexClient,
     taskId: taskID ?? '',
   });
-  const messages = queryData?.messages ?? [];
-  const messageIndex = messages.findIndex(m => m.id === message.id);
+  const messageIndex = messages.findIndex(
+    (m: TaskMessage) => m.id === message.id
+  );
   const nextMessage = messageIndex !== -1 ? messages[messageIndex + 1] : null;
 
   const reasoningInProgress = useMemo(() => {

--- a/agentex-ui/components/task-messages/task-message-tool-pair.tsx
+++ b/agentex-ui/components/task-messages/task-message-tool-pair.tsx
@@ -45,11 +45,13 @@ type TaskMessageToolPairProps = {
   toolResponseMessage?:
     | (TaskMessage & { content: ToolResponseContent })
     | undefined;
+  isInProgress?: boolean;
 };
 
 function TaskMessageToolPairImpl({
   toolRequestMessage,
   toolResponseMessage,
+  isInProgress = false,
 }: TaskMessageToolPairProps) {
   const [isCollapsed, setIsCollapsed] = useState(true);
 
@@ -92,9 +94,9 @@ function TaskMessageToolPairImpl({
       >
         <Wrench className="size-4" />
         <ShimmeringText
-          enabled={!toolResponseMessage}
+          enabled={isInProgress}
           text={
-            !toolResponseMessage
+            isInProgress
               ? 'Using tool:  ' + toolRequestMessage.content.name
               : 'Used tool:  ' + toolRequestMessage.content.name
           }

--- a/agentex-ui/components/task-messages/task-messages.tsx
+++ b/agentex-ui/components/task-messages/task-messages.tsx
@@ -52,6 +52,13 @@ function TaskMessagesImpl({
   const previousLastPairIdRef = useRef<string | null>(null);
   const previousPagesScrollHeightRef = useRef<number | null>(null);
 
+  // Reset scroll state when switching tasks
+  useEffect(() => {
+    isInitialLoadRef.current = true;
+    previousLastPairIdRef.current = null;
+    previousPagesScrollHeightRef.current = null;
+  }, [taskId]);
+
   const { agentexClient, sgpAppURL } = useAgentexClient();
   const { agentName } = useSafeSearchParams();
   const { data: agents = [] } = useAgents(agentexClient);
@@ -190,15 +197,20 @@ function TaskMessagesImpl({
     const isInitial = isInitialLoadRef.current;
     previousLastPairIdRef.current = lastPairId;
 
-    if (!lastPairRef.current) return;
+    const container = scrollContainerRef.current;
 
     if (isInitial) {
-      lastPairRef.current.scrollIntoView({
-        behavior: 'instant',
-        block: 'start',
-      });
+      // On initial load, wait for the browser to paint all content, then
+      // jump to the absolute bottom of the scroll container. Using
+      // requestAnimationFrame ensures layout is complete — scrollIntoView
+      // on a specific element can misfire if content is still rendering.
       isInitialLoadRef.current = false;
-    } else {
+      requestAnimationFrame(() => {
+        if (container) {
+          container.scrollTop = container.scrollHeight;
+        }
+      });
+    } else if (lastPairRef.current) {
       setTimeout(() => {
         lastPairRef.current?.scrollIntoView({
           behavior: 'smooth',
@@ -206,7 +218,7 @@ function TaskMessagesImpl({
         });
       }, 100);
     }
-  }, [lastPairId]);
+  }, [lastPairId, scrollContainerRef]);
 
   // Scroll position preservation after older pages load
   useEffect(() => {

--- a/agentex-ui/components/task-messages/task-messages.tsx
+++ b/agentex-ui/components/task-messages/task-messages.tsx
@@ -1,6 +1,15 @@
-import { Fragment, memo, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
+import { Loader2 } from 'lucide-react';
 
 import { useAgentexClient } from '@/components/providers';
 import { MessageFeedback } from '@/components/task-messages/message-feedback';
@@ -23,6 +32,7 @@ import type {
 type TaskMessagesProps = {
   taskId: string;
   headerRef: React.RefObject<HTMLDivElement | null>;
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
 };
 type MessagePair = {
   id: string;
@@ -30,20 +40,30 @@ type MessagePair = {
   agentMessages: TaskMessage[];
 };
 
-function TaskMessagesImpl({ taskId, headerRef }: TaskMessagesProps) {
+function TaskMessagesImpl({
+  taskId,
+  headerRef,
+  scrollContainerRef,
+}: TaskMessagesProps) {
   const lastPairRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerHeight, setContainerHeight] = useState<number>(0);
+  const isInitialLoadRef = useRef(true);
+  const previousLastPairIdRef = useRef<string | null>(null);
+  const previousPagesScrollHeightRef = useRef<number | null>(null);
 
   const { agentexClient, sgpAppURL } = useAgentexClient();
   const { agentName } = useSafeSearchParams();
   const { data: agents = [] } = useAgents(agentexClient);
   const agent = agents.find(a => a.name === agentName);
 
-  const { data: queryData } = useTaskMessages({ agentexClient, taskId });
-
-  const messages = useMemo(() => queryData?.messages ?? [], [queryData]);
-  const previousMessageCountRef = useRef(messages.length);
+  const {
+    messages,
+    rpcStatus,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useTaskMessages({ agentexClient, taskId });
 
   const toolCallIdToResponseMap = useMemo<
     Map<string, TaskMessage & { content: ToolResponseContent }>
@@ -107,21 +127,36 @@ function TaskMessagesImpl({ taskId, headerRef }: TaskMessagesProps) {
     return pairs;
   }, [messages]);
 
+  const pendingToolCallIds = useMemo(() => {
+    const pending = new Set<string>();
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i]!;
+      if (msg.content.type === 'tool_request') {
+        if (!toolCallIdToResponseMap.has(msg.content.tool_call_id)) {
+          pending.add(msg.content.tool_call_id);
+        }
+      } else if (msg.content.type !== 'tool_response') {
+        break;
+      }
+    }
+    return pending;
+  }, [messages, toolCallIdToResponseMap]);
+
   const shouldShowThinkingForLastPair = useMemo(() => {
     if (messagePairs.length === 0) return false;
 
     const lastPair = messagePairs[messagePairs.length - 1]!;
     const hasNoAgentMessages = lastPair.agentMessages.length === 0;
     const hasUserMessage = lastPair.userMessage !== null;
-    const rpcStatus = queryData?.rpcStatus;
 
     return (
       hasUserMessage &&
       hasNoAgentMessages &&
       (rpcStatus === 'pending' || rpcStatus === 'success')
     );
-  }, [messagePairs, queryData?.rpcStatus]);
+  }, [messagePairs, rpcStatus]);
 
+  // Measure container height for last-pair min-height
   useEffect(() => {
     const measureHeight = () => {
       if (containerRef.current) {
@@ -140,16 +175,30 @@ function TaskMessagesImpl({ taskId, headerRef }: TaskMessagesProps) {
     };
 
     measureHeight();
-
     window.addEventListener('resize', measureHeight);
     return () => window.removeEventListener('resize', measureHeight);
   }, [headerRef, messages]);
 
-  useEffect(() => {
-    const previousCount = previousMessageCountRef.current;
-    const currentCount = messagePairs.length;
+  // Scroll to bottom when NEW messages arrive at the end.
+  // Track the last pair ID — only scroll when it changes (new messages),
+  // not when older messages load at the top (which also increases length).
+  const lastPairId = messagePairs[messagePairs.length - 1]?.id ?? null;
 
-    if (currentCount > previousCount && lastPairRef.current) {
+  useEffect(() => {
+    if (!lastPairId || lastPairId === previousLastPairIdRef.current) return;
+
+    const isInitial = isInitialLoadRef.current;
+    previousLastPairIdRef.current = lastPairId;
+
+    if (!lastPairRef.current) return;
+
+    if (isInitial) {
+      lastPairRef.current.scrollIntoView({
+        behavior: 'instant',
+        block: 'start',
+      });
+      isInitialLoadRef.current = false;
+    } else {
       setTimeout(() => {
         lastPairRef.current?.scrollIntoView({
           behavior: 'smooth',
@@ -157,9 +206,45 @@ function TaskMessagesImpl({ taskId, headerRef }: TaskMessagesProps) {
         });
       }, 100);
     }
+  }, [lastPairId]);
 
-    previousMessageCountRef.current = currentCount;
-  }, [messagePairs.length]);
+  // Scroll position preservation after older pages load
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || previousPagesScrollHeightRef.current === null) return;
+
+    const addedHeight =
+      container.scrollHeight - previousPagesScrollHeightRef.current;
+    if (addedHeight > 0) {
+      container.scrollTop += addedHeight;
+    }
+    previousPagesScrollHeightRef.current = null;
+  }, [messages, scrollContainerRef]);
+
+  const handleLoadOlder = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (container) {
+      previousPagesScrollHeightRef.current = container.scrollHeight;
+    }
+    fetchNextPage();
+  }, [fetchNextPage, scrollContainerRef]);
+
+  // Scroll event listener: fetch older messages when user scrolls near the top.
+  // Unlike IntersectionObserver, scroll events don't fire on mount — only on
+  // actual scroll actions (user or programmatic).
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const onScroll = () => {
+      if (container.scrollTop < 100 && hasNextPage && !isFetchingNextPage) {
+        handleLoadOlder();
+      }
+    };
+
+    container.addEventListener('scroll', onScroll, { passive: true });
+    return () => container.removeEventListener('scroll', onScroll);
+  }, [scrollContainerRef, hasNextPage, isFetchingNextPage, handleLoadOlder]);
 
   const renderMessage = (message: TaskMessage) => {
     switch (message.content.type) {
@@ -178,6 +263,7 @@ function TaskMessagesImpl({ taskId, headerRef }: TaskMessagesProps) {
             toolResponseMessage={toolCallIdToResponseMap.get(
               message.content.tool_call_id
             )}
+            isInProgress={pendingToolCallIds.has(message.content.tool_call_id)}
           />
         );
       case 'tool_response':
@@ -193,6 +279,12 @@ function TaskMessagesImpl({ taskId, headerRef }: TaskMessagesProps) {
       ref={containerRef}
       className="flex w-full flex-1 flex-col items-center"
     >
+      {isFetchingNextPage && (
+        <div className="flex w-full justify-center py-3">
+          <Loader2 className="text-muted-foreground size-5 animate-spin" />
+        </div>
+      )}
+
       {messagePairs.map((pair, index) => {
         const isLastPair = index === messagePairs.length - 1;
         const shouldShowThinking = isLastPair && shouldShowThinkingForLastPair;

--- a/agentex-ui/hooks/custom-subscribe-task-state.tsx
+++ b/agentex-ui/hooks/custom-subscribe-task-state.tsx
@@ -3,6 +3,8 @@ import { aggregateMessageEvents } from 'agentex/lib/aggregate-message-events';
 import { compareDateStrings } from 'agentex/lib/compare-date-strings';
 import { taskStreamEventGenerator } from 'agentex/lib/task-stream-event-generator';
 
+import { fetchMessagesPage } from '@/hooks/fetch-messages';
+
 import type { Agentex } from 'agentex';
 import type { Agent, Task, TaskMessage } from 'agentex/resources';
 
@@ -90,10 +92,13 @@ export async function subscribeTaskState(
   options?: {
     signal?: AbortSignal | undefined | null;
     taskStreamReconnectPolicy?: TaskStreamReconnectPolicy;
+    /** Return cached messages if available, avoiding a duplicate fetch on connect. */
+    getCachedMessages?: () => TaskMessage[] | null;
   }
 ): Promise<AbortedReturn | ErrorReturn> {
   const { taskID } = taskIdentifier;
-  const { signal, taskStreamReconnectPolicy } = options ?? {};
+  const { signal, taskStreamReconnectPolicy, getCachedMessages } =
+    options ?? {};
 
   const startBackoffOnErrorNum =
     taskStreamReconnectPolicy?.startBackoffOnErrorNum ?? 2;
@@ -130,25 +135,30 @@ export async function subscribeTaskState(
               continuousAPIErrorCount = 0;
 
               // pause reading from stream until we initialize state
-              [, , messages] = await Promise.all([
-                client.tasks.retrieve(taskID, null, { signal }).then(res => {
-                  eventListener.onTaskChange(res);
-                  return res;
-                }),
-                client.agents
-                  .list({ task_id: taskID }, { signal })
-                  .then(res => {
-                    eventListener.onAgentsChange(res);
+              {
+                const cachedMessages = getCachedMessages?.();
+                const messagesPromise =
+                  cachedMessages && cachedMessages.length > 0
+                    ? Promise.resolve(cachedMessages)
+                    : fetchMessagesPage(client, taskID, 1, { signal });
+
+                [, , messages] = await Promise.all([
+                  client.tasks.retrieve(taskID, null, { signal }).then(res => {
+                    eventListener.onTaskChange(res);
                     return res;
                   }),
-                client.messages
-                  .list({ task_id: taskID }, { signal })
-                  .then(res => {
-                    const chronologicalMessages = res.slice().reverse();
-                    eventListener.onMessagesChange(chronologicalMessages);
+                  client.agents
+                    .list({ task_id: taskID }, { signal })
+                    .then(res => {
+                      eventListener.onAgentsChange(res);
+                      return res;
+                    }),
+                  messagesPromise.then(res => {
+                    eventListener.onMessagesChange(res);
                     return res;
                   }),
-              ]);
+                ]);
+              }
 
               // reset delta accumulator on connected event
               deltaAccumulator = null;

--- a/agentex-ui/hooks/fetch-messages.ts
+++ b/agentex-ui/hooks/fetch-messages.ts
@@ -1,0 +1,21 @@
+import type AgentexSDK from 'agentex';
+import type { TaskMessage } from 'agentex/resources';
+
+export const MESSAGES_PAGE_SIZE = 50;
+
+/**
+ * Fetches a single page of messages for a task.
+ * API returns newest-first; this reverses to chronological order.
+ */
+export async function fetchMessagesPage(
+  client: AgentexSDK,
+  taskId: string,
+  pageNumber: number,
+  options?: { signal?: AbortSignal | null | undefined }
+): Promise<TaskMessage[]> {
+  const messages = await client.messages.list(
+    { task_id: taskId, limit: MESSAGES_PAGE_SIZE, page_number: pageNumber },
+    options ?? {}
+  );
+  return messages.slice().reverse();
+}

--- a/agentex-ui/hooks/use-task-messages.ts
+++ b/agentex-ui/hooks/use-task-messages.ts
@@ -1,4 +1,11 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import {
+  InfiniteData,
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 import {
   agentRPCNonStreaming,
   agentRPCWithStreaming,
@@ -7,14 +14,14 @@ import {
 import { v4 } from 'uuid';
 
 import { toast } from '@/components/ui/toast';
+import { fetchMessagesPage, MESSAGES_PAGE_SIZE } from '@/hooks/fetch-messages';
 import { agentsKeys } from '@/hooks/use-agents';
 
 import type AgentexSDK from 'agentex';
 import type { IDeltaAccumulator } from 'agentex/lib';
 import type { Agent, TaskMessage, TaskMessageContent } from 'agentex/resources';
 
-export type TaskMessagesData = {
-  messages: TaskMessage[];
+export type TaskMessagesMetadata = {
   deltaAccumulator: IDeltaAccumulator | null;
   rpcStatus: 'idle' | 'pending' | 'success' | 'error';
 };
@@ -24,16 +31,15 @@ export const taskMessagesKeys = {
   byTaskId: (taskId: string) => [...taskMessagesKeys.all, taskId] as const,
 };
 
+export const taskMessagesMetaKeys = {
+  byTaskId: (taskId: string) => ['taskMessagesMeta', taskId] as const,
+};
+
 /**
- * Fetches the conversation messages for a specific task.
+ * Fetches conversation messages for a task using infinite scroll pagination.
  *
- * Returns all messages exchanged between the user and agent during task execution,
- * along with a delta accumulator for handling partial streaming updates and an RPC
- * status indicator. Refetching is disabled to prevent interrupting live message streams.
- *
- * @param agentexClient - AgentexSDK - The SDK client used to fetch messages
- * @param taskId - string - The unique ID of the task whose messages to retrieve
- * @returns UseQueryResult<TaskMessagesData> - Query result containing messages, delta accumulator, and RPC status
+ * Page 1 = newest messages from the API. Scrolling up loads page 2, 3, etc (older).
+ * Returns a flat, deduplicated, chronologically ordered messages array.
  */
 export function useTaskMessages({
   agentexClient,
@@ -42,29 +48,58 @@ export function useTaskMessages({
   agentexClient: AgentexSDK;
   taskId: string;
 }) {
-  return useQuery({
+  const queryClient = useQueryClient();
+
+  const infiniteQuery = useInfiniteQuery({
     queryKey: taskMessagesKeys.byTaskId(taskId),
-    queryFn: async (): Promise<TaskMessagesData> => {
-      if (!taskId) {
-        return { messages: [], deltaAccumulator: null, rpcStatus: 'idle' };
-      }
-
-      const messages = await agentexClient.messages.list({
-        task_id: taskId,
-      });
-
-      // API returns messages in descending order (newest first),
-      // reverse to chronological order (oldest first) for display
-      return {
-        messages: messages.slice().reverse(),
-        deltaAccumulator: null,
-        rpcStatus: 'idle',
-      };
+    queryFn: async ({ pageParam }): Promise<TaskMessage[]> => {
+      if (!taskId) return [];
+      return fetchMessagesPage(agentexClient, taskId, pageParam);
     },
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.length < MESSAGES_PAGE_SIZE) return undefined;
+      return allPages.length + 1;
+    },
+    initialPageParam: 1,
     enabled: !!taskId,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });
+
+  // Flatten pages into a single chronological array with deduplication.
+  // Pages are stored as [page1(newest), page2(older), page3(oldest), ...]
+  // Process newest-first so latest versions of messages win, then reverse.
+  const messages = useMemo(() => {
+    if (!infiniteQuery.data?.pages) return [];
+    const seen = new Set<string>();
+    const byPage: TaskMessage[][] = [];
+    for (const page of infiniteQuery.data.pages) {
+      const filtered: TaskMessage[] = [];
+      for (const msg of page) {
+        const id = msg.id ?? '';
+        if (!id || !seen.has(id)) {
+          if (id) seen.add(id);
+          filtered.push(msg);
+        }
+      }
+      byPage.push(filtered);
+    }
+    return byPage.reverse().flat();
+  }, [infiniteQuery.data?.pages]);
+
+  const metadata =
+    queryClient.getQueryData<TaskMessagesMetadata>(
+      taskMessagesMetaKeys.byTaskId(taskId)
+    ) ?? ({ deltaAccumulator: null, rpcStatus: 'idle' } as const);
+
+  return {
+    messages,
+    rpcStatus: metadata.rpcStatus,
+    fetchNextPage: infiniteQuery.fetchNextPage,
+    hasNextPage: infiniteQuery.hasNextPage,
+    isFetchingNextPage: infiniteQuery.isFetchingNextPage,
+    isLoading: infiniteQuery.isLoading,
+  };
 }
 
 type SendMessageParams = {
@@ -72,6 +107,20 @@ type SendMessageParams = {
   agentName: string;
   content: TaskMessageContent;
 };
+
+/** Helper to update just the first page (newest) of the infinite query cache. */
+function updateFirstPage(
+  oldData: InfiniteData<TaskMessage[]> | undefined,
+  updater: (firstPage: TaskMessage[]) => TaskMessage[]
+): InfiniteData<TaskMessage[]> {
+  if (!oldData) {
+    return { pages: [updater([])], pageParams: [1] };
+  }
+  return {
+    pages: [updater(oldData.pages[0] ?? []), ...oldData.pages.slice(1)],
+    pageParams: oldData.pageParams,
+  };
+}
 
 export function useSendMessage({
   agentexClient,
@@ -83,6 +132,7 @@ export function useSendMessage({
   return useMutation({
     mutationFn: async ({ taskId, agentName, content }: SendMessageParams) => {
       const queryKey = taskMessagesKeys.byTaskId(taskId);
+      const metaKey = taskMessagesMetaKeys.byTaskId(taskId);
 
       const agents = queryClient.getQueryData<Agent[]>(agentsKeys.all) || [];
       const agent = agents.find(a => a.name === agentName);
@@ -94,11 +144,10 @@ export function useSendMessage({
       switch (agent.acp_type) {
         case 'async':
         case 'agentic': {
-          queryClient.setQueryData<TaskMessagesData>(queryKey, data => ({
-            messages: data?.messages || [],
-            deltaAccumulator: data?.deltaAccumulator || null,
+          queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
+            deltaAccumulator: null,
             rpcStatus: 'pending',
-          }));
+          });
 
           const response = await agentRPCNonStreaming(
             agentexClient,
@@ -108,45 +157,41 @@ export function useSendMessage({
           );
 
           if (response.error != null) {
-            queryClient.setQueryData<TaskMessagesData>(queryKey, data => ({
-              messages: data?.messages || [],
-              deltaAccumulator: data?.deltaAccumulator || null,
+            queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
+              deltaAccumulator: null,
               rpcStatus: 'error',
-            }));
+            });
             throw new Error(response.error.message);
           }
 
-          // Refetch messages and spans now that the agent has finished processing
-          await queryClient.invalidateQueries({ queryKey: taskMessagesKeys.byTaskId(taskId) });
+          // Refetch spans now that the agent has finished processing
           queryClient.invalidateQueries({ queryKey: ['spans', taskId] });
 
-          const finalMessages = await agentexClient.messages.list({
-            task_id: taskId,
-          });
+          // Refetch just the newest page and update in place
+          const latestPage = await fetchMessagesPage(agentexClient, taskId, 1);
 
-          const chronologicalMessages = finalMessages.slice().reverse();
+          queryClient.setQueryData<InfiniteData<TaskMessage[]>>(queryKey, old =>
+            updateFirstPage(old, () => latestPage)
+          );
 
-          queryClient.setQueryData<TaskMessagesData>(queryKey, {
-            messages: chronologicalMessages,
+          queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
             deltaAccumulator: null,
             rpcStatus: 'success',
           });
 
-          return {
-            messages: chronologicalMessages,
-            deltaAccumulator: null,
-            rpcStatus: 'success',
-          };
+          return { messages: latestPage };
         }
 
         case 'sync': {
-          const currentData = queryClient.getQueryData<TaskMessagesData>(
-            queryKey
-          ) || {
-            messages: [],
-            deltaAccumulator: null,
-            rpcStatus: 'pending',
-          };
+          // Read current flattened messages from cache for streaming
+          const existingData =
+            queryClient.getQueryData<InfiniteData<TaskMessage[]>>(queryKey);
+          const existingMeta =
+            queryClient.getQueryData<TaskMessagesMetadata>(metaKey);
+
+          const flatMessages = existingData
+            ? [...existingData.pages].reverse().flat()
+            : [];
 
           const tempUserMessage: TaskMessage = {
             id: v4(),
@@ -157,11 +202,14 @@ export function useSendMessage({
             updated_at: new Date().toISOString(),
           };
 
-          let latestMessages = [...currentData.messages, tempUserMessage];
-          let latestDeltaAccumulator = currentData.deltaAccumulator;
+          let latestMessages = [...flatMessages, tempUserMessage];
+          let latestDeltaAccumulator = existingMeta?.deltaAccumulator ?? null;
 
-          queryClient.setQueryData<TaskMessagesData>(queryKey, {
-            messages: latestMessages,
+          // Optimistic: add user message to first page
+          queryClient.setQueryData<InfiniteData<TaskMessage[]>>(queryKey, old =>
+            updateFirstPage(old, firstPage => [...firstPage, tempUserMessage])
+          );
+          queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
             deltaAccumulator: latestDeltaAccumulator,
             rpcStatus: 'pending',
           });
@@ -176,19 +224,11 @@ export function useSendMessage({
             { signal: controller.signal }
           )) {
             if (response.error != null) {
-              queryClient.setQueryData<TaskMessagesData>(queryKey, data => ({
-                messages: data?.messages || [],
-                deltaAccumulator: data?.deltaAccumulator || null,
+              queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
+                deltaAccumulator: null,
                 rpcStatus: 'error',
-              }));
+              });
               throw new Error(response.error.message);
-            }
-
-            const cacheData =
-              queryClient.getQueryData<TaskMessagesData>(queryKey);
-            if (cacheData) {
-              latestMessages = cacheData.messages;
-              latestDeltaAccumulator = cacheData.deltaAccumulator;
             }
 
             const result = aggregateMessageEvents(
@@ -200,8 +240,12 @@ export function useSendMessage({
             latestMessages = result.messages;
             latestDeltaAccumulator = result.deltaAccumulator;
 
-            queryClient.setQueryData<TaskMessagesData>(queryKey, {
-              messages: latestMessages,
+            // Write streaming state to first page
+            queryClient.setQueryData<InfiniteData<TaskMessage[]>>(
+              queryKey,
+              old => updateFirstPage(old, () => latestMessages)
+            );
+            queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
               deltaAccumulator: latestDeltaAccumulator,
               rpcStatus: 'pending',
             });
@@ -211,24 +255,19 @@ export function useSendMessage({
             }
           }
 
-          const finalMessages = await agentexClient.messages.list({
-            task_id: taskId,
-          });
+          // Final reconciliation: refetch page 1
+          const latestPage = await fetchMessagesPage(agentexClient, taskId, 1);
 
-          // API returns messages in descending order (newest first),
-          // reverse to chronological order (oldest first) for display
-          const chronologicalMessages = finalMessages.slice().reverse();
+          queryClient.setQueryData<InfiniteData<TaskMessage[]>>(queryKey, old =>
+            updateFirstPage(old, () => latestPage)
+          );
 
-          queryClient.setQueryData<TaskMessagesData>(queryKey, {
-            messages: chronologicalMessages,
+          queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
             deltaAccumulator: null,
             rpcStatus: 'success',
           });
 
-          return {
-            messages: chronologicalMessages,
-            deltaAccumulator: null,
-          };
+          return { messages: latestPage };
         }
 
         default: {

--- a/agentex-ui/hooks/use-task-subscription.ts
+++ b/agentex-ui/hooks/use-task-subscription.ts
@@ -1,29 +1,28 @@
 import { useEffect } from 'react';
 
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
-// import { subscribeTaskState } from 'agentex/lib';
 
 import { subscribeTaskState } from '@/hooks/custom-subscribe-task-state';
 import { updateTaskInInfiniteQuery } from '@/hooks/use-create-task';
-import { taskMessagesKeys } from '@/hooks/use-task-messages';
-import type { TaskMessagesData } from '@/hooks/use-task-messages';
+import {
+  taskMessagesKeys,
+  taskMessagesMetaKeys,
+} from '@/hooks/use-task-messages';
+import type { TaskMessagesMetadata } from '@/hooks/use-task-messages';
 import { tasksKeys } from '@/hooks/use-tasks';
 
 import type AgentexSDK from 'agentex';
-import type { TaskListResponse, TaskRetrieveResponse } from 'agentex/resources';
+import type {
+  TaskListResponse,
+  TaskMessage,
+  TaskRetrieveResponse,
+} from 'agentex/resources';
 
 /**
  * Subscribes to real-time updates for a task's state, messages, and streaming status.
  *
- * Establishes a persistent connection to the Agentex backend to receive live task updates
- * as they happen. Automatically updates React Query cache when events arrive, triggering
- * UI re-renders. The subscription cleans up automatically on unmount or when dependencies change.
- *
- * @param agentexClient - AgentexSDK - The SDK client used to establish the subscription connection
- * @param taskId - string - The unique ID of the task to monitor
- * @param agentName - string - The name of the agent executing the task (used for cache updates)
- * @param enabled - boolean - Whether the subscription should be active (default: true), should be false for sync agents
- * @returns void - This hook manages side effects and does not return a value
+ * Merges subscription messages into the infinite query cache by ID rather than
+ * overwriting, so already-fetched older pages are preserved.
  */
 export function useTaskSubscription({
   agentexClient,
@@ -48,12 +47,49 @@ export function useTaskSubscription({
       { taskID: taskId },
       {
         onMessagesChange(messages) {
-          queryClient.setQueryData<TaskMessagesData>(
-            taskMessagesKeys.byTaskId(taskId),
-            {
-              messages: [...messages],
-              deltaAccumulator: null,
-              rpcStatus: 'pending',
+          const queryKey = taskMessagesKeys.byTaskId(taskId);
+          const metaKey = taskMessagesMetaKeys.byTaskId(taskId);
+
+          // Merge subscription messages into infinite query pages by ID.
+          // Subscription only knows about the newest messages — preserve older pages.
+          queryClient.setQueryData<InfiniteData<TaskMessage[]>>(
+            queryKey,
+            oldData => {
+              if (!oldData) {
+                return { pages: [[...messages]], pageParams: [1] };
+              }
+
+              // Build a map of subscription messages by ID for lookup
+              const subMessageMap = new Map<string, TaskMessage>();
+              for (const m of messages) {
+                if (m.id) subMessageMap.set(m.id, m);
+              }
+
+              // Update existing messages in all pages; track which IDs we matched
+              const matchedIds = new Set<string>();
+              const updatedPages = oldData.pages.map(page =>
+                page.map(msg => {
+                  if (msg.id && subMessageMap.has(msg.id)) {
+                    matchedIds.add(msg.id);
+                    return { ...subMessageMap.get(msg.id)! };
+                  }
+                  return msg;
+                })
+              );
+
+              // Any unmatched subscription messages are NEW — append to first page
+              const newMessages: TaskMessage[] = [];
+              for (const m of messages) {
+                if (m.id && !matchedIds.has(m.id)) {
+                  newMessages.push(m);
+                }
+              }
+
+              if (newMessages.length > 0) {
+                updatedPages[0] = [...(updatedPages[0] ?? []), ...newMessages];
+              }
+
+              return { pages: updatedPages, pageParams: oldData.pageParams };
             }
           );
 
@@ -61,15 +97,12 @@ export function useTaskSubscription({
             msg => msg.streaming_status === 'IN_PROGRESS'
           );
 
+          queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
+            deltaAccumulator: null,
+            rpcStatus: hasStreamingMessages ? 'pending' : 'success',
+          });
+
           if (!hasStreamingMessages && messages.length > 0) {
-            queryClient.setQueryData<TaskMessagesData>(
-              taskMessagesKeys.byTaskId(taskId),
-              data => ({
-                messages: data?.messages || [],
-                deltaAccumulator: data?.deltaAccumulator || null,
-                rpcStatus: 'success',
-              })
-            );
             queryClient.invalidateQueries({ queryKey: ['spans', taskId] });
           }
         },
@@ -90,17 +123,26 @@ export function useTaskSubscription({
         },
         onStreamStatusChange() {},
         onError() {
-          queryClient.setQueryData<TaskMessagesData>(
-            taskMessagesKeys.byTaskId(taskId),
-            data => ({
-              messages: data?.messages || [],
-              deltaAccumulator: data?.deltaAccumulator || null,
+          queryClient.setQueryData<TaskMessagesMetadata>(
+            taskMessagesMetaKeys.byTaskId(taskId),
+            {
+              deltaAccumulator: null,
               rpcStatus: 'error',
-            })
+            }
           );
         },
       },
-      { signal: abortController.signal }
+      {
+        signal: abortController.signal,
+        getCachedMessages: () => {
+          const data = queryClient.getQueryData<InfiniteData<TaskMessage[]>>(
+            taskMessagesKeys.byTaskId(taskId)
+          );
+          if (!data?.pages?.length) return null;
+          // Flatten all pages to chronological order for the subscription's local state
+          return [...data.pages].reverse().flat();
+        },
+      }
     );
 
     return () => {


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/7e993d40-e68f-4c2c-83e3-208d7aa62711

- **Infinite scroll pagination**: Messages now load the newest page first (50 messages). Older messages are fetched on-demand when the user scrolls to the top, with scroll position preservation so the viewport doesn't jump.
- **Fix subscription overwriting**: `onMessagesChange` in `useTaskSubscription` now merges subscription messages into the infinite query cache by ID instead of overwriting, preserving already-fetched older pages.
- **Deduplicate fetch logic**: Extracted shared `fetchMessagesPage` utility (`hooks/fetch-messages.ts`) — removed duplicate implementations from `use-task-messages.ts` and `custom-subscribe-task-state.tsx`. Subscription skips the fetch entirely if messages are already cached.
- **Fix shimmer on null tool results**: Tool calls with no response that appear earlier in the conversation no longer shimmer — only the trailing in-progress tool calls do.

## Changed files
- `hooks/fetch-messages.ts` — new shared fetch utility
- `hooks/use-task-messages.ts` — `useQuery` → `useInfiniteQuery`, metadata on separate key, `useSendMessage` writes to first page only
- `hooks/custom-subscribe-task-state.tsx` — uses shared utility, accepts `getCachedMessages` to skip redundant fetch
- `hooks/use-task-subscription.ts` — ID-based merge into infinite query pages instead of overwriting
- `components/task-messages/task-messages.tsx` — scroll event listener for loading older pages, scroll position preservation, shimmer fix
- `components/primary-content/chat-view.tsx` — passes `scrollContainerRef` to `TaskMessages`
- `components/task-messages/task-message-tool-pair.tsx` — `isInProgress` prop for shimmer
- `components/task-messages/task-message-reasoning-content.tsx` — updated for new hook return shape

## Test plan
- [ ] Open a task with >50 messages — should see only ~50 initially, scrolled to bottom
- [ ] Scroll to top — spinner appears, older messages load, scroll position preserved
- [ ] Send a message — streaming works, older messages not lost
- [ ] Disconnect/reconnect — subscription reconnection preserves older pages
- [ ] Tool calls with null results don't shimmer; only trailing in-progress tools shimmer
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds infinite scroll pagination for chat messages — loading the newest 50 messages first and fetching older pages as the user scrolls up — with scroll-position preservation so the viewport doesn't jump. It also fixes subscription message merging (ID-based instead of overwrite to preserve older pages), extracts a shared `fetchMessagesPage` utility, and fixes shimmer to apply only to trailing in-progress tool calls.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the only finding is a P2 style suggestion that does not affect runtime correctness

Pagination logic, deduplication, scroll-position preservation, and ID-based merge are all correct. The single flagged item is a missing useCallback wrapper per project convention.

agentex-ui/components/task-messages/task-messages.tsx — renderMessage should use useCallback per project rule
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex-ui/hooks/fetch-messages.ts | New shared fetch utility; simple page fetch with chronological reversal via .slice().reverse() |
| agentex-ui/hooks/use-task-messages.ts | Migrates to useInfiniteQuery with separate metadata key; updateFirstPage helper is sound; deduplication across pages ensures streaming correctness |
| agentex-ui/hooks/custom-subscribe-task-state.tsx | Uses shared fetchMessagesPage and new getCachedMessages option to skip redundant fetch on reconnect |
| agentex-ui/hooks/use-task-subscription.ts | ID-based merge preserves older pages; correctly appends new messages to page1 and updates existing messages in-place |
| agentex-ui/components/task-messages/task-messages.tsx | Adds scroll pagination, scroll-position preservation, and shimmer fix; renderMessage helper missing useCallback |
| agentex-ui/components/primary-content/chat-view.tsx | Passes scrollContainerRef to TaskMessages; minimal correct change |
| agentex-ui/components/task-messages/task-message-tool-pair.tsx | Adds isInProgress prop to decouple shimmer from toolResponseMessage presence; fixes shimmer for non-trailing tool calls |
| agentex-ui/components/task-messages/task-message-reasoning-content.tsx | Updates destructuring for new useTaskMessages return shape; functionally equivalent |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant TaskMessages
    participant useTaskMessages
    participant Cache as React Query Cache
    participant API

    User->>TaskMessages: Mount / switch task
    TaskMessages->>useTaskMessages: useInfiniteQuery(page=1)
    useTaskMessages->>API: fetchMessagesPage(taskId, 1)
    API-->>useTaskMessages: newest 50 messages
    useTaskMessages-->>TaskMessages: messages (flat, deduped, chronological)
    TaskMessages->>TaskMessages: scrollTop = scrollHeight (initial)

    User->>TaskMessages: Scroll to top
    TaskMessages->>TaskMessages: save scrollHeight
    TaskMessages->>useTaskMessages: fetchNextPage() (page=2)
    useTaskMessages->>API: fetchMessagesPage(taskId, 2)
    API-->>useTaskMessages: next 50 older messages
    useTaskMessages-->>TaskMessages: updated messages
    TaskMessages->>TaskMessages: scrollTop += addedHeight (preserve position)

    User->>TaskMessages: Send message (sync/streaming)
    TaskMessages->>Cache: updateFirstPage(all pages flattened + new msg)
    loop streaming events
        Cache-->>TaskMessages: re-render with latestMessages in page1
    end
    TaskMessages->>API: fetchMessagesPage(taskId, 1)
    API-->>Cache: reconciled page1
    TaskMessages->>TaskMessages: page1 reset to newest 50
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: agentex-ui/components/task-messages/task-messages.tsx
Line: 261-287

Comment:
**`renderMessage` should be wrapped in `useCallback`**

`renderMessage` is a render-logic helper that closes over `toolCallIdToResponseMap` and `pendingToolCallIds` but is recreated on every render. Per the project's performance convention, wrap it in `useCallback` with its memoized dependencies.

```suggestion
  const renderMessage = useCallback((message: TaskMessage) => {
    switch (message.content.type) {
      case 'text':
        return <TaskMessageTextContent content={message.content} />;
      case 'data':
        return <TaskMessageDataContent content={message.content} />;
      case 'reasoning':
        return <TaskMessageReasoning message={message} />;
      case 'tool_request':
        return (
          <TaskMessageToolPair
            toolRequestMessage={
              message as TaskMessage & { content: ToolRequestContent }
            }
            toolResponseMessage={toolCallIdToResponseMap.get(
              message.content.tool_call_id
            )}
            isInProgress={pendingToolCallIds.has(message.content.tool_call_id)}
          />
        );
      case 'tool_response':
        return null;
      default:
        message.content.type satisfies undefined;
        return null;
    }
  }, [toolCallIdToResponseMap, pendingToolCallIds]);
```

**Rule Used:** Add useCallback hooks for helper functions that ar... ([source](https://app.greptile.com/review/custom-context?memory=bd7eade1-377b-4ad4-999e-e61ec112815b))

**Learnt From**
[scaleapi/scaleapi#126960](https://github.com/scaleapi/scaleapi/pull/126960)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Clear state when switching task\_ids"](https://github.com/scaleapi/scale-agentex/commit/fbfec3e4246736178f0b86574a48959b2295bda0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27591818)</sub>

**Context used:**

- Rule used - Add useCallback hooks for helper functions that ar... ([source](https://app.greptile.com/review/custom-context?memory=bd7eade1-377b-4ad4-999e-e61ec112815b))

**Learnt From**
[scaleapi/scaleapi#126960](https://github.com/scaleapi/scaleapi/pull/126960)

<!-- /greptile_comment -->