### PR TITLE
fix: use public Chainguard bases for Docker images

### DIFF
--- a/agentex-ui/Dockerfile
+++ b/agentex-ui/Dockerfile
@@ -1,13 +1,16 @@
 # Build stage — install build deps, build the Next.js app
-FROM node:20-trixie-slim AS builder
+# Public versioned Chainguard language images require org access; install Node 20 from Wolfi instead.
+FROM cgr.dev/chainguard/wolfi-base:latest AS builder
 ARG SOURCE_DIR=agentex-ui
+ENTRYPOINT []
 
 # Install system dependencies for native modules (node-gyp)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 \
-    make \
-    g++ \
-    && rm -rf /var/lib/apt/lists/*
+USER root
+RUN apk add --no-cache \
+    build-base \
+    nodejs-20 \
+    npm \
+    python-3.12
 
 WORKDIR /app
 
@@ -38,8 +41,12 @@ RUN npm run build
 RUN npm prune --production
 
 # Production stage — clean image without build tools
-FROM node:20-trixie-slim AS production
+# Public versioned Chainguard language images require org access; install Node 20 from Wolfi instead.
+FROM cgr.dev/chainguard/wolfi-base:latest AS production
 ENTRYPOINT []
+
+USER root
+RUN apk add --no-cache nodejs-20
 
 WORKDIR /app
 
@@ -48,26 +55,15 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-# Remove npm and its bundled vulnerable deps (tar, glob, minimatch, cross-spawn)
-# npm is not needed at runtime — we run next start directly via node
-RUN npm cache clean --force && \
-    rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
-
 # Copy built application from builder (no build tools, no dev deps)
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/next.config.ts ./
-COPY --from=builder /app/LICENSE ./LICENSE
+COPY --from=builder --chown=65532:65532 /app/.next ./.next
+COPY --from=builder --chown=65532:65532 /app/node_modules ./node_modules
+COPY --from=builder --chown=65532:65532 /app/package.json ./
+COPY --from=builder --chown=65532:65532 /app/public ./public
+COPY --from=builder --chown=65532:65532 /app/next.config.ts ./
+COPY --from=builder --chown=65532:65532 /app/LICENSE ./LICENSE
 
-# Create nonroot user and set ownership
-RUN groupadd --system --gid 65532 nonroot && \
-    useradd --system --uid 65532 --gid nonroot nonroot && \
-    chown -R nonroot:nonroot /app
-
-# Switch to non-root user
-USER 65532
+USER nonroot
 
 EXPOSE 3000
 

--- a/agentex-ui/Dockerfile
+++ b/agentex-ui/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage — install build deps, build the Next.js app
 # Public versioned Chainguard language images require org access; install Node 20 from Wolfi instead.
-FROM cgr.dev/chainguard/wolfi-base:latest AS builder
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31 AS builder
 ARG SOURCE_DIR=agentex-ui
 ENTRYPOINT []
 
@@ -42,7 +42,7 @@ RUN npm prune --production
 
 # Production stage — clean image without build tools
 # Public versioned Chainguard language images require org access; install Node 20 from Wolfi instead.
-FROM cgr.dev/chainguard/wolfi-base:latest AS production
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31 AS production
 ENTRYPOINT []
 
 USER root

--- a/agentex/Dockerfile
+++ b/agentex/Dockerfile
@@ -1,18 +1,21 @@
-FROM python:3.12-slim-trixie AS base
+# Public versioned Chainguard language images require org access; install Python 3.12 from Wolfi instead.
+FROM cgr.dev/chainguard/wolfi-base:latest AS base
 ARG SOURCE_DIR=agentex
 
 # Install uv package manager
 COPY --from=ghcr.io/astral-sh/uv:0.7.3 /uv /uvx /bin/
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+USER root
+RUN apk add --no-cache \
     bash \
     curl \
     postgresql-client \
-    build-essential \
-    libpq-dev \
+    build-base \
+    libpq \
     gcc \
-    && rm -rf /var/lib/apt/lists/*
+    python-3.12-dev \
+    py3.12-pip
 
 WORKDIR /app
 
@@ -22,7 +25,7 @@ COPY uv.lock /app/uv.lock
 COPY ${SOURCE_DIR}/pyproject.toml ${SOURCE_DIR}/README.md ./${SOURCE_DIR}/
 
 # Install core dependencies to system Python (Debian installs to /usr/local)
-ENV UV_PROJECT_ENVIRONMENT=/usr/local
+ENV UV_PROJECT_ENVIRONMENT=/usr
 RUN uv sync --frozen --no-dev --package agentex-backend
 
 # Development stage (for docker-compose)
@@ -50,28 +53,30 @@ COPY ${SOURCE_DIR}/src/ src/
 RUN cd docs && mkdocs build
 
 # Production stage
-FROM python:3.12-slim-trixie AS production
+# Public versioned Chainguard language images require org access; install Python 3.12 from Wolfi instead.
+FROM cgr.dev/chainguard/wolfi-base:latest AS production
 ENTRYPOINT []
 ARG INCLUDE_DOCS=false
 ARG SOURCE_DIR=agentex
 
 # Install runtime system dependencies only (no build tools)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+USER root
+RUN apk add --no-cache \
     postgresql-client \
-    libpq5 \
-    && rm -rf /var/lib/apt/lists/*
+    libpq \
+    python-3.12
 
 WORKDIR /app
 
-# Copy Python packages and console_scripts from base stage (Debian installs to /usr/local)
-COPY --from=base /usr/local/lib/python3.12 /usr/local/lib/python3.12
-COPY --from=base /usr/local/bin/uvicorn /usr/local/bin/uvicorn
-COPY --from=base /usr/local/bin/ddtrace-run /usr/local/bin/ddtrace-run
-COPY --from=base /usr/local/bin/alembic /usr/local/bin/alembic
+# Copy Python packages and console_scripts from base stage.
+COPY --from=base /usr/lib/python3.12 /usr/lib/python3.12
+COPY --from=base /usr/bin/uvicorn /usr/bin/uvicorn
+COPY --from=base /usr/bin/ddtrace-run /usr/bin/ddtrace-run
+COPY --from=base /usr/bin/alembic /usr/bin/alembic
 
 # Remove non-functional Cargo.lock metadata from temporalio wheel
 # (quinn-proto is a transitive Rust dep not used at runtime — temporalio uses gRPC/TCP, not QUIC)
-RUN rm -f /usr/local/lib/python3.12/site-packages/temporalio/bridge/Cargo.lock
+RUN rm -f /usr/lib/python3.12/site-packages/temporalio/bridge/Cargo.lock
 
 # Copy application files
 COPY ${SOURCE_DIR}/pyproject.toml ${SOURCE_DIR}/README.md ./
@@ -83,8 +88,8 @@ COPY LICENSE /app/LICENSE
 # Conditionally copy docs from builder stage
 COPY --from=docs-builder /app/docs/site /app/docs/site
 
-# Create nonroot user and set ownership
-RUN adduser --disabled-password --gecos '' --uid 65532 nonroot && chown -R nonroot:nonroot /app
+# Set ownership to Chainguard's default nonroot user.
+RUN chown -R 65532:65532 /app
 
 USER nonroot
 

--- a/agentex/Dockerfile
+++ b/agentex/Dockerfile
@@ -1,5 +1,5 @@
 # Public versioned Chainguard language images require org access; install Python 3.12 from Wolfi instead.
-FROM cgr.dev/chainguard/wolfi-base:latest AS base
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31 AS base
 ARG SOURCE_DIR=agentex
 
 # Install uv package manager
@@ -13,7 +13,6 @@ RUN apk add --no-cache \
     postgresql-client \
     build-base \
     libpq \
-    gcc \
     python-3.12-dev \
     py3.12-pip
 
@@ -54,7 +53,7 @@ RUN cd docs && mkdocs build
 
 # Production stage
 # Public versioned Chainguard language images require org access; install Python 3.12 from Wolfi instead.
-FROM cgr.dev/chainguard/wolfi-base:latest AS production
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31 AS production
 ENTRYPOINT []
 ARG INCLUDE_DOCS=false
 ARG SOURCE_DIR=agentex


### PR DESCRIPTION
## Summary

Switch the public AgentEx Docker images from Debian slim bases to public Chainguard/Wolfi bases while preserving the current runtime language constraints:

- `agentex/Dockerfile` now uses `cgr.dev/chainguard/wolfi-base:latest` and installs `python-3.12` / `python-3.12-dev` from Wolfi packages.
- `agentex-ui/Dockerfile` now uses `cgr.dev/chainguard/wolfi-base:latest` and installs `nodejs-20` from Wolfi packages.
- Runtime images continue to run as Chainguard's default `nonroot` user.
- UI runtime image installs only `nodejs-20`; npm remains absent from the final image.

I used `wolfi-base` instead of `cgr.dev/chainguard/python:3.12` or `cgr.dev/chainguard/node:20` because the public Chainguard registry only exposes the moving `latest` / `latest-dev` language tags without org access, and those currently resolve to Python 3.14 and Node 25. Installing the versioned Wolfi packages lets the public repo stay on Python 3.12 and Node 20 without depending on private Chainguard org images.

## Validation

- `DOCKER_BUILDKIT=1 docker build --pull -f agentex/Dockerfile -t scale-agentex-public-chainguard-backend:test .`
- `DOCKER_BUILDKIT=1 docker build --pull -f agentex-ui/Dockerfile -t scale-agentex-public-chainguard-ui:test .`
- Backend runtime smoke check:
  - runs as UID/GID `65532(nonroot)`
  - `python --version` reports `Python 3.12.13`
  - `ddtrace-run` and `uvicorn` are present
  - `python -c "import src.api.app"` succeeds
- UI runtime smoke check:
  - runs as UID/GID `65532(nonroot)`
  - `node --version` reports `v20.20.2`
  - npm is not present in the runtime image
  - `node_modules/.bin/next` is present
- `trivy image --quiet --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 scale-agentex-public-chainguard-backend:test`
- `trivy image --quiet --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 scale-agentex-public-chainguard-ui:test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates both Docker images (`agentex` backend and `agentex-ui` frontend) from Debian slim bases to pinned Chainguard wolfi-base images, installing versioned Wolfi packages (`python-3.12`, `nodejs-20`) to stay on specific language versions without requiring private Chainguard org access. Multi-stage structure, nonroot runtime user (UID 65532), and version pins are all preserved correctly.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — base image pins are digest-locked, nonroot runtime is preserved, and build smoke tests passed per PR description.

Only P2 style findings (stale comment, unnecessary py3.12-pip); no logic errors, security regressions, or broken runtime paths.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/Dockerfile | Switches Python base from python:3.12-slim-trixie to pinned Chainguard wolfi-base, installs Python 3.12 via Wolfi packages, adjusts UV_PROJECT_ENVIRONMENT from /usr/local to /usr, and updates all binary/library copy paths accordingly. Minor stale comment and unnecessary py3.12-pip package. |
| agentex-ui/Dockerfile | Switches Node.js base from node:20-trixie-slim to pinned Chainguard wolfi-base, installs nodejs-20 and npm via Wolfi packages in builder, installs only nodejs-20 in production (npm absent from runtime), and replaces manual nonroot user creation with chown to Chainguard's pre-existing 65532:65532 nonroot user. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    WB["cgr.dev/chainguard/wolfi-base:latest\n@sha256:3258be47…"]

    subgraph agentex/Dockerfile
        B1["base stage\napk: bash, curl, postgresql-client,\nbuild-base, libpq, python-3.12-dev, py3.12-pip\nuv sync (UV_PROJECT_ENVIRONMENT=/usr)"]
        D1["dev stage\nuv sync --group dev"]
        DB1["docs-builder stage\nuv sync --group docs\nmkdocs build"]
        P1["production stage\napk: postgresql-client, libpq, python-3.12\nCOPY /usr/lib/python3.12 from base\nCOPY uvicorn, ddtrace-run, alembic from base\nUSER nonroot (65532)"]
    end

    subgraph agentex-ui/Dockerfile
        B2["builder stage\napk: build-base, nodejs-20, npm, python-3.12\nnpm ci && npm run build\nnpm prune --production"]
        P2["production stage\napk: nodejs-20\nCOPY --chown=65532:65532 from builder\nUSER nonroot (65532)"]
    end

    WB --> B1
    WB --> P1
    B1 --> D1
    B1 --> DB1
    B1 -->|"/usr/lib/python3.12\nuvicorn, ddtrace-run, alembic"| P1
    DB1 -->|"docs/site"| P1

    WB --> B2
    WB --> P2
    B2 -->|".next, node_modules,\npackage.json, public,\nnext.config.ts"| P2
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2FDockerfile%3A26-27%0A**Stale%20comment%20references%20Debian**%0A%0AThe%20parenthetical%20%60%28Debian%20installs%20to%20%2Fusr%2Flocal%29%60%20on%20the%20comment%20is%20a%20leftover%20from%20the%20old%20base%20image.%20On%20Wolfi%2C%20the%20install%20prefix%20is%20%60%2Fusr%60%2C%20which%20is%20what%20%60UV_PROJECT_ENVIRONMENT%60%20is%20now%20set%20to.%20The%20comment%20no%20longer%20matches%20the%20runtime%20and%20will%20confuse%20future%20readers.%0A%0A%60%60%60suggestion%0A%23%20Install%20core%20dependencies%20to%20system%20Python%20%28Wolfi%20installs%20to%20%2Fusr%29%0AENV%20UV_PROJECT_ENVIRONMENT%3D%2Fusr%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2FDockerfile%3A10-17%0A**%60py3.12-pip%60%20is%20unnecessary%20when%20using%20uv**%0A%0A%60uv%20sync%60%20bundles%20its%20own%20pip-compatible%20resolver%20and%20does%20not%20rely%20on%20the%20system%20%60pip%60%20package.%20Installing%20%60py3.12-pip%60%20adds%20a%20package%20to%20the%20build%20stage%20that%20serves%20no%20purpose%20here%2C%20increasing%20layer%20size%20and%20the%20attack%20surface%20for%20that%20stage.%20If%20pip%20is%20needed%20for%20any%20explicit%20%60pip%20install%60%20calls%20elsewhere%20in%20the%20image%20build%2C%20it%20should%20be%20kept%20%E2%80%94%20but%20it%20appears%20unused.%0A%0A%60%60%60suggestion%0ARUN%20apk%20add%20--no-cache%20%5C%0A%20%20%20%20bash%20%5C%0A%20%20%20%20curl%20%5C%0A%20%20%20%20postgresql-client%20%5C%0A%20%20%20%20build-base%20%5C%0A%20%20%20%20libpq%20%5C%0A%20%20%20%20python-3.12-dev%0A%60%60%60%0A%0A&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2FDockerfile%3A26-27%0A**Stale%20comment%20references%20Debian**%0A%0AThe%20parenthetical%20%60%28Debian%20installs%20to%20%2Fusr%2Flocal%29%60%20on%20the%20comment%20is%20a%20leftover%20from%20the%20old%20base%20image.%20On%20Wolfi%2C%20the%20install%20prefix%20is%20%60%2Fusr%60%2C%20which%20is%20what%20%60UV_PROJECT_ENVIRONMENT%60%20is%20now%20set%20to.%20The%20comment%20no%20longer%20matches%20the%20runtime%20and%20will%20confuse%20future%20readers.%0A%0A%60%60%60suggestion%0A%23%20Install%20core%20dependencies%20to%20system%20Python%20%28Wolfi%20installs%20to%20%2Fusr%29%0AENV%20UV_PROJECT_ENVIRONMENT%3D%2Fusr%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2FDockerfile%3A10-17%0A**%60py3.12-pip%60%20is%20unnecessary%20when%20using%20uv**%0A%0A%60uv%20sync%60%20bundles%20its%20own%20pip-compatible%20resolver%20and%20does%20not%20rely%20on%20the%20system%20%60pip%60%20package.%20Installing%20%60py3.12-pip%60%20adds%20a%20package%20to%20the%20build%20stage%20that%20serves%20no%20purpose%20here%2C%20increasing%20layer%20size%20and%20the%20attack%20surface%20for%20that%20stage.%20If%20pip%20is%20needed%20for%20any%20explicit%20%60pip%20install%60%20calls%20elsewhere%20in%20the%20image%20build%2C%20it%20should%20be%20kept%20%E2%80%94%20but%20it%20appears%20unused.%0A%0A%60%60%60suggestion%0ARUN%20apk%20add%20--no-cache%20%5C%0A%20%20%20%20bash%20%5C%0A%20%20%20%20curl%20%5C%0A%20%20%20%20postgresql-client%20%5C%0A%20%20%20%20build-base%20%5C%0A%20%20%20%20libpq%20%5C%0A%20%20%20%20python-3.12-dev%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=216&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22sec%2Fuse-public-chainguard-images%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22sec%2Fuse-public-chainguard-images%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2FDockerfile%3A26-27%0A**Stale%20comment%20references%20Debian**%0A%0AThe%20parenthetical%20%60%28Debian%20installs%20to%20%2Fusr%2Flocal%29%60%20on%20the%20comment%20is%20a%20leftover%20from%20the%20old%20base%20image.%20On%20Wolfi%2C%20the%20install%20prefix%20is%20%60%2Fusr%60%2C%20which%20is%20what%20%60UV_PROJECT_ENVIRONMENT%60%20is%20now%20set%20to.%20The%20comment%20no%20longer%20matches%20the%20runtime%20and%20will%20confuse%20future%20readers.%0A%0A%60%60%60suggestion%0A%23%20Install%20core%20dependencies%20to%20system%20Python%20%28Wolfi%20installs%20to%20%2Fusr%29%0AENV%20UV_PROJECT_ENVIRONMENT%3D%2Fusr%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2FDockerfile%3A10-17%0A**%60py3.12-pip%60%20is%20unnecessary%20when%20using%20uv**%0A%0A%60uv%20sync%60%20bundles%20its%20own%20pip-compatible%20resolver%20and%20does%20not%20rely%20on%20the%20system%20%60pip%60%20package.%20Installing%20%60py3.12-pip%60%20adds%20a%20package%20to%20the%20build%20stage%20that%20serves%20no%20purpose%20here%2C%20increasing%20layer%20size%20and%20the%20attack%20surface%20for%20that%20stage.%20If%20pip%20is%20needed%20for%20any%20explicit%20%60pip%20install%60%20calls%20elsewhere%20in%20the%20image%20build%2C%20it%20should%20be%20kept%20%E2%80%94%20but%20it%20appears%20unused.%0A%0A%60%60%60suggestion%0ARUN%20apk%20add%20--no-cache%20%5C%0A%20%20%20%20bash%20%5C%0A%20%20%20%20curl%20%5C%0A%20%20%20%20postgresql-client%20%5C%0A%20%20%20%20build-base%20%5C%0A%20%20%20%20libpq%20%5C%0A%20%20%20%20python-3.12-dev%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
agentex/Dockerfile:26-27
**Stale comment references Debian**

The parenthetical `(Debian installs to /usr/local)` on the comment is a leftover from the old base image. On Wolfi, the install prefix is `/usr`, which is what `UV_PROJECT_ENVIRONMENT` is now set to. The comment no longer matches the runtime and will confuse future readers.

```suggestion
# Install core dependencies to system Python (Wolfi installs to /usr)
ENV UV_PROJECT_ENVIRONMENT=/usr
```

### Issue 2 of 2
agentex/Dockerfile:10-17
**`py3.12-pip` is unnecessary when using uv**

`uv sync` bundles its own pip-compatible resolver and does not rely on the system `pip` package. Installing `py3.12-pip` adds a package to the build stage that serves no purpose here, increasing layer size and the attack surface for that stage. If pip is needed for any explicit `pip install` calls elsewhere in the image build, it should be kept — but it appears unused.

```suggestion
RUN apk add --no-cache \
    bash \
    curl \
    postgresql-client \
    build-base \
    libpq \
    python-3.12-dev
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address Dockerfile review feedback"](https://github.com/scaleapi/scale-agentex/commit/9850f3412ca1a16ee3b665c4ec358ce49e12ebd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30470819)</sub>

<!-- /greptile_comment -->