### PR TITLE
Run and fix integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
               - 'agentex/**'
 
   test:
-    name: "Run Unit Tests"
+    name: "Run Unit and Integration Tests"
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.agentex == 'true'
@@ -82,13 +82,21 @@ jobs:
         uv run python scripts/test_setup.py --check-docker
         echo "✅ Docker environment validated successfully"
 
-    # Run unit tests only (fast, no integration tests)
+    # Run unit tests
     - name: Run unit tests
       working-directory: ./agentex
       timeout-minutes: 10
       run: |
-        echo "🧪 Running unit tests (fast, isolated)..."
+        echo "🧪 Running unit tests..."
         uv run python scripts/run_tests.py -m unit --cov=src --cov-report=xml --cov-report=term
+
+    # Run integration tests (appends to unit coverage)
+    - name: Run integration tests
+      working-directory: ./agentex
+      timeout-minutes: 20
+      run: |
+        echo "🧪 Running integration tests..."
+        uv run python scripts/run_tests.py -m integration --cov=src --cov-report=xml --cov-report=term --pytest-args="--cov-append"
 
     # Clean up test containers
     - name: Clean up test containers
@@ -112,8 +120,7 @@ jobs:
     - name: Test Summary
       if: always()
       run: |
-        echo "📊 Unit test execution completed"
-        echo "✅ Fast isolated tests for public contributors"
+        echo "📊 Unit and integration test execution completed"
 
   docs:
     name: "Build Documentation"
@@ -176,7 +183,7 @@ jobs:
             
             # Both test and docs must succeed
             if [ "${{ needs.test.result }}" != "success" ]; then
-              echo "❌ Unit tests failed"
+              echo "❌ Tests failed"
               exit 1
             fi
             

--- a/agentex/tests/integration/fixtures/integration_client.py
+++ b/agentex/tests/integration/fixtures/integration_client.py
@@ -259,14 +259,15 @@ async def isolated_repositories(isolated_test_schema):
     from src.domain.repositories.agent_task_tracker_repository import (
         AgentTaskTrackerRepository,
     )
+    from src.domain.repositories.checkpoint_repository import CheckpointRepository
     from src.domain.repositories.deployment_history_repository import (
         DeploymentHistoryRepository,
     )
+    from src.domain.repositories.deployment_repository import DeploymentRepository
     from src.domain.repositories.event_repository import EventRepository
     from src.domain.repositories.span_repository import SpanRepository
     from src.domain.repositories.task_message_repository import TaskMessageRepository
     from src.domain.repositories.task_repository import TaskRepository
-    from src.domain.repositories.checkpoint_repository import CheckpointRepository
     from src.domain.repositories.task_state_repository import TaskStateRepository
 
     # Create Redis repository with mock environment variables
@@ -308,6 +309,9 @@ async def isolated_repositories(isolated_test_schema):
             async_rw_session_factory, async_ro_session_factory
         ),
         "deployment_history_repository": DeploymentHistoryRepository(
+            async_rw_session_factory, async_ro_session_factory
+        ),
+        "deployment_repository": DeploymentRepository(
             async_rw_session_factory, async_ro_session_factory
         ),
         # MongoDB repositories
@@ -370,6 +374,7 @@ async def isolated_integration_app(
     from src.domain.use_cases.agent_api_keys_use_case import AgentAPIKeysUseCase
     from src.domain.use_cases.agent_task_tracker_use_case import AgentTaskTrackerUseCase
     from src.domain.use_cases.agents_use_case import AgentsUseCase
+    from src.domain.use_cases.checkpoints_use_case import CheckpointsUseCase
     from src.domain.use_cases.deployment_history_use_case import (
         DeploymentHistoryUseCase,
     )
@@ -377,7 +382,6 @@ async def isolated_integration_app(
     from src.domain.use_cases.messages_use_case import MessagesUseCase
     from src.domain.use_cases.spans_use_case import SpanUseCase
     from src.domain.use_cases.states_use_case import StatesUseCase
-    from src.domain.use_cases.checkpoints_use_case import CheckpointsUseCase
     from src.domain.use_cases.tasks_use_case import TasksUseCase
 
     # Create use case factory functions with isolated repositories
@@ -388,6 +392,7 @@ async def isolated_integration_app(
             deployment_history_repository=isolated_repositories[
                 "deployment_history_repository"
             ],
+            deployment_repository=isolated_repositories["deployment_repository"],
         )
 
     def create_agent_api_keys_use_case():
@@ -467,15 +472,16 @@ async def isolated_integration_app(
         DDatabaseAsyncReadWriteSessionMaker,
         DMongoDBDatabase,
     )
-    from src.domain.repositories.checkpoint_repository import CheckpointRepository
     from src.domain.repositories.agent_api_key_repository import AgentAPIKeyRepository
     from src.domain.repositories.agent_repository import AgentRepository
     from src.domain.repositories.agent_task_tracker_repository import (
         AgentTaskTrackerRepository,
     )
+    from src.domain.repositories.checkpoint_repository import CheckpointRepository
     from src.domain.repositories.deployment_history_repository import (
         DeploymentHistoryRepository,
     )
+    from src.domain.repositories.deployment_repository import DeploymentRepository
     from src.domain.repositories.event_repository import EventRepository
     from src.domain.repositories.span_repository import SpanRepository
     from src.domain.repositories.task_message_repository import TaskMessageRepository
@@ -525,6 +531,9 @@ async def isolated_integration_app(
             ],
             DeploymentHistoryRepository: lambda: isolated_repositories[
                 "deployment_history_repository"
+            ],
+            DeploymentRepository: lambda: isolated_repositories[
+                "deployment_repository"
             ],
             # Redis repositories
             RedisStreamRepository: lambda: isolated_repositories[


### PR DESCRIPTION
We were only running unit tests before despite integration tests being fairly fast. This PR adds integration tests to the CI/CD and fixes the broken ones by adding the `deployment_repository`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables integration tests in CI by adding a dedicated step in `ci.yml` and fixes the broken tests by supplying the previously missing `DeploymentRepository` to the `AgentsUseCase` factory and FastAPI dependency overrides in the integration test fixture. The changes are minimal and targeted.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is correct and the only remaining finding is a cosmetic Codecov flag label.

All changes are well-scoped: the `DeploymentRepository` is correctly wired in every required location (fixture dict, use-case factory, dependency overrides), and the CI step properly uses `--cov-append` to produce a single combined coverage report. The only finding is a P2 label inconsistency in the Codecov upload step.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds integration test step after unit tests, with `--cov-append` to merge coverage into a single report; minor: Codecov `flags` still reads `unittests` though it now includes integration coverage. |
| agentex/tests/integration/fixtures/integration_client.py | Adds the missing `DeploymentRepository` to `isolated_repositories`, wires it into `AgentsUseCase`, and registers it in `fastapi_app.dependency_overrides`; import reordering to alphabetical order. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant UT as Unit Tests
    participant IT as Integration Tests
    participant CC as Codecov

    GH->>UT: run_tests.py -m unit --cov=src --cov-report=xml
    UT-->>GH: .coverage + coverage.xml (unit only)
    GH->>IT: run_tests.py -m integration --cov=src --cov-report=xml --cov-append
    IT-->>GH: .coverage (appended) + coverage.xml (unit+integration)
    GH->>CC: Upload combined coverage.xml
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A115-116%0A**Codecov%20%60flags%60%20label%20is%20stale**%0A%0AThe%20%60flags%3A%20unittests%60%20label%20was%20accurate%20before%2C%20but%20the%20uploaded%20%60coverage.xml%60%20now%20contains%20merged%20unit%20%2B%20integration%20coverage%20%28via%20%60--cov-append%60%29.%20Codecov%20uses%20flags%20to%20filter%20and%20compare%20reports%2C%20so%20the%20label%20is%20misleading.%20Consider%20updating%20it%20to%20reflect%20the%20combined%20scope.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20flags%3A%20tests%0A%60%60%60%0A%0A&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A115-116%0A**Codecov%20%60flags%60%20label%20is%20stale**%0A%0AThe%20%60flags%3A%20unittests%60%20label%20was%20accurate%20before%2C%20but%20the%20uploaded%20%60coverage.xml%60%20now%20contains%20merged%20unit%20%2B%20integration%20coverage%20%28via%20%60--cov-append%60%29.%20Codecov%20uses%20flags%20to%20filter%20and%20compare%20reports%2C%20so%20the%20label%20is%20misleading.%20Consider%20updating%20it%20to%20reflect%20the%20combined%20scope.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20flags%3A%20tests%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=202&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 115-116

Comment:
**Codecov `flags` label is stale**

The `flags: unittests` label was accurate before, but the uploaded `coverage.xml` now contains merged unit + integration coverage (via `--cov-append`). Codecov uses flags to filter and compare reports, so the label is misleading. Consider updating it to reflect the combined scope.

```suggestion
        flags: tests
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Run and fix integration tests"](https://github.com/scaleapi/scale-agentex/commit/a8d9777d6462897cde52890339032f3e66bdeb31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29057041)</sub>

<!-- /greptile_comment -->