### PR TITLE
docs: add spans.task_id backfill runbook + migration safety guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,29 +304,76 @@ Always create migrations when changing models:
 
 Migrations run automatically during `make dev` startup, and they also run on **pod startup in deployed environments**. This means a long-running migration blocks the application from coming up — the migration runner and the request-serving pod are the same process.
 
-#### Migration safety on large or write-heavy tables
+#### Database migration safety
 
-The default Alembic ergonomics (`op.add_column`, `op.create_index`, `op.create_foreign_key`, `op.execute("UPDATE ...")`) are fine on small tables but dangerous on large or hot ones. Combining several of them in a single revision has historically caused multi-row UPDATEs to hold `AccessExclusiveLock` for long enough to exhaust the application's connection pool. Treat the following as required reading whenever a migration touches a table that already has meaningful production volume.
+Default Alembic ergonomics — `op.add_column`, `op.create_index`, `op.create_foreign_key`, `op.execute("UPDATE ...")` — are fine on small tables and dangerous on large hot ones. The four anti-patterns below have all individually caused, or come close to causing, write outages. Read this section whenever a migration touches a table with meaningful production volume.
 
-**Rules of thumb:**
+##### The four anti-patterns
 
-1. **One concern per revision.** A single migration should do one of: add a column, add a constraint, add an index, run a backfill. Never combine `add_column` + `UPDATE` backfill + `create_foreign_key` + `create_index` in one revision — each of those is fast in isolation and ruinous in combination on a large table.
+1. **Single unbatched `UPDATE` over the whole table.** Postgres MVCC means every updated row becomes a rewrite plus a new tuple, so a multi-million-row `UPDATE` doubles live-plus-dead tuples on the table, generates proportional WAL, and holds row locks for the entire duration. If it fails or is killed, the whole transaction rolls back and burns all that I/O for nothing. **Don't backfill in a migration.** Chunk by id range or hash in an out-of-band script and run the schema-only parts in the migration.
 
-2. **Never run a multi-million-row `UPDATE` in-band.** In-band backfills run inside Alembic's transaction, hold row locks, prevent autovacuum, and block pod startup. Use a separate, operator-driven runbook in `agentex/docs/runbooks/` that loops in batches with `COMMIT` between batches. See `spans-task-id-backfill.md` for the canonical pattern. The migration itself should add only the new column (nullable), and a follow-up migration should attach the FK/index after the backfill is done out-of-band.
+2. **`op.create_foreign_key` (validating).** Default Alembic FK creation issues `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` which takes `ShareRowExclusiveLock` on the referencing table (and `AccessShare` on the referenced table) while it full-scans every row to prove the FK holds. **Two-step it:** add with `NOT VALID` first (cheap, metadata only), then `ALTER TABLE ... VALIDATE CONSTRAINT` in a follow-up migration (`ShareUpdateExclusiveLock`, scan-only, does not block writes). In Alembic: `op.create_foreign_key(..., postgresql_not_valid=True)` or write the raw `ALTER TABLE` with `NOT VALID`.
 
-3. **Add foreign keys with `NOT VALID`.** `op.create_foreign_key` issues `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` which scans the entire table under `AccessExclusiveLock`. On a large table this is the lock that takes the service down. Instead, write raw SQL with `NOT VALID` (skips the validation scan; FK still enforced on subsequent writes) and only run `VALIDATE CONSTRAINT` later if a fully validated state is actually needed (it is rarely needed; `VALIDATE CONSTRAINT` only takes `ShareUpdateExclusiveLock` so it is non-blocking but still scans the whole table).
+3. **`op.create_index` without `CONCURRENTLY`.** Plain `CREATE INDEX` takes a `ShareLock` on the table for the entire build, blocking every `INSERT` / `UPDATE` / `DELETE`. On a hot ingest table that's a write outage. Use `CREATE INDEX CONCURRENTLY` — which means the migration must run outside a transaction. In Alembic: `with op.get_context().autocommit_block(): op.execute("CREATE INDEX CONCURRENTLY ...")`.
 
-4. **Build indexes with `CREATE INDEX CONCURRENTLY`.** `op.create_index` is non-concurrent and blocks writes for the duration of the build. On a large table use raw SQL (`CREATE INDEX CONCURRENTLY IF NOT EXISTS ...`) and wrap the whole migration in `op.get_context().autocommit_block()` — `CONCURRENTLY` cannot run inside a transaction.
+4. **One transaction wrapping all of the above.** Alembic's default is one transaction per migration. With anti-patterns 1–3 stacked in a single revision the locks compound and every writer queues behind them. Use `transaction_per_migration=True` (already set in `env.py`) and `autocommit_block()` for `CONCURRENTLY` operations so the migration cannot accidentally hold compound locks.
 
-5. **`autocommit_block()` requires per-migration transactions.** This repository's `env.py` already sets `transaction_per_migration=True`, but be aware: each migration is its own transaction, and `autocommit_block()` exits that transaction so individual statements (CREATE INDEX CONCURRENTLY, etc.) run with their own implicit transactions.
+##### The correct shape: split into M1, out-of-band backfill, M2
 
-6. **Default timeouts apply.** `env.py` applies `lock_timeout = '3s'` and `statement_timeout = '30s'` per migration via `SET LOCAL` inside the transaction. This is intentional: it makes a runaway migration fail fast rather than block pod startup. Statements run via `autocommit_block()` deliberately bypass these timeouts (so legitimate long-but-non-blocking operations like `CREATE INDEX CONCURRENTLY` still work). If an in-transaction statement legitimately needs more headroom, override per-statement with `SET LOCAL`.
+For any migration that adds a backfilled column with an FK and an index on a large table, ship three things in order:
 
-7. **Make migrations idempotent.** Use `IF NOT EXISTS` / `IF EXISTS` and catalog checks (`pg_constraint`, `pg_indexes`) so a migration is a no-op on environments where the operation has already run. This protects rollouts where some environments ran a previous (potentially broken) version of the migration and others did not.
+| Step | What | Why |
+|---|---|---|
+| **M1 (Alembic)** | `ADD COLUMN` (nullable) + `ADD CONSTRAINT ... NOT VALID` + `CREATE INDEX CONCURRENTLY` (in `autocommit_block()`) | Schema-only, all metadata-cheap or non-blocking. Each operation is idempotent (`IF NOT EXISTS` / `pg_constraint` guard) so the migration is safe to re-run on environments that already ran a previous (broken) version. |
+| **Out-of-band runbook** | Chunked backfill script with `lock_timeout`, small batches, `COMMIT` between batches, `pg_sleep` between batches | Operator-driven; runs during a low-traffic window, can be cancelled cleanly, doesn't block pod startup. Pattern: `agentex/docs/runbooks/spans-task-id-backfill.md`. |
+| **M2 (Alembic)** | `ALTER TABLE ... VALIDATE CONSTRAINT` (only if a fully validated FK state is actually needed) | Runs after the backfill so the scan finds no violations. `ShareUpdateExclusiveLock` is non-blocking against reads/writes but still scans the table — usually optional. |
 
-8. **Test on representative data sizes.** A migration that completes in milliseconds against a near-empty dev table can take tens of minutes against a production table with tens of millions of rows. If you cannot test against a realistic dataset, write the migration as if you can't, and use the patterns above by default.
+The application should also tolerate the partially-backfilled state at read time (e.g. ORing the new column against the legacy column where they overlap) so deployment of M1 is decoupled from the backfill's completion.
 
-9. **Re-run, rollback, and forward-fix.** If a migration is rolled back in production, the `alembic_version` row reflects only what was committed. To recover from a partially-applied broken migration, reduce the broken revision to its safe minimum (idempotent column add, etc.) and add a follow-up migration that finalizes the rest under non-blocking operations. Do not silently rewrite history of a revision that has already been applied somewhere — always make the new behavior idempotent so it is safe on both already-applied and not-yet-applied environments.
+##### Default runtime guardrails
+
+`env.py` applies three timeouts per migration via `SET LOCAL` inside the transaction:
+
+- `lock_timeout = '3s'` — fail fast if the migration's DDL would queue behind active writers.
+- `statement_timeout = '30s'` — cap per-statement runtime so a runaway query aborts cleanly.
+- `idle_in_transaction_session_timeout = '10s'` — kill a stalled transaction so it can't hold locks indefinitely.
+
+Statements run via `autocommit_block()` are outside the transaction and bypass these timeouts deliberately — that's the right behavior for `CREATE INDEX CONCURRENTLY` and similar long-but-non-blocking operations.
+
+##### Escape hatch: `migration-unsafe-ack`
+
+A migration that genuinely needs to override these guardrails (a pre-approved maintenance-window operation, for example) must:
+
+1. Open the migration file with a top-of-file directive comment:
+
+   ```python
+   # migration-unsafe-ack: <one-line reason>
+   ```
+
+2. Add the `migration-unsafe-ack` label on the PR.
+
+The directive is what lets a migration include `SET lock_timeout`, `SET statement_timeout`, `SET idle_in_transaction_session_timeout`, or `RESET` of any of those. The PR label is what tells the reviewer the override is intentional.
+
+Use the escape hatch for "this needs a maintenance window with traffic shifted away" — not for "I want to ship faster." If you find yourself reaching for it, the answer is almost always to split the migration into the M1 / out-of-band / M2 shape above.
+
+##### Anti-pattern → linter rule reference
+
+A migration linter is planned (see SGP-5785) and will enforce these rules at PR time. The mapping below is what the linter will catch — and what reviewers should look for in the meantime:
+
+| Anti-pattern | Linter rule (squawk or equivalent) |
+|---|---|
+| `CREATE INDEX` without `CONCURRENTLY` | `prefer-robust-stmts` |
+| `ADD CONSTRAINT FOREIGN KEY` without `NOT VALID` | `prefer-robust-stmts` |
+| `ADD CONSTRAINT ... UNIQUE` (use `CREATE UNIQUE INDEX CONCURRENTLY` + `ADD CONSTRAINT ... USING INDEX` instead) | `disallowed-unique-constraint` |
+| `ADD COLUMN ... NOT NULL` with a volatile default | `adding-required-field` |
+| Mixing `CONCURRENTLY` ops with same-transaction DDL | `transaction-nesting` |
+| `SET lock_timeout` / `SET statement_timeout` / `SET idle_in_transaction_session_timeout` / `RESET` of any | custom rule (forbidden unless `# migration-unsafe-ack: ...` directive present) |
+
+##### Other rules
+
+- **Make migrations idempotent.** Use `IF NOT EXISTS` / `IF EXISTS` and catalog checks (`pg_constraint`, `pg_indexes`) so a migration is a no-op on environments where the operation has already run.
+- **Test on representative data sizes.** A migration that finishes instantly against an empty dev table can take tens of minutes against a multi-million-row prod table.
+- **Forward-fix, don't quietly rewrite.** If a migration ships broken to any environment, reduce the broken revision to its safe minimum (idempotent column add) and add a follow-up migration that finalizes the rest under non-blocking operations. Don't rewrite a revision's body in a way that would skip work on environments where the original ran successfully.
 
 If a planned migration touches a table you suspect is large in production, ask before merging and route the change through a runbook PR alongside the migration PR.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Public Repository
+
+**This repository is public.** Everything that lands here — source code, comments, commit messages, file headers, runbooks, PR descriptions — is world-readable and indexed by search engines.
+
+When making changes (especially commits, PR descriptions, and any operational docs), keep all of the following **out** of anything that gets pushed:
+
+- Customer or account names (real or codename), and any identifying details about specific deployments, traffic patterns, or incidents tied to a customer.
+- Internal Slack channels, threads, or permalinks (e.g. `scaleapi.slack.com/...`, `#some-internal-channel`).
+- Internal ticket IDs and tracker URLs (Linear, Jira, etc.).
+- Names or handles of individual employees, including in attribution like "per Alice's notes" or `Co-Authored-By` lines pointing at internal emails.
+- Internal infrastructure references that aren't already documented publicly (internal hostnames, internal feature-flag system names, internal repo paths outside this one, etc.).
+- Anything you wouldn't want a competitor or a journalist to read.
+
+When describing motivation for a change, write generically: "on a sufficiently large table this exhausts the connection pool" rather than naming the specific table size, customer, or date. Describe the failure mode, not the incident.
+
+When in doubt, ask before pushing — a redaction after the fact does not remove content from git history without a force-push that rewrites the branch.
+
 ## Repository Overview
 
 Agentex is a comprehensive platform for building and deploying intelligent agents. This repository contains:
@@ -285,7 +302,33 @@ Always create migrations when changing models:
 3. Review generated migration in `database/migrations/versions/`
 4. Apply with `make apply-migrations`
 
-Migrations run automatically during `make dev` startup.
+Migrations run automatically during `make dev` startup, and they also run on **pod startup in deployed environments**. This means a long-running migration blocks the application from coming up — the migration runner and the request-serving pod are the same process.
+
+#### Migration safety on large or write-heavy tables
+
+The default Alembic ergonomics (`op.add_column`, `op.create_index`, `op.create_foreign_key`, `op.execute("UPDATE ...")`) are fine on small tables but dangerous on large or hot ones. Combining several of them in a single revision has historically caused multi-row UPDATEs to hold `AccessExclusiveLock` for long enough to exhaust the application's connection pool. Treat the following as required reading whenever a migration touches a table that already has meaningful production volume.
+
+**Rules of thumb:**
+
+1. **One concern per revision.** A single migration should do one of: add a column, add a constraint, add an index, run a backfill. Never combine `add_column` + `UPDATE` backfill + `create_foreign_key` + `create_index` in one revision — each of those is fast in isolation and ruinous in combination on a large table.
+
+2. **Never run a multi-million-row `UPDATE` in-band.** In-band backfills run inside Alembic's transaction, hold row locks, prevent autovacuum, and block pod startup. Use a separate, operator-driven runbook in `agentex/docs/runbooks/` that loops in batches with `COMMIT` between batches. See `spans-task-id-backfill.md` for the canonical pattern. The migration itself should add only the new column (nullable), and a follow-up migration should attach the FK/index after the backfill is done out-of-band.
+
+3. **Add foreign keys with `NOT VALID`.** `op.create_foreign_key` issues `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY` which scans the entire table under `AccessExclusiveLock`. On a large table this is the lock that takes the service down. Instead, write raw SQL with `NOT VALID` (skips the validation scan; FK still enforced on subsequent writes) and only run `VALIDATE CONSTRAINT` later if a fully validated state is actually needed (it is rarely needed; `VALIDATE CONSTRAINT` only takes `ShareUpdateExclusiveLock` so it is non-blocking but still scans the whole table).
+
+4. **Build indexes with `CREATE INDEX CONCURRENTLY`.** `op.create_index` is non-concurrent and blocks writes for the duration of the build. On a large table use raw SQL (`CREATE INDEX CONCURRENTLY IF NOT EXISTS ...`) and wrap the whole migration in `op.get_context().autocommit_block()` — `CONCURRENTLY` cannot run inside a transaction.
+
+5. **`autocommit_block()` requires per-migration transactions.** This repository's `env.py` already sets `transaction_per_migration=True`, but be aware: each migration is its own transaction, and `autocommit_block()` exits that transaction so individual statements (CREATE INDEX CONCURRENTLY, etc.) run with their own implicit transactions.
+
+6. **Default timeouts apply.** `env.py` applies `lock_timeout = '3s'` and `statement_timeout = '30s'` per migration via `SET LOCAL` inside the transaction. This is intentional: it makes a runaway migration fail fast rather than block pod startup. Statements run via `autocommit_block()` deliberately bypass these timeouts (so legitimate long-but-non-blocking operations like `CREATE INDEX CONCURRENTLY` still work). If an in-transaction statement legitimately needs more headroom, override per-statement with `SET LOCAL`.
+
+7. **Make migrations idempotent.** Use `IF NOT EXISTS` / `IF EXISTS` and catalog checks (`pg_constraint`, `pg_indexes`) so a migration is a no-op on environments where the operation has already run. This protects rollouts where some environments ran a previous (potentially broken) version of the migration and others did not.
+
+8. **Test on representative data sizes.** A migration that completes in milliseconds against a near-empty dev table can take tens of minutes against a production table with tens of millions of rows. If you cannot test against a realistic dataset, write the migration as if you can't, and use the patterns above by default.
+
+9. **Re-run, rollback, and forward-fix.** If a migration is rolled back in production, the `alembic_version` row reflects only what was committed. To recover from a partially-applied broken migration, reduce the broken revision to its safe minimum (idempotent column add, etc.) and add a follow-up migration that finalizes the rest under non-blocking operations. Do not silently rewrite history of a revision that has already been applied somewhere — always make the new behavior idempotent so it is safe on both already-applied and not-yet-applied environments.
+
+If a planned migration touches a table you suspect is large in production, ask before merging and route the change through a runbook PR alongside the migration PR.
 
 ### Redis Port Conflicts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,22 +352,27 @@ A migration that genuinely needs to override these guardrails (a pre-approved ma
 
 2. Add the `migration-unsafe-ack` label on the PR.
 
-The directive is what lets a migration include `SET lock_timeout`, `SET statement_timeout`, `SET idle_in_transaction_session_timeout`, or `RESET` of any of those. The PR label is what tells the reviewer the override is intentional.
+Both signals are required. The directive (with a non-empty reason on the same line) suppresses the linter's checks for that file; the PR label puts the linter into `--warn-only` mode in CI so violations still surface in logs but don't block merge. The combination tells the reviewer the override is intentional.
 
 Use the escape hatch for "this needs a maintenance window with traffic shifted away" — not for "I want to ship faster." If you find yourself reaching for it, the answer is almost always to split the migration into the M1 / out-of-band / M2 shape above.
 
 ##### Anti-pattern → linter rule reference
 
-A migration linter is planned (see SGP-5785) and will enforce these rules at PR time. The mapping below is what the linter will catch — and what reviewers should look for in the meantime:
+The migration linter at `agentex/scripts/lint_migrations.py` enforces these rules at PR time via `.github/workflows/migration-lint.yml`. It only checks files changed vs the PR base, so existing migrations are not retro-flagged. The mapping below is what the linter catches:
 
-| Anti-pattern | Linter rule (squawk or equivalent) |
+| Anti-pattern | Linter rule |
 |---|---|
-| `CREATE INDEX` without `CONCURRENTLY` | `prefer-robust-stmts` |
-| `ADD CONSTRAINT FOREIGN KEY` without `NOT VALID` | `prefer-robust-stmts` |
-| `ADD CONSTRAINT ... UNIQUE` (use `CREATE UNIQUE INDEX CONCURRENTLY` + `ADD CONSTRAINT ... USING INDEX` instead) | `disallowed-unique-constraint` |
-| `ADD COLUMN ... NOT NULL` with a volatile default | `adding-required-field` |
-| Mixing `CONCURRENTLY` ops with same-transaction DDL | `transaction-nesting` |
-| `SET lock_timeout` / `SET statement_timeout` / `SET idle_in_transaction_session_timeout` / `RESET` of any | custom rule (forbidden unless `# migration-unsafe-ack: ...` directive present) |
+| `op.create_index` without `postgresql_concurrently=True` (or raw `CREATE INDEX` outside `autocommit_block`) | `no-concurrently` |
+| `op.create_index(postgresql_concurrently=True)` not wrapped in `autocommit_block()` | `concurrently-outside-autocommit` |
+| `op.create_foreign_key` without `postgresql_not_valid=True` (or raw `ADD CONSTRAINT FOREIGN KEY` without `NOT VALID`) | `fk-without-not-valid` |
+| `op.execute("UPDATE ...")` / `DELETE` data backfills | `in-band-backfill` |
+| `SET` / `RESET` of `lock_timeout` / `statement_timeout` / `idle_in_transaction_session_timeout` | `forbidden-set` |
+
+Run the linter locally before pushing:
+
+```bash
+agentex/scripts/lint_migrations.py --base-ref origin/main
+```
 
 ##### Other rules
 

--- a/agentex/docs/runbooks/spans-task-id-backfill.md
+++ b/agentex/docs/runbooks/spans-task-id-backfill.md
@@ -1,0 +1,230 @@
+# Runbook: backfill `spans.task_id` from `trace_id`
+
+## Purpose
+
+Populate the `spans.task_id` column on historical rows with the value from
+`trace_id`, where `trace_id` matches an existing `tasks.id`. The column is
+written natively by current clients; existing rows still have
+`task_id = NULL`.
+
+**This backfill is optional.** `SpanRepository.list` ORs on `trace_id` when
+filtering by `task_id`, so application reads are correct without it. Run this
+runbook only when:
+
+- We want to drop the `trace_id` fallback in the application (cleanup goal).
+- A downstream consumer specifically needs `WHERE task_id IS NOT NULL` to
+  identify task-scoped spans for historical data.
+
+## Background
+
+An earlier in-band attempt to backfill this column via Alembic ran a single
+large `UPDATE` inside Alembic's transaction on a multi-tens-of-GB `spans`
+table. It held row locks and exhausted the application connection pool while
+concurrent span writes piled up, taking the service offline until the
+migration was killed.
+
+This runbook does the same work in **batched, committed-per-batch chunks**
+with explicit operator control over timing.
+
+## Pre-flight
+
+> Run all queries against the agentex database.
+
+1. Confirm the migration that adds the column has been applied:
+
+   ```sql
+   SELECT version_num FROM alembic_version;
+   ```
+
+   Expected: `a9959ebcbe98` (or later). If the value is `4a9b7787ccd7` or
+   earlier, **stop** — deploy the migration first.
+
+2. Confirm the column exists and the FK + index are in place:
+
+   ```sql
+   \d spans
+   ```
+
+   Expected: `task_id` column, `fk_spans_task_id_tasks` constraint,
+   `ix_spans_task_id` index.
+
+3. Measure the size of the backlog:
+
+   ```sql
+   SELECT
+       count(*) FILTER (WHERE s.task_id IS NULL AND t.id IS NOT NULL) AS to_backfill,
+       count(*) FILTER (WHERE s.task_id IS NULL AND t.id IS NULL)     AS untouched_non_task_spans,
+       count(*) FILTER (WHERE s.task_id IS NOT NULL)                  AS already_set,
+       count(*)                                                       AS total
+   FROM spans s
+   LEFT JOIN tasks t ON t.id = s.trace_id;
+   ```
+
+   Note the `to_backfill` number. With 10 000 rows per batch and 100 ms
+   sleep between batches, expect roughly 1 000 batches per minute. A
+   ~25M-row backlog is therefore ~25 minutes of wall-clock time at the
+   default pace.
+
+4. Confirm there is no other long-running write or maintenance activity on
+   the `spans` table:
+
+   ```sql
+   SELECT pid, now() - xact_start AS duration, state, wait_event, query
+   FROM pg_stat_activity
+   WHERE query ILIKE '%spans%'
+     AND state <> 'idle'
+   ORDER BY duration DESC;
+   ```
+
+## Coordination requirements
+
+- Notify the operating team before starting and post the `to_backfill`
+  count from step 3.
+- Run during a confirmed low-traffic window, or shift traffic away from the
+  service for the duration.
+- Get sign-off from infra/platform.
+- Have a rollback plan ready — the script below is safely cancellable
+  (Ctrl-C in psql, then run the cancel snippet); no schema change happens.
+
+## Execution
+
+Connect to the agentex DB with `psql` (not via the application), and run:
+
+```sql
+-- 1. Apply per-session timeouts. lock_timeout fails fast if any other
+--    session holds AccessExclusiveLock on spans (e.g. a stuck migration).
+--    statement_timeout caps the *per-batch* runtime; total runtime is
+--    unbounded because we loop and commit between batches.
+SET lock_timeout = '3s';
+SET statement_timeout = '60s';
+
+-- 2. Loop in 10 000-row chunks. ROW_COUNT is checked between iterations to
+--    detect when the backlog is drained. Each iteration commits before the
+--    next starts, so autovacuum can reclaim dead tuples and the table
+--    does not bloat.
+DO $$
+DECLARE
+    rows_updated INT := 1;
+    total_updated BIGINT := 0;
+BEGIN
+    WHILE rows_updated > 0 LOOP
+        WITH batch AS (
+            SELECT s.ctid
+            FROM spans s
+            JOIN tasks t ON t.id = s.trace_id
+            WHERE s.task_id IS NULL
+            LIMIT 10000
+        )
+        UPDATE spans
+        SET task_id = trace_id
+        WHERE ctid IN (SELECT ctid FROM batch);
+
+        GET DIAGNOSTICS rows_updated = ROW_COUNT;
+        total_updated := total_updated + rows_updated;
+
+        RAISE NOTICE 'updated batch: % rows (running total: %)',
+            rows_updated, total_updated;
+
+        COMMIT;
+        PERFORM pg_sleep(0.1);
+    END LOOP;
+END$$;
+```
+
+Notes on the SQL choices:
+
+- `ctid` selection in a CTE means each batch operates on a fixed set of rows
+  selected at the start of the batch — we don't read and write the same row
+  in a single statement, and we don't hold locks across batches.
+- `JOIN tasks` filters out spans whose `trace_id` is not actually a task id
+  (system or framework spans). Those rows stay with `task_id = NULL`, which
+  matches the application's existing semantics.
+- The `COMMIT` inside the `DO` block requires PostgreSQL ≥ 11. Confirm the
+  server version with `SELECT version();` if running this in an older env.
+- `pg_sleep(0.1)` gives autovacuum and concurrent writes breathing room.
+
+### Monitoring while it runs
+
+In a separate `psql` session:
+
+```sql
+-- Live progress (rerun periodically)
+SELECT count(*) AS remaining
+FROM spans s JOIN tasks t ON t.id = s.trace_id
+WHERE s.task_id IS NULL;
+
+-- Active sessions on spans
+SELECT pid, now() - xact_start AS duration, state, wait_event, left(query, 80)
+FROM pg_stat_activity
+WHERE query ILIKE '%spans%' AND state <> 'idle'
+ORDER BY duration DESC;
+
+-- Lock contention
+SELECT pg_class.relname, pg_locks.mode, pg_locks.granted, pg_locks.pid
+FROM pg_locks
+JOIN pg_class ON pg_class.oid = pg_locks.relation
+WHERE pg_class.relname = 'spans';
+```
+
+## Cancellation
+
+The script is safe to interrupt at any batch boundary — already-committed
+batches are durable; in-flight batches roll back cleanly.
+
+- **From the same psql session**: Ctrl-C cancels the current statement.
+- **From another session**, if the runner is stuck:
+
+  ```sql
+  -- Cancel the runner gracefully (releases locks at end of current batch)
+  SELECT pg_cancel_backend(<pid>);
+
+  -- If pg_cancel_backend doesn't return control, escalate:
+  SELECT pg_terminate_backend(<pid>);
+  ```
+
+  Prefer `pg_cancel_backend` for this batched runbook;
+  `pg_terminate_backend` should be reserved for situations where graceful
+  cancellation has already failed.
+
+## Exit criteria
+
+The backfill is complete when both of the following return `0`:
+
+```sql
+SELECT count(*) AS remaining_to_backfill
+FROM spans s JOIN tasks t ON t.id = s.trace_id
+WHERE s.task_id IS NULL;
+```
+
+```sql
+-- Sanity: no orphaned task_ids (FK is NOT VALID, so this is the only
+-- way to verify referential cleanliness for backfilled rows).
+SELECT count(*) AS orphaned_task_ids
+FROM spans
+WHERE task_id IS NOT NULL
+  AND task_id NOT IN (SELECT id FROM tasks);
+```
+
+Once both are zero, notify the operating team and restore normal traffic
+(if it was diverted).
+
+## Follow-ups after a successful backfill
+
+- Open a PR to drop the `trace_id` OR-fallback in
+  `SpanRepository.list` — task-scoped spans can now be queried purely by
+  `task_id`.
+- Optionally run `ALTER TABLE spans VALIDATE CONSTRAINT fk_spans_task_id_tasks`
+  to convert the FK from `NOT VALID` to `VALID`. This takes a
+  `ShareUpdateExclusiveLock` (does **not** block reads/writes) and scans the
+  table once. Coordinate with infra; a multi-tens-of-GB scan is non-trivial
+  even when non-blocking.
+
+## What this runbook deliberately does *not* do
+
+- It does **not** modify any schema. The column, FK, and index are managed
+  by the alembic migrations.
+- It does **not** populate `task_id` for spans whose `trace_id` is not a
+  task id. Those rows correctly remain `NULL`.
+- It does **not** run from inside a deploy or pod-startup path. Migrations
+  run on agentex pod startup; a multi-minute backfill in that path would
+  recreate the original failure mode.

--- a/agentex/docs/runbooks/spans-task-id-backfill.md
+++ b/agentex/docs/runbooks/spans-task-id-backfill.md
@@ -198,11 +198,13 @@ WHERE s.task_id IS NULL;
 
 ```sql
 -- Sanity: no orphaned task_ids (FK is NOT VALID, so this is the only
--- way to verify referential cleanliness for backfilled rows).
+-- way to verify referential cleanliness for backfilled rows). NOT EXISTS
+-- with a correlated subquery uses the tasks(id) primary-key index and
+-- avoids materialising every tasks.id (which NOT IN would force).
 SELECT count(*) AS orphaned_task_ids
-FROM spans
-WHERE task_id IS NOT NULL
-  AND task_id NOT IN (SELECT id FROM tasks);
+FROM spans s
+WHERE s.task_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM tasks t WHERE t.id = s.task_id);
 ```
 
 Once both are zero, notify the operating team and restore normal traffic


### PR DESCRIPTION
## Summary

Adds two things, both about not making the same mistake twice:

1. **Operator-driven backfill runbook** at `agentex/docs/runbooks/spans-task-id-backfill.md`. Batched, committed-per-batch `UPDATE` procedure for populating `spans.task_id` from `trace_id`. Companion to the migration changes in the code PR.
2. **CLAUDE.md additions:**
   - A "Public Repository" section listing what must stay out of commits, file headers, runbooks, and PR descriptions (customer/account names, internal channels and links, ticket IDs, employee names, internal infra references).
   - An expanded "Database Migrations" section with safety rules for large or write-heavy tables — one concern per revision, no in-band `UPDATE` backfills, FKs added `NOT VALID`, indexes built `CONCURRENTLY`, `autocommit_block()` requirements, default timeouts, idempotency, rollback/forward-fix patterns.

## Why a runbook instead of a migration

The companion code PR makes a deliberate split: migrations stay short and in-band, the heavy backfill becomes operator-driven. A multi-hour batched `UPDATE` inside Alembic would block pod startup (migrations run on startup) and recreate the original failure mode in slow motion. A runbook gives the operator timing control — traffic-shifting window, live `pg_stat_activity` monitoring, clean cancellation.

The runbook is also intentionally **optional**: the application tolerates NULL `task_id` by ORing on `trace_id` at query time. This runbook becomes load-bearing only when we eventually want to drop the OR-fallback or when a downstream consumer specifically needs a fully-populated column.

## Why the CLAUDE.md additions

The migration-runner changes in the code PR encode "what to do" in source. The CLAUDE.md additions encode "why and when" so future contributors (and Claude) follow the same patterns by default — and so that operational docs that land in this repo do not leak customer or internal-system details. The migration safety rules are distilled directly from the patterns shipped in the code PR.

## Test plan

- [ ] Reviewed by the on-call/platform team
- [ ] Markdown lint pass (runbook lives at `agentex/docs/runbooks/`, outside the mkdocs `docs_dir`, so it is not published with the SDK docs)
- [ ] First production run logged with timing data; update the runbook with actual batch throughput / total wall-clock if it differs materially from the wall-clock estimate in the runbook

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds a "Public Repository" policy section to CLAUDE.md and an expanded DB migration safety guide covering the M1 / out-of-band backfill / M2 split pattern, linter rules, and runtime guardrails.
- Introduces a new operator runbook (`agentex/docs/runbooks/spans-task-id-backfill.md`) for batching the `spans.task_id` backfill outside of Alembic; the runbook's throughput estimate (1 000 batches/min with 100 ms sleep) contradicts the stated 25-minute wall-clock, and there is no recovery note for `statement_timeout` exits.
- CLAUDE.md describes `agentex/scripts/lint_migrations.py` and `.github/workflows/migration-lint.yml` as already active, but neither file exists in the repository — contributors who follow the \"run locally\" instructions will hit a missing-file error and CI enforcement is not actually in place.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge once the linter reference is qualified to reflect its companion-PR dependency, and the runbook throughput math is corrected.

One P1 in CLAUDE.md: the linter and workflow files it describes as active do not exist in the repo, making the 'run locally' instruction fail and giving a false sense of CI coverage. P2s (throughput math and timeout recovery) are already flagged in previous review comments. No P0s.

CLAUDE.md — the linter/workflow existence claim at line 361 needs to be qualified before merge.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CLAUDE.md | Adds 'Public Repository' policy and expanded DB migration safety section; contains false present-tense claims that a migration linter and CI workflow already exist when neither file is present in the repo. |
| agentex/docs/runbooks/spans-task-id-backfill.md | New operator runbook for batched spans.task_id backfill; throughput estimate (1 000 batches/min) is physically impossible with 100 ms sleep per batch, and statement_timeout exits need recovery guidance — both flagged in previous comments. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[M1 Alembic Migration] --> B["ADD COLUMN task_id (nullable)\nADD CONSTRAINT ... NOT VALID\nCREATE INDEX CONCURRENTLY"]
    B --> C{App tolerates\nNULL task_id?}
    C -->|Yes - OR fallback active| D[Deploy M1 safely\nno write outage]
    D --> E[Out-of-band Runbook\nBatched UPDATE 10k rows/batch\nCOMMIT between batches\npg_sleep 100ms]
    E --> F{to_backfill = 0?}
    F -->|No| E
    F -->|Yes| G[Optional: M2 Alembic\nVALIDATE CONSTRAINT\nShareUpdateExclusiveLock]
    G --> H[Drop trace_id OR-fallback\nin SpanRepository.list]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `CLAUDE.md`, line 7-16 ([link](https://github.com/scaleapi/scale-agentex/blob/58e7018b6a50d6e32f6626870749da47f6bedbf8/CLAUDE.md#L7-L16)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **PR description violates the public-repo policy it introduces**

   The PR description for this very change contains the categories of content the new section forbids: two `scaleapi.slack.com` permalink URLs, the Linear ticket ID `SGP-5784`, employee names used in attribution ("per Alvin's prevention notes"), and internal system names ("Rocket", "Precog") not documented publicly. The policy explicitly lists "PR descriptions" as world-readable. The description should be scrubbed to generic language before merge — a redaction after the fact does not remove content from git history without a force-push that rewrites the branch.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: CLAUDE.md
   Line: 7-16

   Comment:
   **PR description violates the public-repo policy it introduces**

   The PR description for this very change contains the categories of content the new section forbids: two `scaleapi.slack.com` permalink URLs, the Linear ticket ID `SGP-5784`, employee names used in attribution ("per Alvin's prevention notes"), and internal system names ("Rocket", "Precog") not documented publicly. The policy explicitly lists "PR descriptions" as world-readable. The description should be scrubbed to generic language before merge — a redaction after the fact does not remove content from git history without a force-push that rewrites the branch.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%207-16%0A%0AComment%3A%0A**PR%20description%20violates%20the%20public-repo%20policy%20it%20introduces**%0A%0AThe%20PR%20description%20for%20this%20very%20change%20contains%20the%20categories%20of%20content%20the%20new%20section%20forbids%3A%20two%20%60scaleapi.slack.com%60%20permalink%20URLs%2C%20the%20Linear%20ticket%20ID%20%60SGP-5784%60%2C%20employee%20names%20used%20in%20attribution%20%28%22per%20Alvin's%20prevention%20notes%22%29%2C%20and%20internal%20system%20names%20%28%22Rocket%22%2C%20%22Precog%22%29%20not%20documented%20publicly.%20The%20policy%20explicitly%20lists%20%22PR%20descriptions%22%20as%20world-readable.%20The%20description%20should%20be%20scrubbed%20to%20generic%20language%20before%20merge%20%E2%80%94%20a%20redaction%20after%20the%20fact%20does%20not%20remove%20content%20from%20git%20history%20without%20a%20force-push%20that%20rewrites%20the%20branch.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%207-16%0A%0AComment%3A%0A**PR%20description%20violates%20the%20public-repo%20policy%20it%20introduces**%0A%0AThe%20PR%20description%20for%20this%20very%20change%20contains%20the%20categories%20of%20content%20the%20new%20section%20forbids%3A%20two%20%60scaleapi.slack.com%60%20permalink%20URLs%2C%20the%20Linear%20ticket%20ID%20%60SGP-5784%60%2C%20employee%20names%20used%20in%20attribution%20%28%22per%20Alvin's%20prevention%20notes%22%29%2C%20and%20internal%20system%20names%20%28%22Rocket%22%2C%20%22Precog%22%29%20not%20documented%20publicly.%20The%20policy%20explicitly%20lists%20%22PR%20descriptions%22%20as%20world-readable.%20The%20description%20should%20be%20scrubbed%20to%20generic%20language%20before%20merge%20%E2%80%94%20a%20redaction%20after%20the%20fact%20does%20not%20remove%20content%20from%20git%20history%20without%20a%20force-push%20that%20rewrites%20the%20branch.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22declan-scale%2Fspans-backfill-runbook%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22declan-scale%2Fspans-backfill-runbook%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%207-16%0A%0AComment%3A%0A**PR%20description%20violates%20the%20public-repo%20policy%20it%20introduces**%0A%0AThe%20PR%20description%20for%20this%20very%20change%20contains%20the%20categories%20of%20content%20the%20new%20section%20forbids%3A%20two%20%60scaleapi.slack.com%60%20permalink%20URLs%2C%20the%20Linear%20ticket%20ID%20%60SGP-5784%60%2C%20employee%20names%20used%20in%20attribution%20%28%22per%20Alvin's%20prevention%20notes%22%29%2C%20and%20internal%20system%20names%20%28%22Rocket%22%2C%20%22Precog%22%29%20not%20documented%20publicly.%20The%20policy%20explicitly%20lists%20%22PR%20descriptions%22%20as%20world-readable.%20The%20description%20should%20be%20scrubbed%20to%20generic%20language%20before%20merge%20%E2%80%94%20a%20redaction%20after%20the%20fact%20does%20not%20remove%20content%20from%20git%20history%20without%20a%20force-push%20that%20rewrites%20the%20branch.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `CLAUDE.md`, line 361 ([link](https://github.com/scaleapi/scale-agentex/blob/7ea098480ebbbaae855f2829fd312faa551ad175/CLAUDE.md#L361)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The newly-added migration safety section references the internal Linear ticket `SGP-5785`, which violates the "Public Repository" policy introduced just above in this same PR. The policy explicitly forbids "Internal ticket IDs and tracker URLs (Linear, Jira, etc.)" from appearing in anything pushed to this public repo — CLAUDE.md is world-readable and indexed by search engines.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: CLAUDE.md
   Line: 361

   Comment:
   The newly-added migration safety section references the internal Linear ticket `SGP-5785`, which violates the "Public Repository" policy introduced just above in this same PR. The policy explicitly forbids "Internal ticket IDs and tracker URLs (Linear, Jira, etc.)" from appearing in anything pushed to this public repo — CLAUDE.md is world-readable and indexed by search engines.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%20361%0A%0AComment%3A%0AThe%20newly-added%20migration%20safety%20section%20references%20the%20internal%20Linear%20ticket%20%60SGP-5785%60%2C%20which%20violates%20the%20%22Public%20Repository%22%20policy%20introduced%20just%20above%20in%20this%20same%20PR.%20The%20policy%20explicitly%20forbids%20%22Internal%20ticket%20IDs%20and%20tracker%20URLs%20%28Linear%2C%20Jira%2C%20etc.%29%22%20from%20appearing%20in%20anything%20pushed%20to%20this%20public%20repo%20%E2%80%94%20CLAUDE.md%20is%20world-readable%20and%20indexed%20by%20search%20engines.%0A%0A%60%60%60suggestion%0AA%20migration%20linter%20is%20planned%20and%20will%20enforce%20these%20rules%20at%20PR%20time.%20The%20mapping%20below%20is%20what%20the%20linter%20will%20catch%20%E2%80%94%20and%20what%20reviewers%20should%20look%20for%20in%20the%20meantime%3A%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%20361%0A%0AComment%3A%0AThe%20newly-added%20migration%20safety%20section%20references%20the%20internal%20Linear%20ticket%20%60SGP-5785%60%2C%20which%20violates%20the%20%22Public%20Repository%22%20policy%20introduced%20just%20above%20in%20this%20same%20PR.%20The%20policy%20explicitly%20forbids%20%22Internal%20ticket%20IDs%20and%20tracker%20URLs%20%28Linear%2C%20Jira%2C%20etc.%29%22%20from%20appearing%20in%20anything%20pushed%20to%20this%20public%20repo%20%E2%80%94%20CLAUDE.md%20is%20world-readable%20and%20indexed%20by%20search%20engines.%0A%0A%60%60%60suggestion%0AA%20migration%20linter%20is%20planned%20and%20will%20enforce%20these%20rules%20at%20PR%20time.%20The%20mapping%20below%20is%20what%20the%20linter%20will%20catch%20%E2%80%94%20and%20what%20reviewers%20should%20look%20for%20in%20the%20meantime%3A%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22declan-scale%2Fspans-backfill-runbook%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22declan-scale%2Fspans-backfill-runbook%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%20361%0A%0AComment%3A%0AThe%20newly-added%20migration%20safety%20section%20references%20the%20internal%20Linear%20ticket%20%60SGP-5785%60%2C%20which%20violates%20the%20%22Public%20Repository%22%20policy%20introduced%20just%20above%20in%20this%20same%20PR.%20The%20policy%20explicitly%20forbids%20%22Internal%20ticket%20IDs%20and%20tracker%20URLs%20%28Linear%2C%20Jira%2C%20etc.%29%22%20from%20appearing%20in%20anything%20pushed%20to%20this%20public%20repo%20%E2%80%94%20CLAUDE.md%20is%20world-readable%20and%20indexed%20by%20search%20engines.%0A%0A%60%60%60suggestion%0AA%20migration%20linter%20is%20planned%20and%20will%20enforce%20these%20rules%20at%20PR%20time.%20The%20mapping%20below%20is%20what%20the%20linter%20will%20catch%20%E2%80%94%20and%20what%20reviewers%20should%20look%20for%20in%20the%20meantime%3A%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `CLAUDE.md`, line 361-384 ([link](https://github.com/scaleapi/scale-agentex/blob/617174ff720f3a847d3005e84c933a7878311497/CLAUDE.md#L361-L384)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Linter docs assert existence of tools that don't exist yet**

   `agentex/scripts/lint_migrations.py` and `.github/workflows/migration-lint.yml` are not present in the repository at the current HEAD. Yet the text states they "enforce these rules at PR time" (present tense) and instructs contributors to "run the linter locally before pushing." A contributor who reads this guidance and runs `agentex/scripts/lint_migrations.py --base-ref origin/main` will get a "No such file or directory" error — worse, engineers may assume CI is catching migration anti-patterns when no such check is active. The language should be qualified to reflect the companion code PR's merge dependency.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: CLAUDE.md
   Line: 361-384

   Comment:
   **Linter docs assert existence of tools that don't exist yet**

   `agentex/scripts/lint_migrations.py` and `.github/workflows/migration-lint.yml` are not present in the repository at the current HEAD. Yet the text states they "enforce these rules at PR time" (present tense) and instructs contributors to "run the linter locally before pushing." A contributor who reads this guidance and runs `agentex/scripts/lint_migrations.py --base-ref origin/main` will get a "No such file or directory" error — worse, engineers may assume CI is catching migration anti-patterns when no such check is active. The language should be qualified to reflect the companion code PR's merge dependency.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%20361-384%0A%0AComment%3A%0A**Linter%20docs%20assert%20existence%20of%20tools%20that%20don't%20exist%20yet**%0A%0A%60agentex%2Fscripts%2Flint_migrations.py%60%20and%20%60.github%2Fworkflows%2Fmigration-lint.yml%60%20are%20not%20present%20in%20the%20repository%20at%20the%20current%20HEAD.%20Yet%20the%20text%20states%20they%20%22enforce%20these%20rules%20at%20PR%20time%22%20%28present%20tense%29%20and%20instructs%20contributors%20to%20%22run%20the%20linter%20locally%20before%20pushing.%22%20A%20contributor%20who%20reads%20this%20guidance%20and%20runs%20%60agentex%2Fscripts%2Flint_migrations.py%20--base-ref%20origin%2Fmain%60%20will%20get%20a%20%22No%20such%20file%20or%20directory%22%20error%20%E2%80%94%20worse%2C%20engineers%20may%20assume%20CI%20is%20catching%20migration%20anti-patterns%20when%20no%20such%20check%20is%20active.%20The%20language%20should%20be%20qualified%20to%20reflect%20the%20companion%20code%20PR's%20merge%20dependency.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%20361-384%0A%0AComment%3A%0A**Linter%20docs%20assert%20existence%20of%20tools%20that%20don't%20exist%20yet**%0A%0A%60agentex%2Fscripts%2Flint_migrations.py%60%20and%20%60.github%2Fworkflows%2Fmigration-lint.yml%60%20are%20not%20present%20in%20the%20repository%20at%20the%20current%20HEAD.%20Yet%20the%20text%20states%20they%20%22enforce%20these%20rules%20at%20PR%20time%22%20%28present%20tense%29%20and%20instructs%20contributors%20to%20%22run%20the%20linter%20locally%20before%20pushing.%22%20A%20contributor%20who%20reads%20this%20guidance%20and%20runs%20%60agentex%2Fscripts%2Flint_migrations.py%20--base-ref%20origin%2Fmain%60%20will%20get%20a%20%22No%20such%20file%20or%20directory%22%20error%20%E2%80%94%20worse%2C%20engineers%20may%20assume%20CI%20is%20catching%20migration%20anti-patterns%20when%20no%20such%20check%20is%20active.%20The%20language%20should%20be%20qualified%20to%20reflect%20the%20companion%20code%20PR's%20merge%20dependency.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22declan-scale%2Fspans-backfill-runbook%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22declan-scale%2Fspans-backfill-runbook%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20CLAUDE.md%0ALine%3A%20361-384%0A%0AComment%3A%0A**Linter%20docs%20assert%20existence%20of%20tools%20that%20don't%20exist%20yet**%0A%0A%60agentex%2Fscripts%2Flint_migrations.py%60%20and%20%60.github%2Fworkflows%2Fmigration-lint.yml%60%20are%20not%20present%20in%20the%20repository%20at%20the%20current%20HEAD.%20Yet%20the%20text%20states%20they%20%22enforce%20these%20rules%20at%20PR%20time%22%20%28present%20tense%29%20and%20instructs%20contributors%20to%20%22run%20the%20linter%20locally%20before%20pushing.%22%20A%20contributor%20who%20reads%20this%20guidance%20and%20runs%20%60agentex%2Fscripts%2Flint_migrations.py%20--base-ref%20origin%2Fmain%60%20will%20get%20a%20%22No%20such%20file%20or%20directory%22%20error%20%E2%80%94%20worse%2C%20engineers%20may%20assume%20CI%20is%20catching%20migration%20anti-patterns%20when%20no%20such%20check%20is%20active.%20The%20language%20should%20be%20qualified%20to%20reflect%20the%20companion%20code%20PR's%20merge%20dependency.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACLAUDE.md%3A361-384%0A**Linter%20docs%20assert%20existence%20of%20tools%20that%20don't%20exist%20yet**%0A%0A%60agentex%2Fscripts%2Flint_migrations.py%60%20and%20%60.github%2Fworkflows%2Fmigration-lint.yml%60%20are%20not%20present%20in%20the%20repository%20at%20the%20current%20HEAD.%20Yet%20the%20text%20states%20they%20%22enforce%20these%20rules%20at%20PR%20time%22%20%28present%20tense%29%20and%20instructs%20contributors%20to%20%22run%20the%20linter%20locally%20before%20pushing.%22%20A%20contributor%20who%20reads%20this%20guidance%20and%20runs%20%60agentex%2Fscripts%2Flint_migrations.py%20--base-ref%20origin%2Fmain%60%20will%20get%20a%20%22No%20such%20file%20or%20directory%22%20error%20%E2%80%94%20worse%2C%20engineers%20may%20assume%20CI%20is%20catching%20migration%20anti-patterns%20when%20no%20such%20check%20is%20active.%20The%20language%20should%20be%20qualified%20to%20reflect%20the%20companion%20code%20PR's%20merge%20dependency.%0A%0A&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACLAUDE.md%3A361-384%0A**Linter%20docs%20assert%20existence%20of%20tools%20that%20don't%20exist%20yet**%0A%0A%60agentex%2Fscripts%2Flint_migrations.py%60%20and%20%60.github%2Fworkflows%2Fmigration-lint.yml%60%20are%20not%20present%20in%20the%20repository%20at%20the%20current%20HEAD.%20Yet%20the%20text%20states%20they%20%22enforce%20these%20rules%20at%20PR%20time%22%20%28present%20tense%29%20and%20instructs%20contributors%20to%20%22run%20the%20linter%20locally%20before%20pushing.%22%20A%20contributor%20who%20reads%20this%20guidance%20and%20runs%20%60agentex%2Fscripts%2Flint_migrations.py%20--base-ref%20origin%2Fmain%60%20will%20get%20a%20%22No%20such%20file%20or%20directory%22%20error%20%E2%80%94%20worse%2C%20engineers%20may%20assume%20CI%20is%20catching%20migration%20anti-patterns%20when%20no%20such%20check%20is%20active.%20The%20language%20should%20be%20qualified%20to%20reflect%20the%20companion%20code%20PR's%20merge%20dependency.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=224&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22declan-scale%2Fspans-backfill-runbook%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22declan-scale%2Fspans-backfill-runbook%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACLAUDE.md%3A361-384%0A**Linter%20docs%20assert%20existence%20of%20tools%20that%20don't%20exist%20yet**%0A%0A%60agentex%2Fscripts%2Flint_migrations.py%60%20and%20%60.github%2Fworkflows%2Fmigration-lint.yml%60%20are%20not%20present%20in%20the%20repository%20at%20the%20current%20HEAD.%20Yet%20the%20text%20states%20they%20%22enforce%20these%20rules%20at%20PR%20time%22%20%28present%20tense%29%20and%20instructs%20contributors%20to%20%22run%20the%20linter%20locally%20before%20pushing.%22%20A%20contributor%20who%20reads%20this%20guidance%20and%20runs%20%60agentex%2Fscripts%2Flint_migrations.py%20--base-ref%20origin%2Fmain%60%20will%20get%20a%20%22No%20such%20file%20or%20directory%22%20error%20%E2%80%94%20worse%2C%20engineers%20may%20assume%20CI%20is%20catching%20migration%20anti-patterns%20when%20no%20such%20check%20is%20active.%20The%20language%20should%20be%20qualified%20to%20reflect%20the%20companion%20code%20PR's%20merge%20dependency.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
CLAUDE.md:361-384
**Linter docs assert existence of tools that don't exist yet**

`agentex/scripts/lint_migrations.py` and `.github/workflows/migration-lint.yml` are not present in the repository at the current HEAD. Yet the text states they "enforce these rules at PR time" (present tense) and instructs contributors to "run the linter locally before pushing." A contributor who reads this guidance and runs `agentex/scripts/lint_migrations.py --base-ref origin/main` will get a "No such file or directory" error — worse, engineers may assume CI is catching migration anti-patterns when no such check is active. The language should be qualified to reflect the companion code PR's merge dependency.


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["docs(claude.md): point at shipped migrat..."](https://github.com/scaleapi/scale-agentex/commit/617174ff720f3a847d3005e84c933a7878311497) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31012737)</sub>

<!-- /greptile_comment -->