### PR TITLE
ci: add conventional commit enforcement for PR titles

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,40 @@
+name: Lint PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore
+            ci
+            build
+            perf
+            revert
+          requireScope: false
+          # Allow skipping this check with a label (e.g. for automated/bot PRs)
+          ignoreLabels: |
+            skip-conventional-commit-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,27 +47,28 @@ To set up your development environment for Agentex, please refer to the [README.
 
 ---
 
-## Best Practices for Writing Commit Messages
+## Commit and PR Title Guidelines
 
-- **Separate subject from body with a blank line**.
-- **Limit the subject line to 50 characters**.
-- **Capitalize the subject line**.
-- **Do not end the subject line with a period**.
-- **Use the imperative mood in the subject line**  
-  (e.g., “Fix bug” not “Fixed bug” or “Fixes bug”).
-- **Wrap the body at 72 characters**.
+This project enforces [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) on PR titles. A CI check will validate your PR title before it can be merged.
+
+**Format:** `type: description` or `type(scope): description`
+
+**Allowed types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`, `revert`
+
+**Examples:**
+```
+feat: add user authentication middleware
+fix(api): handle empty request body gracefully
+docs: update contributing guidelines
+chore: bump dependency versions
+```
+
+### General commit message best practices
+
+- **Use the imperative mood** (e.g., “Add feature” not “Added feature”).
+- **Keep the subject line under 72 characters**.
 - **Use the body to explain what and why vs. how** (if needed).
 - **Reference relevant issues/PRs** (e.g., `Fixes #123`).
-
-**Example:**
-```
-Add user authentication middleware
-
-This middleware intercepts requests to check authentication tokens
-and ensures only valid users can access protected routes.
-
-Fixes #42
-```
 
 For more, see: [Chris Beams' guide to writing great commit messages](https://cbea.ms/git-commit/).
 


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`lint-pr.yaml`) that validates PR titles follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format before merging to main
- Uses `amannn/action-semantic-pull-request@v6.1.1` (pinned to SHA), matching the existing setup in the SGP and agentex (private) repositories
- Supports types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `build`, `perf`, `revert`
- Includes a `skip-conventional-commit-check` label escape hatch for bot/automated PRs

> [!NOTE]
> After merging, add `Validate PR title (Conventional Commits)` as a **required status check** in the branch protection rules for `main` (Settings → Branches → `main` rule → Require status checks). Without this, the workflow will run but won't block non-compliant PRs.

## Test plan
- [ ] Verify the workflow runs on this PR
- [ ] Confirm it passes since this PR title follows conventional commit format

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions workflow (`lint-pr.yaml`) that validates PR titles conform to Conventional Commits format, along with updated `CONTRIBUTING.md` documentation reflecting the new requirement. The implementation is clean: the action is SHA-pinned, permissions are minimal (`statuses: write`, `pull-requests: read`), trigger events cover all relevant cases (including `labeled`/`unlabeled` for the escape-hatch label), and the allowed type list is consistent with the PR description.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no logic issues, security concerns, or correctness problems identified.

Both changed files are CI/docs only. The workflow YAML is correct: SHA-pinned action, appropriate permissions, and all relevant trigger events. CONTRIBUTING.md accurately describes the new enforcement. No P0 or P1 findings.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/lint-pr.yaml | New workflow enforcing Conventional Commits on PR titles; SHA-pinned action, correct trigger events (including labeled/unlabeled for the escape hatch), and minimal required permissions. |
| CONTRIBUTING.md | Updated commit guidelines to reflect Conventional Commits enforcement; old informal advice replaced with the enforced format, allowed types, and examples. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Action as action-semantic-pull-request
    participant Status as Commit Status API

    Dev->>GH: Open / Edit / Label PR
    GH->>Action: Trigger lint-pr workflow
    Action->>GH: Read PR title (pull-requests: read)
    alt Title matches Conventional Commits format OR skip label present
        Action->>Status: Post success status (statuses: write)
        Status->>GH: Status check passes → merge unblocked
    else Title does not match
        Action->>Status: Post failure status (statuses: write)
        Status->>GH: Status check fails → merge blocked
        GH->>Dev: Notify: fix PR title or add skip label
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/enforce-c..."](https://github.com/scaleapi/scale-agentex/commit/23c47a2de94bce2285626763a379e3690a3de8c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28649637)</sub>

<!-- /greptile_comment -->