### PR TITLE
feat: Make ix_tasks_metadata_gin index creation concurrent

### DIFF
--- a/agentex/database/migrations/alembic/versions/2026_05_04_1111_add_tasks_metadata_gin_index_e9c4ff9e6542.py
+++ b/agentex/database/migrations/alembic/versions/2026_05_04_1111_add_tasks_metadata_gin_index_e9c4ff9e6542.py
@@ -17,11 +17,13 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_tasks_metadata_gin "
-        "ON tasks USING GIN (task_metadata jsonb_path_ops)"
-    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_tasks_metadata_gin "
+            "ON tasks USING GIN (task_metadata jsonb_path_ops)"
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP INDEX IF EXISTS ix_tasks_metadata_gin")
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_tasks_metadata_gin")


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Wraps `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` in `op.get_context().autocommit_block()` for both `upgrade()` and `downgrade()`, correctly matching the pattern used in the sibling migration `a9959ebcbe98` and satisfying PostgreSQL's requirement that `CONCURRENTLY` cannot run inside a transaction block.
- No new logic issues identified; the change is a targeted, correct fix for the concurrent index creation pattern.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix correctly implements autocommit_block for both upgrade and downgrade, matching the established pattern in the codebase.

No P0 or P1 issues found. The PR fully addresses the previous review comment by adding autocommit_block() wrapping and CONCURRENTLY to both operations, exactly matching the pattern in sibling migration a9959ebcbe98.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/database/migrations/alembic/versions/2026_05_04_1111_add_tasks_metadata_gin_index_e9c4ff9e6542.py | Adds autocommit_block() wrapping and CONCURRENTLY keyword to both upgrade and downgrade, making the GIN index creation non-blocking and transaction-safe — correct pattern, no issues. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Alembic runs migration] --> B{transaction_per_migration=True}
    B --> C[BEGIN transaction]
    C --> D[autocommit_block context manager]
    D --> E[Connection set to AUTOCOMMIT mode]
    E --> F["CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_tasks_metadata_gin\nON tasks USING GIN (task_metadata jsonb_path_ops)"]
    F --> G[Index built without table lock]
    G --> H[Connection restored to transactional mode]
    H --> I[COMMIT outer transaction]

    style F fill:#d4edda,stroke:#28a745
    style G fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: Make ix\_tasks\_metadata\_gin index c..."](https://github.com/scaleapi/scale-agentex/commit/c8392a3c89babc477b3742697f7f258f1e559e1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32062807)</sub>

<!-- /greptile_comment -->