### PR TITLE
fix(temporal): remove private _JSONTypeConverterUnhandled from type annotations

### DIFF
--- a/agentex/src/adapters/temporal/client_factory.py
+++ b/agentex/src/adapters/temporal/client_factory.py
@@ -14,7 +14,6 @@ from temporalio.converter import (
     DefaultPayloadConverter,
     JSONPlainPayloadConverter,
     JSONTypeConverter,
-    _JSONTypeConverterUnhandled,
 )
 from temporalio.runtime import OpenTelemetryConfig, Runtime, TelemetryConfig
 
@@ -39,7 +38,7 @@ class DateTimeJSONTypeConverter(JSONTypeConverter):
 
     def to_typed_value(
         self, hint: type, value: Any
-    ) -> Any | None | _JSONTypeConverterUnhandled:
+    ) -> Any:
         if hint == datetime.datetime:
             return datetime.datetime.fromisoformat(value)
         return JSONTypeConverter.Unhandled

--- a/agentex/src/utils/temporal_client.py
+++ b/agentex/src/utils/temporal_client.py
@@ -10,7 +10,6 @@ from temporalio.converter import (
     DefaultPayloadConverter,
     JSONPlainPayloadConverter,
     JSONTypeConverter,
-    _JSONTypeConverterUnhandled,
 )
 from temporalio.runtime import OpenTelemetryConfig, Runtime, TelemetryConfig
 
@@ -25,7 +24,7 @@ class DateTimeJSONEncoder(AdvancedJSONEncoder):
 class DateTimeJSONTypeConverter(JSONTypeConverter):
     def to_typed_value(
         self, hint: type, value: Any
-    ) -> Any | None | _JSONTypeConverterUnhandled:
+    ) -> Any:
         if hint == datetime.datetime:
             return datetime.datetime.fromisoformat(value)
         return JSONTypeConverter.Unhandled


### PR DESCRIPTION
## Summary

- `_JSONTypeConverterUnhandled` was removed in temporalio 1.25.0 — it was never part of the public API
- It was only used in the return type annotation of `DateTimeJSONTypeConverter.to_typed_value` in two files; the method body already uses the public `JSONTypeConverter.Unhandled` sentinel
- Fix: replace `Any | None | _JSONTypeConverterUnhandled` with `Any` and remove the import

## Root cause

The Dockerfile installs dependencies without a lockfile (`uv pip install --system -e .`), so it resolved temporalio 1.25.0 at build time. 1.25.0 removed `_JSONTypeConverterUnhandled`, causing an `ImportError` at pod startup and `/readyz` returning 503 indefinitely.

## Verified

Built the FIPS production image locally with temporalio 1.25.0 installed — imports succeed and `DateTimeJSONTypeConverter` loads correctly.

## Test plan

- [ ] CI build passes
- [ ] agentex pod starts and `/readyz` returns 200 on dev cluster after next nightly deploy

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes references to `_JSONTypeConverterUnhandled`, a private temporalio symbol that was removed in v1.25.0, replacing the return type annotation `Any | None | _JSONTypeConverterUnhandled` with `Any` in two files. The method bodies already use the public `JSONTypeConverter.Unhandled` sentinel correctly, so only the annotations needed updating.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, targeted fix that removes a broken private import without changing runtime behavior.

The change only removes a private symbol from type annotations. The method body already used the correct public API (`JSONTypeConverter.Unhandled`), so no runtime behavior changes. Both files are updated consistently, and the simplified `Any` return type is accurate. No new logic, no side effects, no security implications.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/adapters/temporal/client_factory.py | Removes private `_JSONTypeConverterUnhandled` import and simplifies `to_typed_value` return type annotation to `Any`; runtime behavior unchanged. |
| agentex/src/utils/temporal_client.py | Identical fix to client_factory.py — removes private import and simplifies return type annotation; method body already uses public API sentinel. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DateTimeJSONTypeConverter.to_typed_value(hint, value)"] --> B{hint == datetime.datetime?}
    B -- Yes --> C["datetime.fromisoformat(value)\nreturn datetime object"]
    B -- No --> D["return JSONTypeConverter.Unhandled\n(public sentinel)"]
    D --> E["Temporal SDK detects Unhandled\nand falls back to default converter"]
    C --> F["Caller receives typed datetime"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(temporal): remove private \_JSONTypeC..."](https://github.com/scaleapi/scale-agentex/commit/d15631389035664f31031c7695ba67c35bbeb397) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27808781)</sub>

<!-- /greptile_comment -->