### PR TITLE
fix: pin litellm <1.82.7 due to security vulnerability

### DIFF
--- a/agentex/pyproject.toml
+++ b/agentex/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12,<3.13"
 readme = "README.md"
 dependencies = [
     "fastapi>=0.115.0",
-    "litellm>=1.48.2,<2",
+    "litellm>=1.48.2,<1.82.7",
     "python-dotenv>=1.0.1,<2",
     "temporalio>=1.18.0,<2",
     "uvicorn[standard]>=0.35.0,<0.36",

--- a/uv.lock
+++ b/uv.lock
@@ -128,7 +128,7 @@ requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.2" },
     { name = "json-log-formatter", specifier = ">=1.1.1" },
     { name = "kubernetes-asyncio", specifier = ">=31.1.0,<32" },
-    { name = "litellm", specifier = ">=1.48.2,<2" },
+    { name = "litellm", specifier = ">=1.48.2,<1.82.7" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.28.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.28.0" },


### PR DESCRIPTION
## Summary
- Pins `litellm` to `<1.82.7` (was `<2`) to address a security vulnerability flagged by Rishabh Shah
- Currently resolved version is `1.77.5`, well under the cap — no functional change

## Test plan
- [x] `uv lock` resolves successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins `litellm` to `<1.82.7` in `agentex/pyproject.toml` to protect against the supply-chain compromise in versions 1.82.7 and 1.82.8, which were published with credential-stealing malware to PyPI on March 24, 2026 (both since removed). The currently resolved version (1.77.5) is unaffected and there is no functional change.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted security pin with no functional change and a clean resolved version.

The only finding is a P2 suggestion to use `!=` specifiers instead of a hard upper bound, which is a future-proofing concern rather than a current defect. The resolved version (1.77.5) is unaffected by the supply-chain compromise, and both compromised versions have been removed from PyPI.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

- This PR directly addresses a supply chain compromise (GHSA-5mg7-485q-xm76): litellm 1.82.7 and 1.82.8 contained credential-stealing malware targeting SSH keys, cloud credentials, environment variables, and Kubernetes secrets. Both versions have been removed from PyPI.
- The upper bound `<1.82.7` prevents resolving to 1.82.7 but does **not** explicitly exclude 1.82.8 by version specifier; however, since 1.82.8 is also removed from PyPI, uv cannot resolve to it in practice.
- The resolved version (1.77.5) is clean and pre-dates the compromise.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/pyproject.toml | Pins litellm to `>=1.48.2,<1.82.7` to block the supply-chain-compromised versions 1.82.7/1.82.8; constraint is correct and the resolved version (1.77.5) is safe. |
| uv.lock | Lock file updated to reflect new litellm specifier; resolves to 1.77.5, which is unaffected by the supply-chain compromise. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["uv lock resolution"] --> B{"litellm version\navailable on PyPI?"}
    B -->|"1.82.7 / 1.82.8\n(removed from PyPI)"| C["❌ Cannot resolve\n(removed)"]
    B -->|"1.77.5\n(satisfies >=1.48.2,<1.82.7)"| D["✅ Resolves to 1.77.5\n(safe)"]
    D --> E["Build / Deploy"]
    C --> F["Resolution failure\n(protected)"]

    style C fill:#ffcccc
    style D fill:#ccffcc
    style F fill:#ffcccc
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fpyproject.toml%3A10%0A**Upper%20bound%20blocks%20future%20clean%20releases**%0A%0AThe%20constraint%20%60%3C1.82.7%60%20will%20also%20prevent%20upgrading%20to%20any%20clean%20litellm%20release%20above%201.82.6%20%28e.g.%20a%20future%201.83.x%29%20without%20a%20manual%20constraint%20update.%20Since%20both%20compromised%20versions%20%281.82.7%20and%201.82.8%29%20have%20been%20removed%20from%20PyPI%2C%20using%20%60!%3D1.82.7%2C!%3D1.82.8%60%20instead%20would%20protect%20against%20cached%2Fmirrored%20copies%20of%20those%20exact%20versions%20while%20still%20allowing%20clean%20future%20releases.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22litellm%3E%3D1.48.2%2C!%3D1.82.7%2C!%3D1.82.8%2C%3C2%22%2C%0A%60%60%60%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fpyproject.toml%3A10%0A**Upper%20bound%20blocks%20future%20clean%20releases**%0A%0AThe%20constraint%20%60%3C1.82.7%60%20will%20also%20prevent%20upgrading%20to%20any%20clean%20litellm%20release%20above%201.82.6%20%28e.g.%20a%20future%201.83.x%29%20without%20a%20manual%20constraint%20update.%20Since%20both%20compromised%20versions%20%281.82.7%20and%201.82.8%29%20have%20been%20removed%20from%20PyPI%2C%20using%20%60!%3D1.82.7%2C!%3D1.82.8%60%20instead%20would%20protect%20against%20cached%2Fmirrored%20copies%20of%20those%20exact%20versions%20while%20still%20allowing%20clean%20future%20releases.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22litellm%3E%3D1.48.2%2C!%3D1.82.7%2C!%3D1.82.8%2C%3C2%22%2C%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: agentex/pyproject.toml
Line: 10

Comment:
**Upper bound blocks future clean releases**

The constraint `<1.82.7` will also prevent upgrading to any clean litellm release above 1.82.6 (e.g. a future 1.83.x) without a manual constraint update. Since both compromised versions (1.82.7 and 1.82.8) have been removed from PyPI, using `!=1.82.7,!=1.82.8` instead would protect against cached/mirrored copies of those exact versions while still allowing clean future releases.

```suggestion
    "litellm>=1.48.2,!=1.82.7,!=1.82.8,<2",
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: pin litellm &lt;1.82.7 due to security..."](https://github.com/scaleapi/scale-agentex/commit/578a7345a9db0111e56880ce8d298dcb172d366a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27881623)</sub>

<!-- /greptile_comment -->