### PR TITLE
fix(agentex-ui): chat UI fixes: overflow, padding, message order

### DIFF
--- a/agentex-ui/components/primary-content/chat-view.tsx
+++ b/agentex-ui/components/primary-content/chat-view.tsx
@@ -49,7 +49,7 @@ export function ChatView({
       key="chat-view"
       layout
       ref={scrollContainerRef}
-      className="relative flex-1 flex-col overflow-y-auto"
+      className="relative flex-1 flex-col overflow-x-hidden overflow-y-auto"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.25, ease: 'easeInOut' }}

--- a/agentex-ui/components/task-messages/task-message-scroll-container.tsx
+++ b/agentex-ui/components/task-messages/task-message-scroll-container.tsx
@@ -17,7 +17,7 @@ const TaskMessageScrollContainer = forwardRef<
   return (
     <div
       ref={ref}
-      className={cn('flex w-full flex-col gap-4 px-4 pt-4', className)}
+      className={cn('flex w-full min-w-0 flex-col gap-4 px-4 pt-4', className)}
       style={
         isLastPair && containerHeight > 0
           ? {

--- a/agentex-ui/components/task-messages/task-message-text-content.tsx
+++ b/agentex-ui/components/task-messages/task-message-text-content.tsx
@@ -10,8 +10,8 @@ import type { TextContent } from 'agentex/resources';
 const variants = cva('', {
   variants: {
     author: {
-      user: 'rounded-md shadow-sm bg-muted text-muted-foreground ml-auto w-fit max-w-[80%] p-4',
-      agent: '',
+      user: 'rounded-md shadow-sm bg-muted text-muted-foreground ml-auto w-fit max-w-[80%] p-4 overflow-hidden [overflow-wrap:anywhere]',
+      agent: 'min-w-0 [overflow-wrap:anywhere]',
     },
   },
 });

--- a/agentex-ui/components/task-messages/task-messages.tsx
+++ b/agentex-ui/components/task-messages/task-messages.tsx
@@ -164,8 +164,8 @@ function TaskMessagesImpl({
       lastPair.agentMessages[lastPair.agentMessages.length - 1]!;
     const lastType = lastAgentMessage.content.type;
 
-    // Already have text streaming or complete — not "thinking"
-    if (lastType === 'text') return false;
+    // Already have a terminal response (text or data) — not "thinking"
+    if (lastType === 'text' || lastType === 'data') return false;
 
     // Tool or reasoning still in progress — show their own indicator, not "Thinking..."
     if (lastAgentMessage.streaming_status === 'IN_PROGRESS') return false;

--- a/agentex-ui/components/task-messages/task-messages.tsx
+++ b/agentex-ui/components/task-messages/task-messages.tsx
@@ -327,32 +327,35 @@ function TaskMessagesImpl({
           >
             <AnimatePresence>
               {pair.userMessage && renderMessage(pair.userMessage)}
-              {pair.agentMessages.map(agentMessage => (
-                <Fragment key={agentMessage.id}>
-                  <div className="group/feedback">
-                    {renderMessage(agentMessage)}
-                    {sgpAppURL &&
-                      agentMessage.id &&
-                      agentMessage.content.type === 'text' &&
-                      agentMessage.content.author === 'agent' &&
-                      agentMessage.streaming_status !== 'IN_PROGRESS' && (
-                        <MessageFeedback
-                          messageId={agentMessage.id}
-                          taskId={taskId}
-                          agentMessageContent={agentMessage.content.content}
-                          userMessageContent={
-                            pair.userMessage?.content.type === 'text'
-                              ? pair.userMessage.content.content
-                              : ''
-                          }
-                          agentName={agent?.name}
-                          agentId={agent?.id}
-                          agentAcpType={agent?.acp_type}
-                        />
-                      )}
-                  </div>
-                </Fragment>
-              ))}
+              {pair.agentMessages.map(agentMessage => {
+                if (agentMessage.content.type === 'tool_response') return null;
+                return (
+                  <Fragment key={agentMessage.id}>
+                    <div className="group/feedback">
+                      {renderMessage(agentMessage)}
+                      {sgpAppURL &&
+                        agentMessage.id &&
+                        agentMessage.content.type === 'text' &&
+                        agentMessage.content.author === 'agent' &&
+                        agentMessage.streaming_status !== 'IN_PROGRESS' && (
+                          <MessageFeedback
+                            messageId={agentMessage.id}
+                            taskId={taskId}
+                            agentMessageContent={agentMessage.content.content}
+                            userMessageContent={
+                              pair.userMessage?.content.type === 'text'
+                                ? pair.userMessage.content.content
+                                : ''
+                            }
+                            agentName={agent?.name}
+                            agentId={agent?.id}
+                            agentAcpType={agent?.acp_type}
+                          />
+                        )}
+                    </div>
+                  </Fragment>
+                );
+              })}
             </AnimatePresence>
             <AnimatePresence>
               {shouldShowThinking && (

--- a/agentex-ui/hooks/use-task-messages.ts
+++ b/agentex-ui/hooks/use-task-messages.ts
@@ -167,19 +167,19 @@ export function useSendMessage({
           // Refetch spans now that the agent has finished processing
           queryClient.invalidateQueries({ queryKey: ['spans', taskId] });
 
-          // Refetch just the newest page and update in place
-          const latestPage = await fetchMessagesPage(agentexClient, taskId, 1);
-
-          queryClient.setQueryData<InfiniteData<TaskMessage[]>>(queryKey, old =>
-            updateFirstPage(old, () => latestPage)
-          );
+          // Refetch all loaded pages so the cache stays consistent when the
+          // user has scrolled up and loaded older pages — refetching only
+          // page 1 leaves a stale gap at the page boundary as the thread grows.
+          await queryClient.invalidateQueries({ queryKey });
 
           queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
             deltaAccumulator: null,
             rpcStatus: 'success',
           });
 
-          return { messages: latestPage };
+          const latestData =
+            queryClient.getQueryData<InfiniteData<TaskMessage[]>>(queryKey);
+          return { messages: latestData?.pages[0] ?? [] };
         }
 
         case 'sync': {
@@ -255,19 +255,19 @@ export function useSendMessage({
             }
           }
 
-          // Final reconciliation: refetch page 1
-          const latestPage = await fetchMessagesPage(agentexClient, taskId, 1);
-
-          queryClient.setQueryData<InfiniteData<TaskMessage[]>>(queryKey, old =>
-            updateFirstPage(old, () => latestPage)
-          );
+          // Final reconciliation: refetch all loaded pages so the cache stays
+          // consistent when older pages have been loaded — refetching only
+          // page 1 leaves a stale gap at the page boundary as the thread grows.
+          await queryClient.invalidateQueries({ queryKey });
 
           queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
             deltaAccumulator: null,
             rpcStatus: 'success',
           });
 
-          return { messages: latestPage };
+          const latestData =
+            queryClient.getQueryData<InfiniteData<TaskMessage[]>>(queryKey);
+          return { messages: latestData?.pages[0] ?? [] };
         }
 
         default: {

--- a/agentex-ui/hooks/use-task-messages.ts
+++ b/agentex-ui/hooks/use-task-messages.ts
@@ -170,7 +170,9 @@ export function useSendMessage({
           // Refetch all loaded pages so the cache stays consistent when the
           // user has scrolled up and loaded older pages — refetching only
           // page 1 leaves a stale gap at the page boundary as the thread grows.
-          await queryClient.invalidateQueries({ queryKey });
+          // Use refetchQueries (not invalidateQueries) so the fetch runs even
+          // when there are no active observers (e.g. component unmounted mid-RPC).
+          await queryClient.refetchQueries({ queryKey });
 
           queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
             deltaAccumulator: null,
@@ -258,7 +260,9 @@ export function useSendMessage({
           // Final reconciliation: refetch all loaded pages so the cache stays
           // consistent when older pages have been loaded — refetching only
           // page 1 leaves a stale gap at the page boundary as the thread grows.
-          await queryClient.invalidateQueries({ queryKey });
+          // Use refetchQueries (not invalidateQueries) so the fetch runs even
+          // when there are no active observers (e.g. component unmounted mid-stream).
+          await queryClient.refetchQueries({ queryKey });
 
           queryClient.setQueryData<TaskMessagesMetadata>(metaKey, {
             deltaAccumulator: null,

--- a/agentex-ui/lib/task-utils.ts
+++ b/agentex-ui/lib/task-utils.ts
@@ -3,6 +3,11 @@ import type { TaskListResponse } from 'agentex/resources';
 export function createTaskName(
   task: TaskListResponse.TaskListResponseItem
 ): string {
+  const displayName = task?.task_metadata?.display_name;
+  if (typeof displayName === 'string' && displayName) {
+    return displayName;
+  }
+
   if (
     task?.params?.description &&
     typeof task.params.description === 'string'


### PR DESCRIPTION
## Summary
- Fix overflow and padding issues in the chat view (chat-view, scroll container, text content, task-messages)
- Preserve message order in long-running threads via updates to `use-task-messages` and `task-messages` rendering

## Test plan
- [ ] Open a chat task and verify content does not overflow the container
- [ ] Verify padding around messages renders correctly across message types
- [ ] Run a long-running task that streams many messages and confirm message order is preserved (no reordering on refetch/reconnect)
- [ ] Smoke test scrolling behavior (auto-scroll on new messages, manual scroll retained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes overflow and padding issues in the chat view through a set of targeted CSS additions (`overflow-x-hidden`, `min-w-0`, `[overflow-wrap:anywhere]`), and improves message ordering by switching from a single-page refetch to `refetchQueries` that refreshes all loaded pages after an RPC completes. It also adds `data` as a terminal content type for the "Thinking…" indicator, filters `tool_response` messages from the render loop to avoid empty DOM wrappers, and surfaces `task_metadata.display_name` as the preferred task name.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all findings are P2 style nits with no functional impact.

No P0 or P1 issues found. The only finding is a stale inline comment in task-messages.tsx that lists `data` as a "still thinking" case after the guard was updated to treat it as terminal. All CSS, query, and rendering changes look correct.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex-ui/components/primary-content/chat-view.tsx | Adds `overflow-x-hidden` to the chat container to prevent horizontal overflow. |
| agentex-ui/components/task-messages/task-message-scroll-container.tsx | Adds `min-w-0` to prevent the flex child from overflowing its parent. |
| agentex-ui/components/task-messages/task-message-text-content.tsx | Adds `overflow-hidden [overflow-wrap:anywhere]` for user bubbles and `min-w-0 [overflow-wrap:anywhere]` for agent messages to handle long unbreakable strings. |
| agentex-ui/components/task-messages/task-messages.tsx | Adds `data` as a terminal type for the thinking indicator; adds an early-return filter for `tool_response` messages in the render loop to avoid empty DOM wrappers; stale comment at line 178 still lists `data` as a "thinking" case. |
| agentex-ui/hooks/use-task-messages.ts | Switches from single-page fetch+setQueryData to `refetchQueries` to refresh all loaded pages after an RPC completes, addressing the stale-data gap at page boundaries; reads back `pages[0]` for the mutation return value. |
| agentex-ui/lib/task-utils.ts | Adds priority lookup of `task_metadata.display_name` before falling back to `params.description` for task naming. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User sends message] --> B{agent.acp_type?}
    B -->|async / agentic| C[agentRPCNonStreaming]
    B -->|sync| D[agentRPCWithStreaming stream loop]
    C --> E[invalidateQueries spans]
    D --> F[Write streaming state to page 1 on each event]
    F --> G[stream done event]
    G --> E
    E --> H[refetchQueries ALL loaded pages]
    H --> I[getQueryData → pages 0]
    I --> J[return messages to mutation caller]
    J --> K[TaskMessages renders pairs]
    K --> L{agentMessage.content.type?}
    L -->|tool_response| M[return null — skip wrapper]
    L -->|tool_request| N[TaskMessageToolPair with response lookup]
    L -->|text / data| O[Render content — terminal, hide Thinking…]
    L -->|reasoning| P[TaskMessageReasoning]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex-ui%2Fcomponents%2Ftask-messages%2Ftask-messages.tsx%3A178-180%0A**Stale%20comment%20still%20lists%20%60data%60%20as%20a%20%22thinking%22%20case**%0A%0AThe%20inline%20comment%20on%20line%20178%20still%20mentions%20%60data%60%20in%20the%20list%20of%20content%20types%20that%20reach%20%60return%20true%60%20%28%22agent%20is%20thinking%20about%20the%20next%20step%22%29.%20However%2C%20the%20guard%20two%20lines%20above%20this%20now%20short-circuits%20with%20%60return%20false%60%20when%20%60lastType%20%3D%3D%3D%20'data'%60%2C%20so%20%60data%60%20never%20reaches%20this%20point.%20The%20comment%20should%20be%20updated%20to%20reflect%20that%20%60data%60%20is%20now%20a%20terminal%20response%20type%2C%20not%20a%20%22still%20thinking%22%20type.%0A%0A&pr=217&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex-ui%2Fcomponents%2Ftask-messages%2Ftask-messages.tsx%3A178-180%0A**Stale%20comment%20still%20lists%20%60data%60%20as%20a%20%22thinking%22%20case**%0A%0AThe%20inline%20comment%20on%20line%20178%20still%20mentions%20%60data%60%20in%20the%20list%20of%20content%20types%20that%20reach%20%60return%20true%60%20%28%22agent%20is%20thinking%20about%20the%20next%20step%22%29.%20However%2C%20the%20guard%20two%20lines%20above%20this%20now%20short-circuits%20with%20%60return%20false%60%20when%20%60lastType%20%3D%3D%3D%20'data'%60%2C%20so%20%60data%60%20never%20reaches%20this%20point.%20The%20comment%20should%20be%20updated%20to%20reflect%20that%20%60data%60%20is%20now%20a%20terminal%20response%20type%2C%20not%20a%20%22still%20thinking%22%20type.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=217&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22declan-scale%2Fchat-ui-fixes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22declan-scale%2Fchat-ui-fixes%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex-ui%2Fcomponents%2Ftask-messages%2Ftask-messages.tsx%3A178-180%0A**Stale%20comment%20still%20lists%20%60data%60%20as%20a%20%22thinking%22%20case**%0A%0AThe%20inline%20comment%20on%20line%20178%20still%20mentions%20%60data%60%20in%20the%20list%20of%20content%20types%20that%20reach%20%60return%20true%60%20%28%22agent%20is%20thinking%20about%20the%20next%20step%22%29.%20However%2C%20the%20guard%20two%20lines%20above%20this%20now%20short-circuits%20with%20%60return%20false%60%20when%20%60lastType%20%3D%3D%3D%20'data'%60%2C%20so%20%60data%60%20never%20reaches%20this%20point.%20The%20comment%20should%20be%20updated%20to%20reflect%20that%20%60data%60%20is%20now%20a%20terminal%20response%20type%2C%20not%20a%20%22still%20thinking%22%20type.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex-ui/components/task-messages/task-messages.tsx:178-180
**Stale comment still lists `data` as a "thinking" case**

The inline comment on line 178 still mentions `data` in the list of content types that reach `return true` ("agent is thinking about the next step"). However, the guard two lines above this now short-circuits with `return false` when `lastType === 'data'`, so `data` never reaches this point. The comment should be updated to reflect that `data` is now a terminal response type, not a "still thinking" type.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Address comments, fix data rendering ui"](https://github.com/scaleapi/scale-agentex/commit/42e73e12f198242b1928a43a499cdd68389635ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30509221)</sub>

<!-- /greptile_comment -->