### PR TITLE
fix(server): unblock per-pod concurrency — uvicorn workers=4 + asyncio.to_thread for pymongo

### DIFF
--- a/agentex/Dockerfile
+++ b/agentex/Dockerfile
@@ -36,6 +36,9 @@ RUN uv sync --frozen --group dev --package agentex-backend
 COPY ${SOURCE_DIR}/src/ ./src/
 EXPOSE 5003
 ENV PYTHONPATH=/app
+# Dev / single-worker stage. `--reload` doesn't work with `--workers >1`.
+# Production multi-worker config is set in the final stage at the bottom of
+# this file.
 CMD ["ddtrace-run", "uvicorn", "src.api.app:app", "--host", "0.0.0.0", "--port", "5003", "--reload"]
 
 # Docs builder stage
@@ -90,4 +93,12 @@ USER nonroot
 
 EXPOSE 5003
 ENV PYTHONPATH=/app
-CMD ["ddtrace-run", "uvicorn", "src.api.app:app", "--host", "0.0.0.0", "--port", "5003"]
+# Run uvicorn with multiple workers so a single pod isn't bottlenecked to one
+# in-flight request at a time. The MongoDB adapter uses `pymongo` (sync) inside
+# `async def` methods, which blocks the event loop for the duration of every
+# Mongo round-trip; the only way to get per-pod concurrency today is via
+# separate worker processes. Default of 4 is a safe match for the typical 1
+# CPU / 2Gi pod limits; bump UVICORN_WORKERS up to ~cpu_count when those
+# limits are increased.
+ENV UVICORN_WORKERS=4
+CMD ["sh", "-c", "exec ddtrace-run uvicorn src.api.app:app --host 0.0.0.0 --port 5003 --workers ${UVICORN_WORKERS}"]

--- a/agentex/src/adapters/crud_store/adapter_mongodb.py
+++ b/agentex/src/adapters/crud_store/adapter_mongodb.py
@@ -216,7 +216,7 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
             if data.get("updated_at") is None:
                 data["updated_at"] = now
 
-            result = self.collection.insert_one(data)
+            result = await asyncio.to_thread(self.collection.insert_one, data)
 
             # Update item with generated ID (as string)
             # Set the .id field with the string representation of _id
@@ -274,7 +274,7 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
 
                 data_list.append(data)
 
-            result = self.collection.insert_many(data_list)
+            result = await asyncio.to_thread(self.collection.insert_many, data_list)
 
             # Update items with generated IDs (as strings)
             for idx, inserted_id in enumerate(result.inserted_ids):
@@ -320,7 +320,7 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
             else:
                 query = {"name": name}
 
-            document = self.collection.find_one(query)
+            document = await asyncio.to_thread(self.collection.find_one, query)
             if document is None:
                 msg = (
                     f"Item with {'id' if id else 'name'} '{id or name}' does not exist."
@@ -362,7 +362,9 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
                 except Exception:
                     pass
 
-            document = self.collection.find_one({mongo_field_name: mongo_field_value})
+            document = await asyncio.to_thread(
+                self.collection.find_one, {mongo_field_name: mongo_field_value}
+            )
             if document is None:
                 raise ItemDoesNotExist(
                     f"Item with {field_name} '{field_value}' does not exist."
@@ -392,8 +394,7 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
             elif names:
                 query["name"] = {"$in": names}
 
-            cursor = self.collection.find(query)
-            results = list(cursor)
+            results = await asyncio.to_thread(lambda: list(self.collection.find(query)))
             if not results:
                 key = "ids" if ids else "names"
                 msg = f"No items found with {key} '{ids or names}'."
@@ -429,14 +430,18 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
             # Add updated_at timestamp
             update_data["updated_at"] = datetime.now(UTC)
 
-            result = self.collection.update_one(
-                {"_id": id_value}, {"$set": update_data}
+            result = await asyncio.to_thread(
+                self.collection.update_one,
+                {"_id": id_value},
+                {"$set": update_data},
             )
 
             if result.matched_count == 0:
                 raise ItemDoesNotExist(f"Item with id '{id_value}' does not exist.")
 
-            updated_doc = self.collection.find_one({"_id": id_value})
+            updated_doc = await asyncio.to_thread(
+                self.collection.find_one, {"_id": id_value}
+            )
             return self._deserialize(updated_doc)
         except ItemDoesNotExist:
             raise
@@ -476,7 +481,7 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
             else:
                 query = {"name": name}
 
-            result = self.collection.delete_one(query)
+            result = await asyncio.to_thread(self.collection.delete_one, query)
             if result.deleted_count == 0:
                 msg = (
                     f"Item with {'id' if id else 'name'} '{id or name}' does not exist."
@@ -507,7 +512,7 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
             elif names:
                 query["name"] = {"$in": names}
 
-            result = self.collection.delete_many(query)
+            result = await asyncio.to_thread(self.collection.delete_many, query)
             if result.deleted_count == 0:
                 key = "ids" if ids else "names"
                 msg = f"No items found with {key} '{ids or names}'."
@@ -536,11 +541,6 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
             raise ClientError("Page number must be greater than 0")
         page_number = page_number or 1
         skip = (page_number - 1) * limit
-        if filters:
-            cursor = self.collection.find(filters)
-        else:
-            cursor = self.collection.find()
-        cursor = cursor.skip(skip).limit(limit)
 
         sort_list = []
         if order_by:
@@ -553,10 +553,16 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
 
         # Always use _id as tiebreaker
         sort_list.append(("_id", pymongo.ASCENDING))
-        cursor = cursor.sort(sort_list)
+
+        def _fetch() -> builtins.list[dict[str, Any]]:
+            cursor = (
+                self.collection.find(filters) if filters else self.collection.find()
+            )
+            return list(cursor.skip(skip).limit(limit).sort(sort_list))
 
         try:
-            return [self._deserialize(doc) for doc in cursor]
+            docs = await asyncio.to_thread(_fetch)
+            return [self._deserialize(doc) for doc in docs]
         except Exception as e:
             raise ServiceError(
                 message=f"Failed to list items from MongoDB: {e}", detail=str(e)
@@ -600,25 +606,27 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
             if filters:
                 query.update(filters)
 
-            cursor = self.collection.find(query)
-
             # Apply sorting
             sort_by_items = list(sort_by.items()) if sort_by else []
             # Use ID for tiebreaking
             sort_by_items.append(("_id", 1))
-            cursor = cursor.sort(sort_by_items)
 
             # Apply limit if specified
             limit = limit or DEFAULT_PAGE_LIMIT
-            cursor = cursor.limit(limit)
 
             # Apply page number if specified
             if page_number is not None and page_number < 1:
                 raise ClientError("Page number must be greater than 0")
-            if page_number is not None:
-                cursor = cursor.skip((page_number - 1) * limit)
+            skip = (page_number - 1) * limit if page_number is not None else 0
 
-            return [self._deserialize(doc) for doc in cursor]
+            def _fetch() -> builtins.list[dict[str, Any]]:
+                cursor = self.collection.find(query).sort(sort_by_items).limit(limit)
+                if skip:
+                    cursor = cursor.skip(skip)
+                return list(cursor)
+
+            docs = await asyncio.to_thread(_fetch)
+            return [self._deserialize(doc) for doc in docs]
         except Exception as e:
             raise ServiceError(
                 message=f"Failed to find items by field in MongoDB: {e}", detail=str(e)
@@ -677,7 +685,9 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
                 except Exception:
                     cursor_object_id = cursor_id
 
-                cursor_doc = self.collection.find_one({"_id": cursor_object_id})
+                cursor_doc = await asyncio.to_thread(
+                    self.collection.find_one, {"_id": cursor_object_id}
+                )
                 if cursor_doc and "created_at" in cursor_doc:
                     cursor_timestamp = cursor_doc["created_at"]
                     if before_id:
@@ -705,20 +715,20 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
                             },
                         ]
 
-            # Create a cursor
-            db_cursor = self.collection.find(query)
-
             # Apply sorting
             sort_by_items = list(sort_by.items()) if sort_by else []
             # Use ID for tiebreaking
             sort_by_items.append(("_id", 1))
-            db_cursor = db_cursor.sort(sort_by_items)
 
             # Apply limit if specified
             limit = limit or DEFAULT_PAGE_LIMIT
-            db_cursor = db_cursor.limit(limit)
 
-            return [self._deserialize(doc) for doc in db_cursor]
+            def _fetch() -> builtins.list[dict[str, Any]]:
+                db_cursor = self.collection.find(query).sort(sort_by_items).limit(limit)
+                return list(db_cursor)
+
+            docs = await asyncio.to_thread(_fetch)
+            return [self._deserialize(doc) for doc in docs]
         except Exception as e:
             raise ServiceError(
                 message=f"Failed to find items by field with cursor in MongoDB: {e}",
@@ -745,7 +755,9 @@ class MongoDBCRUDRepository(CRUDRepository[T], Generic[T]):
                 except Exception:
                     pass
 
-            result = self.collection.delete_many({mongo_field_name: mongo_field_value})
+            result = await asyncio.to_thread(
+                self.collection.delete_many, {mongo_field_name: mongo_field_value}
+            )
             return result.deleted_count
         except Exception as e:
             raise ServiceError(


### PR DESCRIPTION
## Problem

A single AgentEx pod was getting bottlenecked on conversational user traffic, forcing us to scale to ~20 pods just for user testing. Two compounding causes:

1. **uvicorn was running with the default `--workers 1`** in production. One worker == one process == one event loop.
2. **The MongoDB adapter exposes `async def` methods but uses the synchronous `pymongo` driver.** Every Mongo call inside an `async def` blocks the event loop for the full DB round-trip, so even within a single worker the server serialized all in-flight Mongo-bound requests instead of multiplexing them.

Net effect: per-pod throughput on any conversational/persistence path was effectively 1 request at a time.

## Changes

**Tier 1 — `agentex/Dockerfile` (production stage)**
- Default `UVICORN_WORKERS=4`, runtime-overridable via env var.
- Dev stage keeps `--reload` and stays single-worker (the two are incompatible).

**Tier 2 — `agentex/src/adapters/crud_store/adapter_mongodb.py`**
- Every sync pymongo call site (`find`, `find_one`, `insert_one/many`, `update_one`, `delete_one/many`, and cursor materializations) now runs through `asyncio.to_thread`, so the I/O happens on the default thread pool while the event loop keeps serving other requests.
- Cursor methods (`list`, `find_by_field`, `find_by_field_with_cursor`) wrap the full chain (`.find(...).skip().limit().sort()` + `list(...)`) inside a closure passed to `to_thread`, since the chain is lazy and the I/O only fires on iteration/materialization.

## Verification

Built `agentex-test:workers-fix` locally, ran against the local Mongo:

| Endpoint | Path | workers=1 | workers=4 |
|---|---|---|---|
| `/readyz` | pure-async healthcheck | 668 req/s | 1525 req/s |
| `/agents` | hits new `to_thread`-wrapped `list()` | 256 req/s | 892 req/s |

Sustained load: 5000 reqs at concurrency=100 against `/agents` on workers=4: **0 failures**, 879 req/s, container memory ~1 GB (well under the 2 GB pod limit). Response bodies validated equal between worker counts.

Pre-fix the same `/agents` path was bound by event-loop blocking — single worker would have been substantially worse than the 256 req/s we now see.

## Risk

- `asyncio.to_thread` uses Python's default `ThreadPoolExecutor` (max 32 threads by Python 3.9+ default, scales with CPU count). With workers=4 the per-pod pool stays well within Mongo connection-pool defaults (100 by default in pymongo).
- Behavior is preserved: every adapter method is still `async def`, every call site is still awaited; only the synchronous block now executes off the event loop.
- The Dockerfile `dev` stage is unchanged in worker count because `--reload` doesn't compose with `--workers >1`.

## Rollback

Either revert the PR or set `UVICORN_WORKERS=1` at runtime (only undoes Tier 1; Tier 2 is functionally invisible at workers=1, just no longer blocks the loop).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds `--workers ${UVICORN_WORKERS}` (default 4) to the production uvicorn CMD via shell form with `exec` for correct signal propagation; dev `--reload` stage is intentionally left at 1 worker.
- Wraps every sync `pymongo` call site in `asyncio.to_thread`, unblocking the event loop for concurrent request handling within each worker process.
- The `find_by_field` helper uses `if skip:` to conditionally call `.skip()`, which is semantically equivalent to always calling `.skip(0)` since MongoDB treats a zero-skip as a no-op.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no logic regressions or new failure modes introduced.

Both changes are surgical and well-bounded. All pymongo call sites in the class are consistently wrapped in asyncio.to_thread; the retry decorator still intercepts transient errors because they propagate through the thread boundary unchanged. The Dockerfile shell-form CMD with exec ensures SIGTERM reaches uvicorn correctly. No P1 or P0 findings.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/Dockerfile | Adds ENV UVICORN_WORKERS=4 and rewrites the production CMD to shell form with exec, enabling multi-worker uvicorn. Dev stage (--reload) is correctly left unchanged. |
| agentex/src/adapters/crud_store/adapter_mongodb.py | All sync pymongo calls (insert_one, insert_many, find_one, find, update_one, delete_one, delete_many) wrapped in asyncio.to_thread; pagination helpers refactored into _fetch closures that capture local variables correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Uvicorn Worker (async)
    participant asyncio.to_thread
    participant ThreadPoolExecutor
    participant pymongo Collection
    participant MongoDB (Cosmos)

    Client->>Uvicorn Worker (async): HTTP Request
    Uvicorn Worker (async)->>asyncio.to_thread: await asyncio.to_thread(_fetch / op)
    asyncio.to_thread->>ThreadPoolExecutor: submit callable
    ThreadPoolExecutor->>pymongo Collection: insert_one / find / update_one / etc.
    pymongo Collection->>MongoDB (Cosmos): Sync network I/O (10-30ms)
    MongoDB (Cosmos)-->>pymongo Collection: Result
    pymongo Collection-->>ThreadPoolExecutor: Return
    ThreadPoolExecutor-->>asyncio.to_thread: Future resolved
    asyncio.to_thread-->>Uvicorn Worker (async): Awaitable result
    Note over Uvicorn Worker (async): Event loop free to serve other requests during I/O
    Uvicorn Worker (async)-->>Client: HTTP Response
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(server): offload sync pymongo calls ..."](https://github.com/scaleapi/scale-agentex/commit/e4203459d52a7956340b1157a2a37d08e7787903) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32118001)</sub>

<!-- /greptile_comment -->