### PR TITLE
fix(streams): snapshot SSE cursor once on entry to stop drop race

### DIFF
--- a/agentex/src/adapters/streams/adapter_redis.py
+++ b/agentex/src/adapters/streams/adapter_redis.py
@@ -151,6 +151,29 @@ class RedisStreamRepository(StreamRepository):
         except Exception as e:
             logger.error(f"Failed to send metrics: {e}", exc_info=e)
 
+    async def get_stream_tail_id(self, topic: str) -> str:
+        """
+        Snapshot the current tail of a Redis stream as a concrete entry ID.
+
+        The Redis "$" sentinel re-resolves to the stream tail on every XREAD
+        call, so any entry XADD'd in the gap between BLOCKing calls is
+        unreachable. Callers should resolve a stable cursor once on entry
+        via this helper and advance it forward from yielded entry IDs.
+
+        Returns the entry ID of the most recent stream entry, or "0-0" if
+        the stream is empty or does not exist — in which case the next
+        XREAD will return the first XADD whenever it lands.
+        """
+        try:
+            entries = await self.redis.xrevrange(name=topic, count=1)
+        except Exception as e:
+            logger.error(f"Error snapshotting tail of Redis stream {topic}: {e}")
+            raise
+        if not entries:
+            return "0-0"
+        tail_id, _fields = entries[0]
+        return tail_id.decode("utf-8") if isinstance(tail_id, bytes) else tail_id
+
     async def read_messages(
         self, topic: str, last_id: str, timeout_ms: int = 2000, count: int = 10
     ) -> AsyncIterator[tuple[str, dict[str, Any]]]:

--- a/agentex/src/adapters/streams/port.py
+++ b/agentex/src/adapters/streams/port.py
@@ -44,6 +44,23 @@ class StreamRepository(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    async def get_stream_tail_id(self, topic: str) -> str:
+        """
+        Resolve the current tail of a stream into a concrete entry ID
+        suitable for use as a stable cursor in subsequent read_messages calls.
+
+        Unlike the Redis "$" sentinel — which is re-resolved to the tail on
+        every XREAD call and so loses entries XADD'd between calls — this
+        returns a fixed ID at the moment of the call. Callers advance it
+        forward as entries arrive.
+
+        Returns a sentinel meaning "from the beginning" when the stream is
+        empty or does not yet exist, so the next read picks up the first
+        XADD whenever it lands.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     async def cleanup_stream(self, topic: str) -> None:
         """
         Clean up a stream.

--- a/agentex/src/domain/use_cases/streams_use_case.py
+++ b/agentex/src/domain/use_cases/streams_use_case.py
@@ -103,7 +103,12 @@ class StreamsUseCase:
         stream_topic = get_task_event_stream_topic(task_id=task_id)
         # Send initial connection data
         yield f"data: {TaskStreamConnectedEventEntity(type='connected', taskId=task_id).model_dump_json()}\n\n"
-        last_id = "$"  # Start with most recent messages only
+        # Snapshot the tail once on entry rather than passing "$" to every
+        # XREAD. "$" re-resolves to the current tail on each call, so any
+        # entry XADD'd in the gap between BLOCKing reads lands behind the
+        # new "$" and is unreachable — silently dropping deltas from
+        # fast-emitting agents.
+        last_id = await self.stream_repository.get_stream_tail_id(stream_topic)
         last_message_time = asyncio.get_running_loop().time()
         ping_interval = float(
             self.environment_variables.SSE_KEEPALIVE_PING_INTERVAL

--- a/agentex/tests/integration/test_task_stream.py
+++ b/agentex/tests/integration/test_task_stream.py
@@ -462,6 +462,87 @@ class TestTaskEventStream:
 
         print("✅ Stream connected event includes correct task ID")
 
+    async def test_stream_task_events_uses_snapshotted_cursor_not_dollar(
+        self, test_agent_and_task, streams_use_case
+    ):
+        """
+        Regression: stream_task_events must snapshot the Redis stream tail
+        on entry via get_stream_tail_id rather than passing "$" to xread.
+
+        With "$", each BLOCK call re-resolves the cursor to the current
+        stream tail. Any entry XADD'd in the inter-call gap (the ~100ms
+        sleep between empty BLOCKs) lands behind the new "$" and is
+        unreachable from the consumer — silently dropping deltas from
+        fast-emitting agents.
+
+        Spy on the repository to verify (a) get_stream_tail_id is called
+        once on entry, and (b) no call to read_messages ever receives "$"
+        as last_id. The behavioral assertion is deterministic — it
+        doesn't depend on race-window timing.
+        """
+        _agent, task = test_agent_and_task
+
+        repo = streams_use_case.stream_repository
+
+        tail_topic_calls: list[str] = []
+        original_get_tail = repo.get_stream_tail_id
+
+        async def spy_get_stream_tail_id(topic):
+            tail_topic_calls.append(topic)
+            return await original_get_tail(topic)
+
+        cursor_values: list[str] = []
+        original_read_messages = repo.read_messages
+
+        async def spy_read_messages(topic, last_id, timeout_ms=2000, count=10):
+            cursor_values.append(last_id)
+            async for item in original_read_messages(
+                topic, last_id, timeout_ms=timeout_ms, count=count
+            ):
+                yield item
+
+        repo.get_stream_tail_id = spy_get_stream_tail_id
+        repo.read_messages = spy_read_messages
+
+        try:
+
+            async def drive():
+                try:
+                    async for _ in streams_use_case.stream_task_events(task_id=task.id):
+                        pass
+                except asyncio.CancelledError:
+                    pass
+
+            drive_task = asyncio.create_task(drive())
+
+            # Wait past the first 2s BLOCK so a second read_messages call
+            # is issued — that's the call that would re-use "$" under the bug.
+            await asyncio.sleep(2.3)
+
+            drive_task.cancel()
+            try:
+                await drive_task
+            except asyncio.CancelledError:
+                pass
+
+            assert len(tail_topic_calls) == 1, (
+                "Expected exactly one get_stream_tail_id call on entry; "
+                f"got {len(tail_topic_calls)}: {tail_topic_calls}"
+            )
+
+            assert len(cursor_values) >= 2, (
+                "Expected >= 2 read_messages calls (one per BLOCK cycle); "
+                f"got {len(cursor_values)}: {cursor_values}"
+            )
+
+            assert "$" not in cursor_values, (
+                "stream_task_events passed '$' to read_messages — race-prone! "
+                f"cursors observed: {cursor_values}"
+            )
+        finally:
+            repo.get_stream_tail_id = original_get_tail
+            repo.read_messages = original_read_messages
+
     async def test_stream_sends_keepalive_pings_during_idle_periods(
         self, test_agent_and_task, streams_use_case
     ):

--- a/agentex/tests/integration/test_task_stream.py
+++ b/agentex/tests/integration/test_task_stream.py
@@ -462,85 +462,101 @@ class TestTaskEventStream:
 
         print("✅ Stream connected event includes correct task ID")
 
-    async def test_stream_task_events_uses_snapshotted_cursor_not_dollar(
+    async def test_event_xadded_in_inter_cycle_gap_is_delivered(
         self, test_agent_and_task, streams_use_case
     ):
         """
-        Regression: stream_task_events must snapshot the Redis stream tail
-        on entry via get_stream_tail_id rather than passing "$" to xread.
+        Deterministic symptom-level regression for the SSE drop bug.
 
-        With "$", each BLOCK call re-resolves the cursor to the current
-        stream tail. Any entry XADD'd in the inter-call gap (the ~100ms
-        sleep between empty BLOCKs) lands behind the new "$" and is
-        unreachable from the consumer — silently dropping deltas from
-        fast-emitting agents.
+        With last_id="$" the consumer re-resolves its cursor to the
+        current stream tail on every XREAD call. Any entry XADD'd in
+        the ~100ms gap between an empty BLOCK return and the next
+        BLOCK call lands with an ID equal to the new "$" — XREAD waits
+        for entries strictly greater, so the entry is unreachable from
+        this consumer forever.
 
-        Spy on the repository to verify (a) get_stream_tail_id is called
-        once on entry, and (b) no call to read_messages ever receives "$"
-        as last_id. The behavioral assertion is deterministic — it
-        doesn't depend on race-window timing.
+        Reproduction strategy (no race-window timing):
+        - Patch repo.read_messages so it signals an asyncio.Event the
+          instant the first BLOCK returns empty. asyncio scheduling
+          guarantees the consumer is then about to enter its 100ms
+          inter-cycle asyncio.sleep before yielding control back here.
+        - XADD a uniquely-tagged event synchronously on that signal.
+          asyncio yields control to the consumer's sleep, so the XADD
+          lands inside the gap.
+        - Wait for the second BLOCK cycle to elapse, then assert the
+          reader received the sentinel.
+
+        Under the bug this test fails (the XADD is lost); under the fix
+        it passes (snapshotted cursor advances past our entry).
         """
-        _agent, task = test_agent_and_task
+        from src.utils.stream_topics import get_task_event_stream_topic
 
+        _agent, task = test_agent_and_task
+        stream_topic = get_task_event_stream_topic(task_id=task.id)
         repo = streams_use_case.stream_repository
 
-        tail_topic_calls: list[str] = []
-        original_get_tail = repo.get_stream_tail_id
-
-        async def spy_get_stream_tail_id(topic):
-            tail_topic_calls.append(topic)
-            return await original_get_tail(topic)
-
-        cursor_values: list[str] = []
+        first_empty_block_returned = asyncio.Event()
+        call_count = 0
         original_read_messages = repo.read_messages
 
-        async def spy_read_messages(topic, last_id, timeout_ms=2000, count=10):
-            cursor_values.append(last_id)
+        async def patched_read_messages(topic, last_id, timeout_ms=2000, count=10):
+            nonlocal call_count
+            call_count += 1
+            my_idx = call_count
+            yielded = False
             async for item in original_read_messages(
                 topic, last_id, timeout_ms=timeout_ms, count=count
             ):
+                yielded = True
                 yield item
+            if my_idx == 1 and not yielded:
+                first_empty_block_returned.set()
 
-        repo.get_stream_tail_id = spy_get_stream_tail_id
-        repo.read_messages = spy_read_messages
+        repo.read_messages = patched_read_messages
 
-        try:
+        sentinel = "inter-cycle-gap-sentinel"
+        received_sentinels: list[str] = []
 
-            async def drive():
-                try:
-                    async for _ in streams_use_case.stream_task_events(task_id=task.id):
-                        pass
-                except asyncio.CancelledError:
-                    pass
-
-            drive_task = asyncio.create_task(drive())
-
-            # Wait past the first 2s BLOCK so a second read_messages call
-            # is issued — that's the call that would re-use "$" under the bug.
-            await asyncio.sleep(2.3)
-
-            drive_task.cancel()
+        async def reader():
             try:
-                await drive_task
+                async for event_data in streams_use_case.stream_task_events(
+                    task_id=task.id
+                ):
+                    if event_data.startswith("data: "):
+                        payload_str = event_data[6:].strip()
+                        if sentinel in payload_str:
+                            received_sentinels.append(payload_str)
             except asyncio.CancelledError:
                 pass
 
-            assert len(tail_topic_calls) == 1, (
-                "Expected exactly one get_stream_tail_id call on entry; "
-                f"got {len(tail_topic_calls)}: {tail_topic_calls}"
+        reader_task = asyncio.create_task(reader())
+
+        try:
+            await asyncio.wait_for(first_empty_block_returned.wait(), timeout=5)
+
+            # XADD synchronously inside the gap. Under the bug, the next
+            # xread re-resolves "$" to this entry's ID and waits for
+            # strictly greater entries — losing this one forever.
+            await repo.send_data(
+                stream_topic,
+                {"type": "error", "message": sentinel},
             )
 
-            assert len(cursor_values) >= 2, (
-                "Expected >= 2 read_messages calls (one per BLOCK cycle); "
-                f"got {len(cursor_values)}: {cursor_values}"
-            )
+            # Allow the second BLOCK cycle to complete.
+            await asyncio.sleep(2.5)
 
-            assert "$" not in cursor_values, (
-                "stream_task_events passed '$' to read_messages — race-prone! "
-                f"cursors observed: {cursor_values}"
+            assert received_sentinels, (
+                "Sentinel XADDed during the inter-cycle gap was not "
+                "delivered to the consumer. The stream cursor has "
+                "regressed to literal '$' — fast-emitting agents will "
+                "silently drop deltas."
             )
         finally:
-            repo.get_stream_tail_id = original_get_tail
+            reader_task.cancel()
+            try:
+                await reader_task
+            except asyncio.CancelledError:
+                pass
             repo.read_messages = original_read_messages
 
     async def test_stream_sends_keepalive_pings_during_idle_periods(


### PR DESCRIPTION
## Summary

`stream_task_events` in `streams_use_case.py` initialized `last_id = "$"` and only advanced it when `XREAD` returned entries. When `BLOCK` timed out empty, the outer loop re-issued `XREAD` with the literal `"$"` — Redis re-resolves `"$"` to the current stream tail at call time, so any entry `XADD`-ed in the ~100ms gap between the empty return and the next call landed *behind* the new `"$"` and was unreachable from the consumer.

For fast-emitting agents (token-level LLM streaming at multiple Hz, ~7 Hz bursts in practice), this silently dropped deltas. Slow agents were unaffected, which made the failure mode timing-dependent and easy to miss.

## What changed

- New repo helper `RedisStreamRepository.get_stream_tail_id(topic) -> str` that snapshots the current tail via `XREVRANGE topic + - COUNT 1`, returning `"0-0"` for empty/missing streams. Also added to the `StreamRepository` port so any future implementation must honour the cursor-snapshot contract.
- `stream_task_events` now calls `get_stream_tail_id` once on entry and uses that as the starting `last_id`. The existing loop already advances `last_id` correctly from yielded entry IDs, so this is the only change needed.

## Out of scope

These are deliberate non-changes — happy to follow up in a separate PR if there's appetite:

- **Switching to `XREADGROUP` with per-subscriber consumer groups.** At-least-once + PEL recovery + replica fan-out is the principled fix; the cursor snapshot is the minimal correct fix. Consumer-group lifecycle (create, ack, expire, clean up) is a bigger architectural change.
- **Exposing `Last-Event-ID` / `since=` on the endpoint and SDK.** Lets reconnecting SSE clients resume across disconnects without losing the gap. Requires an API change.

## Test plan

New integration test `test_event_xadded_in_inter_cycle_gap_is_delivered` — **deterministic symptom-level reproduction**, not race-window timing:

- Patches `repo.read_messages` to set an `asyncio.Event` the instant the first BLOCK returns empty. asyncio scheduling guarantees the consumer is then entering its 100ms inter-cycle `asyncio.sleep` before yielding back to the test.
- Test XADDs a uniquely-tagged event synchronously on the signal — guaranteed to land inside the gap.
- Waits 2.5s for the second BLOCK cycle, then asserts the reader received the sentinel.

Under the bug: the next `XREAD $` re-resolves `$` to the sentinel's ID and waits for strictly-greater entries — the sentinel is lost forever, test fails (verified locally: `AssertionError: assert []`).

Under the fix: snapshotted cursor stays put across the empty cycle; the sentinel has an ID > snapshot and is delivered.

- [x] New regression test passes against the fix.
- [x] New regression test FAILS against the unfixed code (verified by reverting the one-line change and re-running).
- [x] All 6 existing tests in `test_task_stream.py` still pass with the fix.
- [x] `ruff check` and `ruff format --check` clean on changed files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent message-drop race in `stream_task_events` where the Redis `"$"` cursor sentinel was re-resolved to the stream tail on every `XREAD` call, causing entries `XADD`ed during the ~100ms gap between empty-BLOCK returns and the next call to be permanently unreachable. The fix snapshots the tail once on entry via a new `XREVRANGE`-backed helper.

- **New `get_stream_tail_id` method** on `RedisStreamRepository` (and the `StreamRepository` port) snapshots the stream tail using `XREVRANGE topic + - COUNT 1`, returning `"0-0"` for empty/non-existent streams so the first future `XADD` is always captured.
- **`stream_task_events`** now calls `get_stream_tail_id` once before the read loop; the existing loop already advances `last_id` from yielded entry IDs, so no further changes to the loop body are needed.
- **Regression test** `test_event_xadded_in_inter_cycle_gap_is_delivered` patches `read_messages` to deterministically fire an event at the precise inter-cycle gap, `XADD`s a sentinel there, and asserts delivery — confirmed to fail against the unfixed code.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted one-call change to snapshot the stream cursor, with a deterministic regression test confirming the fix and all existing tests still passing.

The change is minimal and surgical: a single `await` on entry to `stream_task_events` replaces the problematic `"$"` literal. The new `get_stream_tail_id` helper is straightforward (`XREVRANGE COUNT 1`), handles the bytes/str duality from the Redis client, and falls back safely to `"0-0"` for empty streams. The regression test is deterministic and was confirmed to fail against the original code. No existing loop logic is touched.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/adapters/streams/adapter_redis.py | Adds `get_stream_tail_id` using `XREVRANGE count=1` to snapshot the current stream tail; handles both bytes and str return types correctly and returns `"0-0"` for empty/non-existent streams. |
| agentex/src/adapters/streams/port.py | Adds `get_stream_tail_id` as an abstract method to the `StreamRepository` port, enforcing the cursor-snapshot contract on any future implementations. |
| agentex/src/domain/use_cases/streams_use_case.py | Replaces the `last_id = "$"` assignment with a one-time `get_stream_tail_id` call before the read loop, eliminating the cursor re-resolution race on each empty-BLOCK cycle. |
| agentex/tests/integration/test_task_stream.py | Adds `test_event_xadded_in_inter_cycle_gap_is_delivered`, a deterministic regression test that patches `read_messages` to signal after the first empty BLOCK, XADDs a sentinel in that gap, and asserts delivery. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as SSE Client
    participant UC as StreamsUseCase
    participant Repo as RedisStreamRepository
    participant Redis as Redis

    Client->>UC: stream_task_events(task_id)
    UC->>Client: yield connected event
    UC->>Repo: get_stream_tail_id(stream_topic)
    Repo->>Redis: XREVRANGE topic + - COUNT 1
    Redis-->>Repo: [(tail_id, fields)] or []
    Repo-->>UC: tail_id (or "0-0" if empty)
    Note over UC: last_id = tail_id (stable cursor)

    loop Read loop
        UC->>Repo: read_messages(topic, last_id)
        Repo->>Redis: XREAD BLOCK 2000ms STREAMS topic last_id
        alt Messages available
            Redis-->>Repo: [(msg_id, fields), ...]
            Repo-->>UC: yield (msg_id, data)
            UC->>Client: yield SSE event
            Note over UC: last_id = msg_id (advanced)
        else Timeout (empty)
            Redis-->>Repo: null
            Note over UC: last_id unchanged (stable — no re-resolve of "$")
            UC->>Client: yield :ping (if interval elapsed)
        end
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(streams): make SSE drop test determ..."](https://github.com/scaleapi/scale-agentex/commit/2900c04508ca30babb5bfed8869d1cb0ae0d4fb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32392969)</sub>

<!-- /greptile_comment -->