### PR TITLE
feat: allow GUI task creation params

### DIFF
--- a/agentex-ui/components/primary-content/prompt-input.tsx
+++ b/agentex-ui/components/primary-content/prompt-input.tsx
@@ -8,9 +8,11 @@ import { Prec } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
 import CodeMirror from '@uiw/react-codemirror';
 import { DataContent, TextContent } from 'agentex/resources';
-import { ArrowUp } from 'lucide-react';
+import { ArrowUp, ChevronDown } from 'lucide-react';
 
 import { useAgentexClient } from '@/components/providers';
+import { Button } from '@/components/ui/button';
+import { Collapsible } from '@/components/ui/collapsible';
 import { IconButton } from '@/components/ui/icon-button';
 import { Switch } from '@/components/ui/switch';
 import { toast } from '@/components/ui/toast';
@@ -21,6 +23,7 @@ import {
 } from '@/hooks/use-safe-search-params';
 import { useSendMessage } from '@/hooks/use-task-messages';
 import { useTask } from '@/hooks/use-tasks';
+import { parseOptionalJsonObject } from '@/lib/json-utils';
 import { TaskStatusEnum } from '@/lib/types';
 
 type PromptInputProps = {
@@ -49,6 +52,8 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
   const { taskID, agentName, updateParams } = useSafeSearchParams();
   const [isClient, setIsClient] = useState(false);
   const [isSendingJSON, setIsSendingJSON] = useState(false);
+  const [isTaskParamsOpen, setIsTaskParamsOpen] = useState(false);
+  const [taskParamsPrompt, setTaskParamsPrompt] = useState('');
 
   const { agentexClient } = useAgentexClient();
 
@@ -58,6 +63,7 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
 
   const textInputRef = useRef<HTMLInputElement>(null);
   const codeMirrorViewRef = useRef<EditorView | null>(null);
+  const taskParamsCodeMirrorViewRef = useRef<EditorView | null>(null);
 
   const isTaskTerminal = useMemo(() => {
     if (!taskID || !task) return false;
@@ -116,12 +122,25 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
       }
     }
 
+    let taskParams: Record<string, unknown> | undefined;
+    if (!currentTaskId) {
+      try {
+        taskParams = parseOptionalJsonObject(taskParamsPrompt);
+      } catch (error) {
+        toast.error({
+          title: 'Invalid task creation params',
+          message: error instanceof Error ? error.message : 'Invalid JSON object',
+        });
+        return;
+      }
+    }
+
     setPrompt('');
 
     if (!currentTaskId) {
       const task = await createTaskMutation.mutateAsync({
         agentName: agentName,
-        params: {
+        params: taskParams ?? {
           description: prompt,
           content: currentPrompt,
         },
@@ -159,10 +178,21 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
     sendMessageMutation,
     setPrompt,
     isSendingJSON,
+    taskParamsPrompt,
   ]);
 
   return (
     <div className="flex w-full max-w-3xl flex-col gap-2">
+      {!taskID && (
+        <TaskCreationParamsEditor
+          value={taskParamsPrompt}
+          setValue={setTaskParamsPrompt}
+          isOpen={isTaskParamsOpen}
+          setIsOpen={setIsTaskParamsOpen}
+          isDisabled={isDisabled}
+          codeMirrorViewRef={taskParamsCodeMirrorViewRef}
+        />
+      )}
       <div
         className={`border-input dark:bg-input ${isDisabled ? 'bg-muted scale-90 cursor-not-allowed' : 'scale-100'} flex w-full items-center justify-between rounded-4xl border py-2 pr-2 pl-6 shadow-sm transition-transform duration-300 disabled:cursor-not-allowed`}
       >
@@ -210,6 +240,80 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
     </div>
   );
 }
+
+const TaskCreationParamsEditor = ({
+  value,
+  setValue,
+  isOpen,
+  setIsOpen,
+  isDisabled,
+  codeMirrorViewRef,
+}: {
+  value: string;
+  setValue: (value: string) => void;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  isDisabled: boolean;
+  codeMirrorViewRef: React.MutableRefObject<EditorView | null>;
+}) => {
+  const handleToggle = useCallback(() => {
+    const nextIsOpen = !isOpen;
+    setIsOpen(nextIsOpen);
+  }, [isOpen, setIsOpen]);
+
+  return (
+    <div
+      className="text-muted-foreground flex flex-col gap-2 px-4 text-sm"
+      style={{
+        opacity: isDisabled ? 0 : 1,
+        transition: 'opacity 0.2s',
+      }}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground hover:text-foreground h-auto w-fit gap-1 px-0 py-0 text-xs"
+        onClick={handleToggle}
+        disabled={isDisabled}
+        aria-expanded={isOpen}
+      >
+        <ChevronDown
+          className={`size-3 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+        />
+        Task creation params
+      </Button>
+      <Collapsible collapsed={!isOpen}>
+        <div className="border-input bg-background dark:bg-input/30 rounded-xl border p-2 shadow-sm">
+          <CodeMirror
+            className="text-sm"
+            value={value}
+            onChange={(nextValue: string) => setValue(nextValue)}
+            onCreateEditor={view => {
+              codeMirrorViewRef.current = view;
+            }}
+            extensions={[json(), noOutlineTheme, closeBrackets()]}
+            placeholder='{ "container_id": "..." }'
+            basicSetup={{
+              lineNumbers: false,
+              foldGutter: false,
+              highlightActiveLineGutter: false,
+              highlightActiveLine: false,
+            }}
+            editable={!isDisabled}
+            theme="none"
+            maxHeight="180px"
+          />
+        </div>
+        <p className="mt-1 text-xs">
+          Optional JSON object sent as task/create params only when this GUI
+          starts a new task. Leave empty to use the prompt as the default
+          params.
+        </p>
+      </Collapsible>
+    </div>
+  );
+};
 
 const TextInput = ({
   prompt,

--- a/agentex-ui/components/primary-content/prompt-input.tsx
+++ b/agentex-ui/components/primary-content/prompt-input.tsx
@@ -147,6 +147,8 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
       });
       currentTaskId = task.id;
       updateParams({ [SearchParamKey.TASK_ID]: currentTaskId });
+      setIsTaskParamsEnabled(false);
+      setTaskParamsPrompt('');
     }
 
     const content: TextContent | DataContent = isSendingJSON

--- a/agentex-ui/components/primary-content/prompt-input.tsx
+++ b/agentex-ui/components/primary-content/prompt-input.tsx
@@ -8,11 +8,10 @@ import { Prec } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
 import CodeMirror from '@uiw/react-codemirror';
 import { DataContent, TextContent } from 'agentex/resources';
-import { ArrowUp, ChevronDown } from 'lucide-react';
+import { ArrowUp } from 'lucide-react';
 
 import { useAgentexClient } from '@/components/providers';
 import { Button } from '@/components/ui/button';
-import { Collapsible } from '@/components/ui/collapsible';
 import { IconButton } from '@/components/ui/icon-button';
 import { Switch } from '@/components/ui/switch';
 import { toast } from '@/components/ui/toast';
@@ -52,7 +51,7 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
   const { taskID, agentName, updateParams } = useSafeSearchParams();
   const [isClient, setIsClient] = useState(false);
   const [isSendingJSON, setIsSendingJSON] = useState(false);
-  const [isTaskParamsOpen, setIsTaskParamsOpen] = useState(false);
+  const [isTaskParamsEnabled, setIsTaskParamsEnabled] = useState(false);
   const [taskParamsPrompt, setTaskParamsPrompt] = useState('');
 
   const { agentexClient } = useAgentexClient();
@@ -123,7 +122,7 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
     }
 
     let taskParams: Record<string, unknown> | undefined;
-    if (!currentTaskId) {
+    if (!currentTaskId && isTaskParamsEnabled) {
       try {
         taskParams = parseOptionalJsonObject(taskParamsPrompt);
       } catch (error) {
@@ -178,6 +177,7 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
     sendMessageMutation,
     setPrompt,
     isSendingJSON,
+    isTaskParamsEnabled,
     taskParamsPrompt,
   ]);
 
@@ -187,8 +187,8 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
         <TaskCreationParamsEditor
           value={taskParamsPrompt}
           setValue={setTaskParamsPrompt}
-          isOpen={isTaskParamsOpen}
-          setIsOpen={setIsTaskParamsOpen}
+          isEnabled={isTaskParamsEnabled}
+          setIsEnabled={setIsTaskParamsEnabled}
           isDisabled={isDisabled}
           codeMirrorViewRef={taskParamsCodeMirrorViewRef}
         />
@@ -244,22 +244,34 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
 const TaskCreationParamsEditor = ({
   value,
   setValue,
-  isOpen,
-  setIsOpen,
+  isEnabled,
+  setIsEnabled,
   isDisabled,
   codeMirrorViewRef,
 }: {
   value: string;
   setValue: (value: string) => void;
-  isOpen: boolean;
-  setIsOpen: (isOpen: boolean) => void;
+  isEnabled: boolean;
+  setIsEnabled: (isEnabled: boolean) => void;
   isDisabled: boolean;
   codeMirrorViewRef: React.MutableRefObject<EditorView | null>;
 }) => {
-  const handleToggle = useCallback(() => {
-    const nextIsOpen = !isOpen;
-    setIsOpen(nextIsOpen);
-  }, [isOpen, setIsOpen]);
+  const handleAdd = useCallback(() => {
+    setIsEnabled(true);
+  }, [setIsEnabled]);
+
+  const handleRemove = useCallback(() => {
+    setIsEnabled(false);
+    setValue('');
+  }, [setIsEnabled, setValue]);
+
+  useEffect(() => {
+    if (!isEnabled) return;
+
+    requestAnimationFrame(() => {
+      codeMirrorViewRef.current?.focus();
+    });
+  }, [codeMirrorViewRef, isEnabled]);
 
   return (
     <div
@@ -269,22 +281,21 @@ const TaskCreationParamsEditor = ({
         transition: 'opacity 0.2s',
       }}
     >
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="text-muted-foreground hover:text-foreground h-auto w-fit gap-1 px-0 py-0 text-xs"
-        onClick={handleToggle}
-        disabled={isDisabled}
-        aria-expanded={isOpen}
-      >
-        <ChevronDown
-          className={`size-3 transition-transform ${isOpen ? 'rotate-180' : ''}`}
-        />
-        Task creation params
-      </Button>
-      <Collapsible collapsed={!isOpen}>
+      {isEnabled ? (
         <div className="border-input bg-background dark:bg-input/30 rounded-xl border p-2 shadow-sm">
+          <div className="mb-2 flex items-center justify-between px-1">
+            <span className="text-xs font-medium">Task creation params</span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground hover:text-foreground h-auto px-0 py-0 text-xs"
+              onClick={handleRemove}
+              disabled={isDisabled}
+            >
+              Remove
+            </Button>
+          </div>
           <CodeMirror
             className="text-sm"
             value={value}
@@ -304,13 +315,22 @@ const TaskCreationParamsEditor = ({
             theme="none"
             maxHeight="180px"
           />
+          <p className="text-muted-foreground mt-2 px-1 text-xs">
+            Optional JSON object sent only when this GUI starts a new task.
+          </p>
         </div>
-        <p className="mt-1 text-xs">
-          Optional JSON object sent as task/create params only when this GUI
-          starts a new task. Leave empty to use the prompt as the default
-          params.
-        </p>
-      </Collapsible>
+      ) : (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-foreground h-auto w-fit px-0 py-0 text-xs"
+          onClick={handleAdd}
+          disabled={isDisabled}
+        >
+          + Add task creation params
+        </Button>
+      )}
     </div>
   );
 };

--- a/agentex-ui/components/primary-content/prompt-input.tsx
+++ b/agentex-ui/components/primary-content/prompt-input.tsx
@@ -128,7 +128,8 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
       } catch (error) {
         toast.error({
           title: 'Invalid task creation params',
-          message: error instanceof Error ? error.message : 'Invalid JSON object',
+          message:
+            error instanceof Error ? error.message : 'Invalid JSON object',
         });
         return;
       }

--- a/agentex-ui/lib/json-utils.test.ts
+++ b/agentex-ui/lib/json-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { serializeValue } from '@/lib/json-utils';
+import { parseOptionalJsonObject, serializeValue } from '@/lib/json-utils';
 import type { JsonValue } from '@/lib/types';
 
 describe('serializeValue', () => {
@@ -75,5 +75,34 @@ describe('serializeValue', () => {
     const data = 0;
     const result = serializeValue(data);
     expect(result).toBe('0');
+  });
+});
+
+describe('parseOptionalJsonObject', () => {
+  it('returns undefined for empty input', () => {
+    expect(parseOptionalJsonObject('')).toBeUndefined();
+    expect(parseOptionalJsonObject('   ')).toBeUndefined();
+  });
+
+  it('parses a valid JSON object', () => {
+    expect(parseOptionalJsonObject('{ "container_id": "abc123" }')).toEqual({
+      container_id: 'abc123',
+    });
+  });
+
+  it('rejects invalid JSON', () => {
+    expect(() => parseOptionalJsonObject('{ bad json }')).toThrow(
+      'Invalid JSON'
+    );
+  });
+
+  it('rejects arrays', () => {
+    expect(() => parseOptionalJsonObject('[]')).toThrow('Expected a JSON object');
+  });
+
+  it('rejects null', () => {
+    expect(() => parseOptionalJsonObject('null')).toThrow(
+      'Expected a JSON object'
+    );
   });
 });

--- a/agentex-ui/lib/json-utils.test.ts
+++ b/agentex-ui/lib/json-utils.test.ts
@@ -97,7 +97,9 @@ describe('parseOptionalJsonObject', () => {
   });
 
   it('rejects arrays', () => {
-    expect(() => parseOptionalJsonObject('[]')).toThrow('Expected a JSON object');
+    expect(() => parseOptionalJsonObject('[]')).toThrow(
+      'Expected a JSON object'
+    );
   });
 
   it('rejects null', () => {

--- a/agentex-ui/lib/json-utils.ts
+++ b/agentex-ui/lib/json-utils.ts
@@ -1,5 +1,7 @@
 import type { JsonValue } from '@/lib/types';
 
+export type JsonObject = { [key: string]: JsonValue };
+
 export function serializeValue(data: JsonValue): string {
   if (typeof data === 'object' && data !== null) {
     return JSON.stringify(data, null, 2);
@@ -8,4 +10,31 @@ export function serializeValue(data: JsonValue): string {
     return data;
   }
   return String(data);
+}
+
+export function parseJsonObject(input: string): JsonObject {
+  let parsedValue: unknown;
+  try {
+    parsedValue = JSON.parse(input) as unknown;
+  } catch (error) {
+    throw new Error('Invalid JSON', { cause: error });
+  }
+
+  if (
+    parsedValue === null ||
+    typeof parsedValue !== 'object' ||
+    Array.isArray(parsedValue)
+  ) {
+    throw new Error('Expected a JSON object');
+  }
+
+  return parsedValue as JsonObject;
+}
+
+export function parseOptionalJsonObject(input: string): JsonObject | undefined {
+  if (!input.trim()) {
+    return undefined;
+  }
+
+  return parseJsonObject(input);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an optional `+ Add task creation params` control to the OOB chat prompt that is only shown before a task exists.
- Reveal a JSON editor for task creation params when users opt in, with a remove action that clears stale params.
- Use the provided JSON object as `task/create.params` when present, while preserving the existing prompt-derived params fallback when empty or not enabled.
- Reset task params UI state after successful task creation, independent of whether the first prompt is text or JSON.
- Add JSON object parsing helpers and unit coverage for empty, invalid, and non-object inputs.

## Validation
- `npm run lint`
- `npm test -- --run lib/json-utils.test.ts`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d11d6a98-352d-4343-8e1d-a92c40279a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d11d6a98-352d-4343-8e1d-a92c40279a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

