### PR TITLE
fix: DeploymentStatus ORM binds by member name, Postgres enum expects .value

### DIFF
--- a/agentex/src/adapters/orm.py
+++ b/agentex/src/adapters/orm.py
@@ -238,8 +238,14 @@ class DeploymentORM(BaseORM):
     registration_metadata = Column(JSONB, nullable=True)
 
     # Runtime state (updated during lifecycle)
+    # values_callable makes SQLAlchemy emit the enum's .value ("Pending"/"Ready"/"Failed")
+    # instead of its member name ("PENDING"/"READY"/"FAILED"). The Postgres enum created
+    # by migration 2026_03_30_1900_deployments_4a9b7787ccd7 uses the .value form.
     status = Column(
-        SQLAlchemyEnum(DeploymentStatus),
+        SQLAlchemyEnum(
+            DeploymentStatus,
+            values_callable=lambda enum_cls: [e.value for e in enum_cls],
+        ),
         nullable=False,
         default=DeploymentStatus.PENDING,
     )


### PR DESCRIPTION
## Summary

One-line fix to the `DeploymentORM.status` column — pass `values_callable=` so SQLAlchemy serializes by the enum's `.value` instead of its member name, matching the Postgres enum created by the companion migration.

## Why

Migration `agentex/database/migrations/alembic/versions/2026_03_30_1900_deployments_4a9b7787ccd7.py:29` creates the `deploymentstatus` enum with `'Pending', 'Ready', 'Failed'`. The Python enum uses the same strings as `.value`s: `PENDING = "Pending"`, etc.

But the ORM column at `agentex/src/adapters/orm.py:241` was declared as plain `SQLAlchemyEnum(DeploymentStatus)`, and SQLAlchemy's default is to serialize `Enum` members by **name**. So every INSERT tried to write `"READY"` / `"PENDING"` / `"FAILED"` into a column that only accepts `"Ready"` / `"Pending"` / `"Failed"`, and failed with:

```
asyncpg.exceptions.InvalidTextRepresentationError:
  invalid input value for enum deploymentstatus: "READY"
```

Introduced in #181. Any agent pod that registers with `AGENTEX_DEPLOYMENT_ID` (SGP's versioned-deployment flow) crash-loops on startup because `register_agent` gets a 500, Uvicorn exits with `Application startup failed`, and k8s restarts the pod forever. Observed on sgp-dev today hitting every agent on the new registration path.

## Fix

```diff
     status = Column(
-        SQLAlchemyEnum(DeploymentStatus),
+        SQLAlchemyEnum(
+            DeploymentStatus,
+            values_callable=lambda enum_cls: [e.value for e in enum_cls],
+        ),
         nullable=False,
         default=DeploymentStatus.PENDING,
     )
```

Added a code comment calling out the coupling to the migration so future readers don't re-break this.

## Test plan

- [ ] Unit tests in `agentex/tests/` still green locally (`make test` or equivalent)
- [ ] Fresh agent deploy on sgp-dev with `AGENTEX_DEPLOYMENT_ID` set — pod registers cleanly, deployment row lands with `status = 'Ready'`, SGP rollout reaches healthy
- [ ] Existing agents using the legacy `agent.acp_url` registration path (no `deployment_id`) continue to work unchanged
- [ ] Promote flow still works — `DeploymentStatus.READY` comparisons in `deployment_repository.py:96-99` still match DB values round-tripped through this binding

## Linked

- Linear: [EE-45](https://linear.app/scale-epd/issue/EE-45/deploymentstatus-orm-enum-sqlalchemy-emits-member-name-ready-but)
- Root-caused in #181 (didn't flag because that PR's test plan `[ ] Verify migration applies cleanly` was unchecked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)