### PR TITLE
fix(streams): add sliding TTL to Redis stream keys

### DIFF
--- a/agentex/src/adapters/streams/adapter_redis.py
+++ b/agentex/src/adapters/streams/adapter_redis.py
@@ -54,14 +54,32 @@ class RedisStreamRepository(StreamRepository):
 
             logger.info(f"Publishing data to stream {topic}, data: {data_json}")
 
-            # Add to Redis stream with maxlen to prevent unbounded growth
+            # Add to Redis stream with maxlen to prevent unbounded growth.
+            # Pipeline XADD + EXPIRE in one round-trip so the stream key gets
+            # a sliding TTL — orphaned streams (no writes for TTL window) self-delete.
             await self.send_redis_connection_metrics()
-            message_id = await self.redis.xadd(
-                name=topic,
-                fields={"data": data_json},
-                maxlen=self.environment_variables.REDIS_STREAM_MAXLEN,
-                approximate=True,  # Use ~ for better performance (O(1) vs O(N))
-            )
+
+            ttl_seconds = self.environment_variables.REDIS_STREAM_TTL_SECONDS
+            maxlen = self.environment_variables.REDIS_STREAM_MAXLEN
+
+            if ttl_seconds > 0:
+                async with self.redis.pipeline(transaction=False) as pipe:
+                    pipe.xadd(
+                        name=topic,
+                        fields={"data": data_json},
+                        maxlen=maxlen,
+                        approximate=True,
+                    )
+                    pipe.expire(name=topic, time=ttl_seconds)
+                    results = await pipe.execute()
+                    message_id = results[0]
+            else:
+                message_id = await self.redis.xadd(
+                    name=topic,
+                    fields={"data": data_json},
+                    maxlen=maxlen,
+                    approximate=True,
+                )
             return message_id
         except Exception as e:
             logger.error(f"Error publishing data to Redis stream {topic}: {e}")

--- a/agentex/src/adapters/streams/adapter_redis.py
+++ b/agentex/src/adapters/streams/adapter_redis.py
@@ -72,6 +72,7 @@ class RedisStreamRepository(StreamRepository):
                     )
                     pipe.expire(name=topic, time=ttl_seconds)
                     results = await pipe.execute()
+                    # results[0] = xadd message ID, results[1] = expire bool
                     message_id = results[0]
             else:
                 message_id = await self.redis.xadd(

--- a/agentex/src/adapters/streams/adapter_redis.py
+++ b/agentex/src/adapters/streams/adapter_redis.py
@@ -71,9 +71,21 @@ class RedisStreamRepository(StreamRepository):
                         approximate=True,
                     )
                     pipe.expire(name=topic, time=ttl_seconds)
-                    results = await pipe.execute()
-                    # results[0] = xadd message ID, results[1] = expire bool
+                    # raise_on_error=False so an EXPIRE failure does not surface
+                    # to the caller after XADD already succeeded — that would
+                    # risk callers retrying and duplicating messages. A failed
+                    # TTL refresh is recoverable: MAXLEN still caps RAM and the
+                    # next write resets the clock.
+                    results = await pipe.execute(raise_on_error=False)
+                    # results[0] = xadd message ID (or Exception)
+                    # results[1] = expire bool (or Exception)
                     message_id = results[0]
+                    if isinstance(message_id, Exception):
+                        raise message_id
+                    if isinstance(results[1], Exception):
+                        logger.warning(
+                            f"Failed to refresh TTL on stream {topic}: {results[1]}"
+                        )
             else:
                 message_id = await self.redis.xadd(
                     name=topic,

--- a/agentex/src/config/environment_variables.py
+++ b/agentex/src/config/environment_variables.py
@@ -41,6 +41,7 @@ class EnvVarKeys(str, Enum):
     REDIS_CONNECTION_TIMEOUT = "REDIS_CONNECTION_TIMEOUT"
     REDIS_SOCKET_TIMEOUT = "REDIS_SOCKET_TIMEOUT"
     REDIS_STREAM_MAXLEN = "REDIS_STREAM_MAXLEN"
+    REDIS_STREAM_TTL_SECONDS = "REDIS_STREAM_TTL_SECONDS"
     IMAGE_PULL_SECRET_NAME = "IMAGE_PULL_SECRET_NAME"
     AGENTEX_AUTH_URL = "AGENTEX_AUTH_URL"
     ALLOWED_ORIGINS = "ALLOWED_ORIGINS"
@@ -93,6 +94,9 @@ class EnvironmentVariables(BaseModel):
     REDIS_SOCKET_TIMEOUT: int = 30  # Socket timeout in seconds
     REDIS_STREAM_MAXLEN: int = (
         10000  # Max entries per Redis stream to prevent unbounded growth
+    )
+    REDIS_STREAM_TTL_SECONDS: int = (
+        3600  # Sliding TTL on stream keys (seconds). 0 disables.
     )
     IMAGE_PULL_SECRET_NAME: str | None = None
     AGENTEX_AUTH_URL: str | None = None
@@ -156,6 +160,9 @@ class EnvironmentVariables(BaseModel):
             ),
             REDIS_STREAM_MAXLEN=int(
                 os.environ.get(EnvVarKeys.REDIS_STREAM_MAXLEN, "10000")
+            ),
+            REDIS_STREAM_TTL_SECONDS=int(
+                os.environ.get(EnvVarKeys.REDIS_STREAM_TTL_SECONDS, "3600")
             ),
             IMAGE_PULL_SECRET_NAME=os.environ.get(EnvVarKeys.IMAGE_PULL_SECRET_NAME),
             AGENTEX_AUTH_URL=os.environ.get(EnvVarKeys.AGENTEX_AUTH_URL),

--- a/agentex/tests/fixtures/repositories.py
+++ b/agentex/tests/fixtures/repositories.py
@@ -133,6 +133,7 @@ def create_redis_stream_repository(redis_client):
         def __init__(self, redis_url):
             self.REDIS_URL = redis_url
             self.REDIS_STREAM_MAXLEN = 10000  # Default from EnvironmentVariables
+            self.REDIS_STREAM_TTL_SECONDS = 3600  # Default from EnvironmentVariables
             self.ENVIRONMENT = "test"
 
     # Get the Redis URL from the client connection pool

--- a/agentex/tests/integration/fixtures/integration_client.py
+++ b/agentex/tests/integration/fixtures/integration_client.py
@@ -275,6 +275,7 @@ async def isolated_repositories(isolated_test_schema):
         def __init__(self, redis_url):
             self.REDIS_URL = redis_url
             self.REDIS_STREAM_MAXLEN = 10000  # Default from EnvironmentVariables
+            self.REDIS_STREAM_TTL_SECONDS = 3600  # Default from EnvironmentVariables
             self.ENVIRONMENT = "test"
 
     # Get Redis URL from client

--- a/agentex/tests/integration/test_redis_stream_ttl.py
+++ b/agentex/tests/integration/test_redis_stream_ttl.py
@@ -24,3 +24,20 @@ class TestRedisStreamTTL:
 
         # Cleanup
         await repo.redis.delete(topic)
+
+    async def test_send_data_skips_ttl_when_disabled(self, isolated_repositories):
+        """With REDIS_STREAM_TTL_SECONDS=0, no TTL is set on the stream key."""
+        repo = isolated_repositories["redis_stream_repository"]
+        repo.environment_variables.REDIS_STREAM_TTL_SECONDS = 0
+        topic = "test:stream:ttl:disabled"
+
+        try:
+            await repo.send_data(topic, {"hello": "world"})
+
+            ttl = await repo.redis.ttl(topic)
+            # -1 means key exists but has no TTL.
+            assert ttl == -1, f"Expected no TTL (-1), got {ttl}"
+        finally:
+            # Restore default + cleanup so other tests aren't affected.
+            repo.environment_variables.REDIS_STREAM_TTL_SECONDS = 3600
+            await repo.redis.delete(topic)

--- a/agentex/tests/integration/test_redis_stream_ttl.py
+++ b/agentex/tests/integration/test_redis_stream_ttl.py
@@ -41,3 +41,22 @@ class TestRedisStreamTTL:
             # Restore default + cleanup so other tests aren't affected.
             repo.environment_variables.REDIS_STREAM_TTL_SECONDS = 3600
             await repo.redis.delete(topic)
+
+    async def test_send_data_still_applies_maxlen(self, isolated_repositories):
+        """Stream length stays bounded near MAXLEN after many writes."""
+        repo = isolated_repositories["redis_stream_repository"]
+        # Tighten MAXLEN for this test so we can verify trimming without 10k writes.
+        repo.environment_variables.REDIS_STREAM_MAXLEN = 50
+        topic = "test:stream:ttl:maxlen"
+
+        try:
+            for i in range(200):
+                await repo.send_data(topic, {"i": i})
+
+            length = await repo.redis.xlen(topic)
+            # `approximate=True` (XADD ~) lets length exceed MAXLEN slightly,
+            # but should be in the same order of magnitude (well under 200).
+            assert length <= 100, f"Expected length <= 100 with MAXLEN=50, got {length}"
+        finally:
+            repo.environment_variables.REDIS_STREAM_MAXLEN = 10000
+            await repo.redis.delete(topic)

--- a/agentex/tests/integration/test_redis_stream_ttl.py
+++ b/agentex/tests/integration/test_redis_stream_ttl.py
@@ -15,12 +15,13 @@ class TestRedisStreamTTL:
 
         ttl = await repo.redis.ttl(topic)
         # ttl returns seconds remaining; -1 = no TTL, -2 = key missing.
-        # We expect it close to the configured 3600 (allow generous slack for test scheduling).
+        # 120s slack tolerates CI scheduling jitter (cold-starts, GC pauses)
+        # while still catching a regression where EXPIRE isn't called.
         assert ttl > 0, f"Expected positive TTL, got {ttl}"
         assert ttl <= 3600, f"Expected TTL <= 3600, got {ttl}"
         assert (
-            ttl >= 3590
-        ), f"Expected TTL >= 3590 (within 10s of configured), got {ttl}"
+            ttl >= 3480
+        ), f"Expected TTL >= 3480 (within 120s of configured), got {ttl}"
 
         # Cleanup
         await repo.redis.delete(topic)

--- a/agentex/tests/integration/test_redis_stream_ttl.py
+++ b/agentex/tests/integration/test_redis_stream_ttl.py
@@ -56,6 +56,7 @@ class TestRedisStreamTTL:
             length = await repo.redis.xlen(topic)
             # `approximate=True` (XADD ~) lets length exceed MAXLEN slightly,
             # but should be in the same order of magnitude (well under 200).
+            assert length >= 1, f"Expected at least 1 entry in stream, got {length}"
             assert length <= 100, f"Expected length <= 100 with MAXLEN=50, got {length}"
         finally:
             repo.environment_variables.REDIS_STREAM_MAXLEN = 10000

--- a/agentex/tests/integration/test_redis_stream_ttl.py
+++ b/agentex/tests/integration/test_redis_stream_ttl.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestRedisStreamTTL:
+    """Integration tests for the sliding TTL on Redis stream keys."""
+
+    async def test_send_data_sets_ttl_on_stream_key(self, isolated_repositories):
+        """After send_data, the stream key has a TTL approximately equal to REDIS_STREAM_TTL_SECONDS."""
+        repo = isolated_repositories["redis_stream_repository"]
+        topic = "test:stream:ttl:basic"
+
+        await repo.send_data(topic, {"hello": "world"})
+
+        ttl = await repo.redis.ttl(topic)
+        # ttl returns seconds remaining; -1 = no TTL, -2 = key missing.
+        # We expect it close to the configured 3600 (allow generous slack for test scheduling).
+        assert ttl > 0, f"Expected positive TTL, got {ttl}"
+        assert ttl <= 3600, f"Expected TTL <= 3600, got {ttl}"
+        assert (
+            ttl >= 3590
+        ), f"Expected TTL >= 3590 (within 10s of configured), got {ttl}"
+
+        # Cleanup
+        await repo.redis.delete(topic)


### PR DESCRIPTION
## Summary

- Adds env-var-configurable sliding TTL on per-task Redis stream keys via pipelined `XADD` + `EXPIRE`.
- Default `REDIS_STREAM_TTL_SECONDS=3600` (1h sliding window).
- Set `REDIS_STREAM_TTL_SECONDS=0` to disable (preserves pre-change behavior).

Fixes orphan stream accumulation when the SSE-disconnect cleanup path doesn't run (e.g., consumer never connects, backend crashes mid-task). Active streams stay alive indefinitely — every write refreshes the TTL.

## Test plan

- [x] `test_send_data_sets_ttl_on_stream_key` — TTL ~3600s set on key after `send_data`
- [x] `test_send_data_skips_ttl_when_disabled` — no TTL set when `REDIS_STREAM_TTL_SECONDS=0`
- [x] `test_send_data_still_applies_maxlen` — MAXLEN trimming still works
- [x] Full `make test` suite passes (389 passed locally)
- [ ] Operators with long-idle workloads can override the env var pre-deploy

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a configurable sliding TTL to Redis stream keys by pipelining `XADD` + `EXPIRE` in a single round-trip, defaulting to 3600 s and disabling cleanly at `REDIS_STREAM_TTL_SECONDS=0`. The implementation correctly handles pipeline errors with `raise_on_error=False` and per-result type checks, and is covered by focused integration tests.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no blocking issues; logic is correct, error handling is sound, and tests provide good coverage.

The previous P1 concern about raise_on_error has been fully addressed. Pipeline results are inspected individually, XADD failures propagate correctly, and EXPIRE failures degrade gracefully. The TTL-disabled path preserves the original behaviour exactly. No new P0 or P1 findings.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/adapters/streams/adapter_redis.py | Core change: branches on TTL env var to use a non-transactional pipeline (XADD + EXPIRE) with per-result error handling; XADD failures are re-raised, EXPIRE failures are logged as warnings — logic is sound and well-commented. |
| agentex/src/config/environment_variables.py | Adds REDIS_STREAM_TTL_SECONDS enum key, model field (default 3600), and from_env parsing — consistent with existing pattern for REDIS_STREAM_MAXLEN. |
| agentex/tests/integration/test_redis_stream_ttl.py | New integration test file covering TTL set, TTL disabled, and MAXLEN still applied; uses try/finally for cleanup and restoring mutated env vars. |
| agentex/tests/fixtures/repositories.py | Adds REDIS_STREAM_TTL_SECONDS=3600 to the stub env class — mirrors the integration_client fixture change. |
| agentex/tests/integration/fixtures/integration_client.py | Adds REDIS_STREAM_TTL_SECONDS=3600 to the isolated test stub — consistent with the unit test fixture update. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant RedisStreamRepository
    participant RedisPipeline
    participant Redis

    Caller->>RedisStreamRepository: send_data(topic, data)
    RedisStreamRepository->>RedisStreamRepository: check REDIS_STREAM_TTL_SECONDS

    alt TTL > 0
        RedisStreamRepository->>RedisPipeline: pipeline(transaction=False)
        RedisPipeline->>RedisPipeline: queue XADD(topic, data, maxlen)
        RedisPipeline->>RedisPipeline: queue EXPIRE(topic, ttl_seconds)
        RedisPipeline->>Redis: execute(raise_on_error=False)
        Redis-->>RedisPipeline: [message_id | Exception, True/False | Exception]
        RedisPipeline-->>RedisStreamRepository: results[]
        alt results[0] is Exception
            RedisStreamRepository->>Caller: raise Exception
        else results[1] is Exception
            RedisStreamRepository->>RedisStreamRepository: logger.warning(TTL refresh failed)
            RedisStreamRepository->>Caller: return message_id
        else
            RedisStreamRepository->>Caller: return message_id
        end
    else TTL == 0 (disabled)
        RedisStreamRepository->>Redis: xadd(topic, data, maxlen)
        Redis-->>RedisStreamRepository: message_id
        RedisStreamRepository->>Caller: return message_id
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(streams): address greptile review fi..."](https://github.com/scaleapi/scale-agentex/commit/1c1bd78cba5e7809f890e3e9b15ed0a52fb8e3d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30417508)</sub>

<!-- /greptile_comment -->