### PR TITLE
feat: add service account id to auth cache

### DIFF
--- a/agentex/docs/docs/configuration.md
+++ b/agentex/docs/docs/configuration.md
@@ -300,26 +300,40 @@ kubernetes:
 - Keep under 63 characters (Kubernetes limit)
 
 #### Auth Principal Configuration
+
+The `principal` block identifies the calling identity used for authorization on
+agent registration. **Set exactly one of `user_id` or `service_account_id`** —
+they're mutually exclusive.
+
+For a human user identity:
 ```yaml
 auth:
   principal:
-    user_id: "my-dev-cluster-user-id"    # Unique identifier for the user who is deploying the agent
-    account_id: "my-dev-cluster-account-id"  # Account/tenant identifier
+    user_id: "my-dev-cluster-user-id"        # SGP user UUID
+    account_id: "my-dev-cluster-account-id"  # Account/tenant ID the agent registers into
+```
+
+For a service-account identity (machine identity created via the IAM dashboard):
+```yaml
+auth:
+  principal:
+    service_account_id: "my-service-account-uuid"  # SGP service account UUID
+    account_id: "my-account-id"                    # Account where the SA has manager/admin role
 ```
 
 **Auth Principal Purpose:**
 
-- **User Identification**: Identifies the user/service account deploying the agent
-- **Deployment Authorization**: Controls who can deploy agents to specific environments
-- **Account/Tenant Isolation**: Associates deployments with specific accounts or tenants
-- **Audit Trail**: Tracks who deployed which agents and when
+- **Identity selection**: Tells the registration call who is acting — a user or a service account.
+- **Deployment Authorization**: Controls who can register agents on a given account.
+- **Account/Tenant Isolation**: Associates the registered agent with a specific account/tenant.
+- **Audit Trail**: Tracks who registered which agents and when.
 
 **Best Practices:**
 
-- **Unique per environment**: Use different user_id for dev vs prod deployment contexts
-- **Environment-specific**: `my-dev-cluster-user-id` vs `my-prod-cluster-user-id`
-- **Consistent format**: Use same naming pattern across your organization
-- **Proper identifiers**: user_id should identify the deploying user/service, account_id should identify the account_id that the agent should be created in.
+- **Pick one ID type**: never set both `user_id` and `service_account_id`. The platform rejects requests carrying both.
+- **For automated/non-interactive deploys**, prefer `service_account_id` — it's a long-lived machine identity that can outlive any individual user.
+- **Match the role on the target account**: whichever identity you reference must have `manager` or `admin` role on `account_id` for registration to succeed.
+- **Environment-specific**: Use different IDs for dev vs prod deployment contexts.
 
 #### Helm Overrides
 ```yaml

--- a/agentex/docs/docs/configuration.md
+++ b/agentex/docs/docs/configuration.md
@@ -309,16 +309,16 @@ For a human user identity:
 ```yaml
 auth:
   principal:
-    user_id: "my-dev-cluster-user-id"        # SGP user UUID
-    account_id: "my-dev-cluster-account-id"  # Account/tenant ID the agent registers into
+    user_id: "my-dev-cluster-user-id"        # Unique identifier for the user who is deploying the agent
+    account_id: "my-dev-cluster-account-id"  # Account/tenant identifier
 ```
 
-For a service-account identity (machine identity created via the IAM dashboard):
+For a service-account identity (a machine identity intended for automated/non-interactive deploys):
 ```yaml
 auth:
   principal:
-    service_account_id: "my-service-account-uuid"  # SGP service account UUID
-    account_id: "my-account-id"                    # Account where the SA has manager/admin role
+    service_account_id: "my-service-account-uuid"  # Unique identifier for the service account that is deploying the agent
+    account_id: "my-account-id"                    # Account/tenant identifier
 ```
 
 **Auth Principal Purpose:**
@@ -332,7 +332,7 @@ auth:
 
 - **Pick one ID type**: never set both `user_id` and `service_account_id`. The platform rejects requests carrying both.
 - **For automated/non-interactive deploys**, prefer `service_account_id` — it's a long-lived machine identity that can outlive any individual user.
-- **Match the role on the target account**: whichever identity you reference must have `manager` or `admin` role on `account_id` for registration to succeed.
+- **Match permissions on the target account**: whichever identity you reference must have permissions on `account_id` sufficient to register agents.
 - **Environment-specific**: Use different IDs for dev vs prod deployment contexts.
 
 #### Helm Overrides

--- a/agentex/src/api/authentication_cache.py
+++ b/agentex/src/api/authentication_cache.py
@@ -251,7 +251,15 @@ class AuthenticationCache:
                 context_dict = {"value": str(principal_context)}
 
             # Extract key fields that identify the principal
-            for key in ["user_id", "account_id", "agent_id", "id", "sub", "email"]:
+            for key in [
+                "user_id",
+                "service_account_id",
+                "account_id",
+                "agent_id",
+                "id",
+                "sub",
+                "email",
+            ]:
                 if key in context_dict:
                     principal_key_data[key] = context_dict[key]
 


### PR DESCRIPTION
## Summary

Adds `service_account_id` to the principal-identity field list in `_create_authorization_cache_key`.

Without this, two SA principals in the same account on the same resource would hash to the same authz cache key — one SA's cached permission decision could be served to another SA's request. With per-principal grants supported in `agentex_permissions`, that's a real correctness risk for SA flows.

Also documents the new `user_id` vs `service_account_id` mutual exclusion in `configuration.md`.

## Related PRs (ship together)

- This PR (auth cache key) — `scaleapi/scale-agentex#210`
- SGP backend — https://github.com/scaleapi/scaleapi/pull/141104
- agentex-auth — https://github.com/scaleapi/agentex/pull/333
- scale-agentex-python (SDK validator) — https://github.com/scaleapi/scale-agentex-python/pull/332

## Test Plan

- The code change is a 1-line addition to a static field list; correctness is obvious by inspection. The repo doesn't currently have unit-level tests for `AuthenticationCache` — adding one for this single line would establish a new convention for what's effectively a 1-character change.
- `ruff check` + `ruff format --check` clean.
- Local pre-commit hooks pass (TruffleHog, ruff, ruff-format).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a correctness bug in `_create_authorization_cache_key` where two service-account principals sharing the same `account_id`, `agent_id`, and other fields would produce an identical cache key, causing one SA's cached authorization decision to be served to a different SA's request. The fix adds `service_account_id` to the field-extraction list, making per-SA grants correctly isolated. The accompanying `configuration.md` update clearly documents the `user_id` / `service_account_id` mutual-exclusion contract.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, clearly correct addition with no regressions.

The code change is a single field added to an existing field-extraction list; logic is straightforward and directly addresses the described correctness bug. No new control flow, no data-loss risk, no security issues. All remaining observations are P2 at most.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/api/authentication_cache.py | Adds `service_account_id` to the principal field-extraction list in `_create_authorization_cache_key`; correctly fixes cache-key collision between distinct SA principals. |
| agentex/docs/docs/configuration.md | Documents the new `service_account_id` field and its mutual exclusion with `user_id`; adds a YAML example and updated best-practice bullets. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Authorization check request\nresource_type, resource_selector, operation, principal_context] --> B[_create_authorization_cache_key]
    B --> C{principal_context\npresent?}
    C -- No --> D[empty principal_key_data]
    C -- Yes --> E{has __dict__?}
    E -- Yes --> F[use __dict__]
    E -- No --> G{is dict?}
    G -- Yes --> H[use as-is]
    G -- No --> I[wrap as value string]
    F & H & I --> J[Extract fields:\nuser_id\nservice_account_id NEW\naccount_id\nagent_id\nid / sub / email]
    J --> K{any fields\nfound?}
    K -- Yes --> L[principal_key_data = extracted fields]
    K -- No --> M[principal_key_data = hash of full context]
    L & M & D --> N[cache_data dict\nresource_type + resource_selector\n+ operation + principal]
    N --> O[SHA-256 hash → authz: key]
    O --> P{cache hit?}
    P -- Yes --> Q[Return cached allow/deny]
    P -- No --> R[Run authorization check\nStore result in cache]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into akam/agentex-SA..."](https://github.com/scaleapi/scale-agentex/commit/d83c0624fb83dac81d66118cdf0330ceb1e32992) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29899773)</sub>

<!-- /greptile_comment -->