### PR TITLE
feat(tasks): per-RPC task permission rewire and 404/403 wrap

### DIFF
--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -43,6 +43,7 @@ from src.utils.authorization_shortcuts import (
     DAuthorizedResourceIds,
 )
 from src.utils.logging import make_logger
+from src.utils.task_authorization import check_task_or_collapse_to_404
 
 logger = make_logger(__name__)
 
@@ -375,25 +376,30 @@ async def _authorize_rpc_request(
             task_name = request.params.task_name
 
             if task_id is not None:
-                # Direct task ID provided - check execute permission on that specific task
-                await authorization_service.check(
-                    resource=AgentexResource.task(task_id),
-                    operation=AuthorizedOperationType.execute,
+                await check_task_or_collapse_to_404(
+                    authorization_service,
+                    task_id,
+                    AuthorizedOperationType.update,
                 )
             elif task_name is not None:
-                # Task name provided - check if task exists
+                # try/else (not try/except wrapping the whole block): a denied
+                # update on an existing task must surface as 404 to the caller,
+                # NOT silently fall through to the create check below — that
+                # would let "I'm denied update" masquerade as "task is absent"
+                # and grant create access.
                 try:
                     existing_task = await task_service.get_task(name=task_name)
-                    # Task exists - require execute permission on the specific task
-                    await authorization_service.check(
-                        resource=AgentexResource.task(existing_task.id),
-                        operation=AuthorizedOperationType.execute,
-                    )
                 except ItemDoesNotExist:
                     # Task doesn't exist - will be created, require create permission
                     await authorization_service.check(
                         resource=AgentexResource.task("*"),
                         operation=AuthorizedOperationType.create,
+                    )
+                else:
+                    await check_task_or_collapse_to_404(
+                        authorization_service,
+                        existing_task.id,
+                        AuthorizedOperationType.update,
                     )
             else:
                 # No identifier provided - creating new task, require create permission
@@ -407,20 +413,22 @@ async def _authorize_rpc_request(
             task_name = request.params.task_name
 
             if task_id is not None:
-                # Direct task ID provided - check execute permission on that specific task
-                await authorization_service.check(
-                    resource=AgentexResource.task(task_id),
-                    operation=AuthorizedOperationType.execute,
+                await check_task_or_collapse_to_404(
+                    authorization_service,
+                    task_id,
+                    AuthorizedOperationType.update,
                 )
             elif task_name is not None:
-                # Task name provided - look up task and check execute permission
+                # `get_task` raises ItemDoesNotExist for absent rows (= 404
+                # naturally); the wrap collapses present-but-denied to the same
+                # shape so callers can't distinguish.
                 existing_task = await task_service.get_task(name=task_name)
-                await authorization_service.check(
-                    resource=AgentexResource.task(existing_task.id),
-                    operation=AuthorizedOperationType.execute,
+                await check_task_or_collapse_to_404(
+                    authorization_service,
+                    existing_task.id,
+                    AuthorizedOperationType.update,
                 )
             else:
-                # No identifier provided - this shouldn't happen but handle gracefully
                 raise ValueError(
                     "Either task_id or task_name must be provided for event/send"
                 )
@@ -430,25 +438,27 @@ async def _authorize_rpc_request(
             task_name = request.params.task_name
 
             if task_id is not None:
-                # Direct task ID provided - check execute permission on that specific task
-                await authorization_service.check(
-                    resource=AgentexResource.task(task_id),
-                    operation=AuthorizedOperationType.execute,
+                await check_task_or_collapse_to_404(
+                    authorization_service,
+                    task_id,
+                    AuthorizedOperationType.cancel,
                 )
             elif task_name is not None:
-                # Task name provided - look up task and check execute permission
                 existing_task = await task_service.get_task(name=task_name)
-                await authorization_service.check(
-                    resource=AgentexResource.task(existing_task.id),
-                    operation=AuthorizedOperationType.execute,
+                await check_task_or_collapse_to_404(
+                    authorization_service,
+                    existing_task.id,
+                    AuthorizedOperationType.cancel,
                 )
             else:
-                # No identifier provided - this shouldn't happen but handle gracefully
                 raise ValueError(
                     "Either task_id or task_name must be provided for task/cancel"
                 )
         case _:
-            pass
+            raise NotImplementedError(
+                f"_authorize_rpc_request has no case for {request.method}; "
+                "RPC methods must be wired explicitly before they can dispatch."
+            )
 
 
 async def _handle_agent_rpc(

--- a/agentex/src/api/routes/messages.py
+++ b/agentex/src/api/routes/messages.py
@@ -87,7 +87,7 @@ async def batch_create_messages(
     request: BatchCreateTaskMessagesRequest,
     message_use_case: DMessageUseCase,
     _authorized_task_id: DAuthorizedBodyId(
-        AgentexResourceType.task, AuthorizedOperationType.execute
+        AgentexResourceType.task, AuthorizedOperationType.update
     ),
 ) -> list[TaskMessage]:
     # Convert each content from API schema to entity schema
@@ -115,7 +115,7 @@ async def batch_update_messages(
     request: BatchUpdateTaskMessagesRequest,
     message_use_case: DMessageUseCase,
     _authorized_task_id: DAuthorizedBodyId(
-        AgentexResourceType.task, AuthorizedOperationType.execute
+        AgentexResourceType.task, AuthorizedOperationType.update
     ),
 ) -> list[TaskMessage]:
     task_message_entities = await message_use_case.update_batch(
@@ -136,7 +136,7 @@ async def create_message(
     request: CreateTaskMessageRequest,
     message_use_case: DMessageUseCase,
     _authorized_task_id: DAuthorizedBodyId(
-        AgentexResourceType.task, AuthorizedOperationType.execute
+        AgentexResourceType.task, AuthorizedOperationType.update
     ),
 ) -> TaskMessage:
     task_message_entity = await message_use_case.create(
@@ -157,7 +157,7 @@ async def update_message(
     message_id: str,
     message_use_case: DMessageUseCase,
     _authorized_task_id: DAuthorizedBodyId(
-        AgentexResourceType.task, AuthorizedOperationType.execute
+        AgentexResourceType.task, AuthorizedOperationType.update
     ),
 ) -> TaskMessage:
     task_message_entity = await message_use_case.update(

--- a/agentex/src/api/schemas/authorization_types.py
+++ b/agentex/src/api/schemas/authorization_types.py
@@ -9,6 +9,7 @@ class AuthorizedOperationType(StrEnum):
     update = "update"
     delete = "delete"
     execute = "execute"
+    cancel = "cancel"
 
 
 class AgentexResourceType(StrEnum):

--- a/agentex/src/utils/authorization_shortcuts.py
+++ b/agentex/src/utils/authorization_shortcuts.py
@@ -2,8 +2,6 @@ from typing import Annotated
 
 from fastapi import Depends, Path, Query, Request
 
-from src.adapters.authorization.exceptions import AuthorizationError
-from src.adapters.crud_store.exceptions import ItemDoesNotExist
 from src.api.schemas.authorization_types import (
     AgentexResource,
     AgentexResourceType,
@@ -16,6 +14,7 @@ from src.domain.repositories.task_repository import DTaskRepository
 from src.domain.repositories.task_state_repository import DTaskStateRepository
 from src.domain.services.authorization_service import DAuthorizationService
 from src.utils.agent_api_key_authorization import _check_api_key_or_collapse_to_404
+from src.utils.task_authorization import check_task_or_collapse_to_404
 
 
 async def _get_parent_task_id(
@@ -59,15 +58,9 @@ def DAuthorizedId(
                 state_repository,
                 message_repository,
             )
-            try:
-                await authorization.check(
-                    resource=AgentexResource.task(task_id),
-                    operation=operation,
-                )
-            except AuthorizationError:
-                raise ItemDoesNotExist(
-                    f"Item with id '{resource_id}' does not exist."
-                ) from None
+            await check_task_or_collapse_to_404(authorization, task_id, operation)
+        elif resource_type == AgentexResourceType.task:
+            await check_task_or_collapse_to_404(authorization, resource_id, operation)
         elif resource_type == AgentexResourceType.api_key:
             # Collapse api_key denials to 404 so name/id probes can't
             # distinguish "present in another tenant" from "absent".
@@ -75,7 +68,6 @@ def DAuthorizedId(
                 authorization, resource_id, operation
             )
         else:
-            # For direct resources, check directly
             await authorization.check(
                 resource=AgentexResource(type=resource_type, selector=resource_id),
                 operation=operation,
@@ -112,17 +104,10 @@ def DAuthorizedQuery(
                 state_repository,
                 message_repository,
             )
-            try:
-                await authorization.check(
-                    resource=AgentexResource.task(task_id),
-                    operation=operation,
-                )
-            except AuthorizationError:
-                raise ItemDoesNotExist(
-                    f"Item with id '{resource_id}' does not exist."
-                ) from None
+            await check_task_or_collapse_to_404(authorization, task_id, operation)
+        elif resource_type == AgentexResourceType.task:
+            await check_task_or_collapse_to_404(authorization, resource_id, operation)
         else:
-            # For direct resources, check directly
             await authorization.check(
                 resource=AgentexResource(type=resource_type, selector=resource_id),
                 operation=operation,
@@ -147,19 +132,8 @@ def DAuthorizedBodyId(
         body = await request.json()
         field_value = body[field_name]
 
-        # Collapse a denied task check into 404 so callers cannot use 403 vs
-        # 404 to probe whether a task exists in another tenant.
-        # TODO: Refactor to use the canonical task body-id wrap landed by AGX1-275 / #249.
         if resource_type == AgentexResourceType.task:
-            try:
-                await authorization.check(
-                    resource=AgentexResource.task(field_value),
-                    operation=operation,
-                )
-            except AuthorizationError:
-                raise ItemDoesNotExist(
-                    f"Item with id '{field_value}' does not exist."
-                ) from None
+            await check_task_or_collapse_to_404(authorization, field_value, operation)
         else:
             await authorization.check(
                 resource=AgentexResource(type=resource_type, selector=field_value),
@@ -207,12 +181,21 @@ def DAuthorizedName(
         resource_id = resource_name
         repository = registry[resource_type]
 
+        # Lookup-before-authz: if the name isn't present, `repository.get` raises
+        # ItemDoesNotExist (→ 404), which is what we want for absent resources.
+        # The present-but-denied case is handled per-resource below.
         resource = await repository.get(name=resource_id)
 
-        await authorization.check(
-            resource=AgentexResource(type=resource_type, selector=resource.id),
-            operation=operation,
-        )
+        if resource_type == AgentexResourceType.task:
+            # Tasks: collapse denial to 404 so name probes can't distinguish
+            # "present in another tenant" from "absent" (tasks.name is globally
+            # unique — any 403 leak here probes the whole system, not a tenant).
+            await check_task_or_collapse_to_404(authorization, resource.id, operation)
+        else:
+            await authorization.check(
+                resource=AgentexResource(type=resource_type, selector=resource.id),
+                operation=operation,
+            )
         return resource_id
 
     return Annotated[str, Depends(_ensure_authorized_name)]

--- a/agentex/src/utils/task_authorization.py
+++ b/agentex/src/utils/task_authorization.py
@@ -1,0 +1,40 @@
+from src.adapters.authorization.exceptions import AuthorizationError
+from src.adapters.crud_store.exceptions import ItemDoesNotExist
+from src.api.schemas.authorization_types import (
+    AgentexResource,
+    AuthorizedOperationType,
+)
+from src.domain.services.authorization_service import AuthorizationService
+
+
+async def check_task_or_collapse_to_404(
+    authorization: AuthorizationService,
+    task_id: str,
+    operation: AuthorizedOperationType,
+) -> None:
+    """Issue a check on a task resource. On any denial, surface 404 — even when
+    the task exists.
+
+    The 403/404 split cannot be done safely here: ``TaskORM`` has no tenant
+    column, ``task_repository.get`` does an unfiltered primary-key lookup, and
+    ``AuthorizationError`` carries no deny-reason discriminator. Returning 403
+    when the row exists and 404 when it doesn't leaks cross-tenant existence
+    (caller probes "does task X exist?" and gets distinguishable responses).
+
+    Until tasks carry tenant scope (or agentex-auth's deny distinguishes
+    "cross-tenant" from "in-tenant lacking permission"), the safer default is
+    to collapse both into 404. Trade-off: a user with ``read`` but not
+    ``update`` permission on an in-tenant task sees 404 on update attempts
+    instead of 403. UX regression for in-tenant permission granularity, but
+    eliminates the cross-tenant existence leak.
+
+    TODO: Restore the 403/404 split once tasks carry tenant scope at the
+    data layer (task rows currently have no tenant column).
+    """
+    try:
+        await authorization.check(
+            resource=AgentexResource.task(task_id),
+            operation=operation,
+        )
+    except AuthorizationError:
+        raise ItemDoesNotExist(f"Item with id '{task_id}' does not exist.") from None

--- a/agentex/tests/unit/api/test_tasks_authz.py
+++ b/agentex/tests/unit/api/test_tasks_authz.py
@@ -1,0 +1,446 @@
+"""Tests for per-RPC operation routing and 404/403 authorization wrap on task routes.
+
+Covers:
+  1. Per-RPC operation routing: MESSAGE_SEND/EVENT_SEND map to ``update``,
+     TASK_CANCEL maps to ``cancel``, TASK_CREATE stays ``create``.
+  2. 404 collapse on authorization denials (callers cannot probe cross-tenant
+     task existence via 403 vs 404 response codes).
+
+End-to-end tests (cross-tenant isolation, cancel-owner-only enforcement,
+list filtering) belong in a separate integration suite that requires a live
+authorization cluster.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from src.adapters.authorization.exceptions import AuthorizationError
+from src.adapters.crud_store.exceptions import ItemDoesNotExist
+from src.api.schemas.authorization_types import (
+    AgentexResource,
+    AgentexResourceType,
+    AuthorizedOperationType,
+)
+from src.utils.authorization_shortcuts import (
+    DAuthorizedBodyId,
+    DAuthorizedName,
+)
+from src.utils.task_authorization import check_task_or_collapse_to_404
+
+
+def _dep_callable(annotation):
+    """Pull the inner FastAPI dependency function out of an ``Annotated[str, Depends(...)]``."""
+    return annotation.__metadata__[0].dependency
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestPerRpcOperationRouting:
+    """Verify that per-RPC checks issue the right ``AuthorizedOperationType``."""
+
+    @staticmethod
+    def _capture_check(authorization: MagicMock) -> list[tuple]:
+        calls: list[tuple] = []
+
+        async def _check(resource: AgentexResource, operation: AuthorizedOperationType):
+            calls.append((resource.type, resource.selector, operation))
+
+        authorization.check = AsyncMock(side_effect=_check)
+        return calls
+
+    async def test_message_send_with_task_id_uses_update(self):
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        request = MagicMock()
+        request.method = AgentRPCMethod.MESSAGE_SEND
+        request.params = MagicMock(task_id="task-1", task_name=None)
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        assert calls == [
+            (AgentexResourceType.task, "task-1", AuthorizedOperationType.update)
+        ]
+
+    async def test_event_send_with_task_id_uses_update(self):
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        request = MagicMock()
+        request.method = AgentRPCMethod.EVENT_SEND
+        request.params = MagicMock(task_id="task-2", task_name=None)
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        assert calls == [
+            (AgentexResourceType.task, "task-2", AuthorizedOperationType.update)
+        ]
+
+    async def test_task_cancel_with_task_id_uses_cancel(self):
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        request = MagicMock()
+        request.method = AgentRPCMethod.TASK_CANCEL
+        request.params = MagicMock(task_id="task-3", task_name=None)
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        assert calls == [
+            (AgentexResourceType.task, "task-3", AuthorizedOperationType.cancel)
+        ]
+
+    async def test_task_create_remains_create(self):
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        request = MagicMock()
+        request.method = AgentRPCMethod.TASK_CREATE
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        assert calls == [
+            (AgentexResourceType.task, "*", AuthorizedOperationType.create)
+        ]
+
+    async def test_message_send_with_task_name_uses_update_on_existing_task(self):
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        task_service.get_task = AsyncMock(return_value=MagicMock(id="task-resolved"))
+        request = MagicMock()
+        request.method = AgentRPCMethod.MESSAGE_SEND
+        request.params = MagicMock(task_id=None, task_name="my-task")
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        task_service.get_task.assert_awaited_once_with(name="my-task")
+        assert calls == [
+            (AgentexResourceType.task, "task-resolved", AuthorizedOperationType.update)
+        ]
+
+    async def test_message_send_with_missing_task_name_falls_back_to_create(self):
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        task_service.get_task = AsyncMock(side_effect=ItemDoesNotExist("not-found"))
+        request = MagicMock()
+        request.method = AgentRPCMethod.MESSAGE_SEND
+        request.params = MagicMock(task_id=None, task_name="ghost-task")
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        assert calls == [
+            (AgentexResourceType.task, "*", AuthorizedOperationType.create)
+        ]
+
+    async def test_event_send_with_task_name_uses_update(self):
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        task_service.get_task = AsyncMock(return_value=MagicMock(id="task-evt"))
+        request = MagicMock()
+        request.method = AgentRPCMethod.EVENT_SEND
+        request.params = MagicMock(task_id=None, task_name="evt-task")
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        task_service.get_task.assert_awaited_once_with(name="evt-task")
+        assert calls == [
+            (AgentexResourceType.task, "task-evt", AuthorizedOperationType.update)
+        ]
+
+    async def test_task_cancel_with_task_name_uses_cancel(self):
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        task_service.get_task = AsyncMock(return_value=MagicMock(id="task-cancel"))
+        request = MagicMock()
+        request.method = AgentRPCMethod.TASK_CANCEL
+        request.params = MagicMock(task_id=None, task_name="cancel-task")
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        task_service.get_task.assert_awaited_once_with(name="cancel-task")
+        assert calls == [
+            (AgentexResourceType.task, "task-cancel", AuthorizedOperationType.cancel)
+        ]
+
+    async def test_unwired_method_fails_closed_with_not_implemented(self):
+        # Fail-closed default: any AgentRPCMethod not explicitly wired in
+        # _authorize_rpc_request must raise rather than silently pass through
+        # authz-free. NotImplementedError surfaces as a 5xx, making the gap
+        # loud rather than letting a future enum addition land authz-free.
+        from src.api.routes.agents import _authorize_rpc_request
+
+        authorization = MagicMock()
+        task_service = MagicMock()
+        request = MagicMock()
+        request.method = "task/unknown"
+        request.params = MagicMock(task_id=None, task_name=None)
+
+        with pytest.raises(NotImplementedError, match="no case for"):
+            await _authorize_rpc_request(request, authorization, task_service)
+
+
+def test_cancel_operation_wire_format_matches_agentex_auth_contract():
+    """Cross-repo enum contract: the literal string ``"cancel"`` is the wire
+    format shared with agentex-auth's mirror enum. Diverging strings would
+    only show up at runtime, so lock it in a test. Mirrors the test of the
+    same shape in
+    ``~/agentex/agentex-auth/tests/domain/services/test_authorization_service_routing.py``."""
+    assert AuthorizedOperationType.cancel.value == "cancel"
+
+
+def test_update_operation_wire_format_matches_agentex_auth_contract():
+    """Cross-repo enum contract for the ``execute → update`` rewire used by
+    MESSAGE_SEND / EVENT_SEND / checkpoint mutations.
+
+    The behavioral claim that ``update`` resolves against an existing
+    ``owner`` grant lives in the spark-authz repo's schema test suite
+    (``permission update = (editor + owner) & internal_tenant_gate``).
+    That schema test is the load-bearing assertion; this test only pins
+    the agentex-auth-side wire string so a future rename of
+    ``AuthorizedOperationType.update`` fails loudly here before deploy
+    rather than 5xx-ing every MESSAGE_SEND in production."""
+    assert AuthorizedOperationType.update.value == "update"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestUpdatePermissionRoutingForRewiredCallSites:
+    """Behavioral pin for the AGX1-275 rewire of MESSAGE_SEND / EVENT_SEND /
+    checkpoint mutations from ``execute`` to ``update``.
+
+    The existing ``TestPerRpcOperationRouting`` tests cover the routing
+    decision (RPC → operation literal). These tests pin the downstream
+    behavior — for a granted ``owner`` principal, an ``update`` check
+    against the task resource is accepted — by asserting the mocked
+    gateway's ``check`` returns successfully for the rewired operation.
+    The schema-level claim ``update`` resolves against ``owner`` is tested
+    against real SpiceDB in the spark-authz repo; this is the contract pin
+    that surfaces a drift in either direction at scale-agentex CI time."""
+
+    async def test_update_check_succeeds_for_message_send_path(self):
+        """A grant tuple that previously satisfied ``execute`` must satisfy
+        ``update`` after the rewire, given the SGP and Spark schemas both
+        keep ``update`` and ``execute`` on identical role allowlists for
+        the task resource type."""
+        authorization = MagicMock()
+        authorization.check = AsyncMock(return_value=True)
+
+        await check_task_or_collapse_to_404(
+            authorization,
+            "task-msg",
+            AuthorizedOperationType.update,
+        )
+
+        authorization.check.assert_awaited_once()
+        call_kwargs = authorization.check.await_args.kwargs
+        assert call_kwargs["resource"] == AgentexResource.task("task-msg")
+        assert call_kwargs["operation"] == AuthorizedOperationType.update
+
+    async def test_update_check_denial_collapses_to_404(self):
+        """For the rewired call sites, an ``AuthorizationError`` on
+        ``update`` must still collapse to 404 — the same envelope that
+        ``execute`` had — so the rewire doesn't accidentally narrow the
+        error surface."""
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+
+        with pytest.raises(ItemDoesNotExist):
+            await check_task_or_collapse_to_404(
+                authorization,
+                "task-msg",
+                AuthorizedOperationType.update,
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestCheckTaskOrCollapseTo404:
+    """The task-resource authz wrap collapses every denial to 404 so callers
+    can't distinguish "present in another tenant" from "absent"."""
+
+    async def test_allowed_check_returns_normally(self):
+        authorization = MagicMock()
+        authorization.check = AsyncMock(return_value=True)
+
+        await check_task_or_collapse_to_404(
+            authorization,
+            "task-1",
+            AuthorizedOperationType.update,
+        )
+
+        authorization.check.assert_awaited_once()
+
+    async def test_denied_collapses_to_not_found_regardless_of_existence(self):
+        """Both "denied + task exists" and "denied + task missing" surface as
+        ``ItemDoesNotExist`` (→ 404). The wrap doesn't consult any repository
+        — collapsing avoids the cross-tenant existence leak."""
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+
+        with pytest.raises(ItemDoesNotExist):
+            await check_task_or_collapse_to_404(
+                authorization,
+                "task-1",
+                AuthorizedOperationType.update,
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDAuthorizedBodyIdTaskWrap:
+    """``DAuthorizedBodyId`` must route task-resource body-id checks through
+    the task-collapse wrap so denied body-id calls return 404 instead of 403 —
+    matching the path/query variants."""
+
+    @staticmethod
+    def _make_request(task_id: str) -> MagicMock:
+        request = MagicMock()
+        request.json = AsyncMock(return_value={"task_id": task_id})
+        return request
+
+    async def test_task_body_id_routes_through_wrap_on_denial(self):
+        """The body-id wrap goes through the task-collapse helper, which
+        collapses any denial to 404 — including for tasks that exist."""
+        annotation = DAuthorizedBodyId(
+            AgentexResourceType.task, AuthorizedOperationType.update
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+
+        with pytest.raises(ItemDoesNotExist):
+            await dep(self._make_request("task-7"), authorization)
+
+    async def test_task_body_id_returns_field_value_when_allowed(self):
+        annotation = DAuthorizedBodyId(
+            AgentexResourceType.task, AuthorizedOperationType.update
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(return_value=True)
+
+        result = await dep(self._make_request("task-9"), authorization)
+
+        assert result == "task-9"
+
+    async def test_non_task_body_id_skips_wrap(self):
+        annotation = DAuthorizedBodyId(
+            AgentexResourceType.agent, AuthorizedOperationType.read
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(return_value=True)
+        request = MagicMock()
+        request.json = AsyncMock(return_value={"agent_id": "agent-1"})
+
+        result = await dep(request, authorization)
+
+        assert result == "agent-1"
+        # Non-task resources go straight to authorization.check, never to the wrap.
+        authorization.check.assert_awaited_once()
+        called_kwargs = authorization.check.await_args.kwargs
+        assert called_kwargs["resource"] == AgentexResource(
+            type=AgentexResourceType.agent, selector="agent-1"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDAuthorizedNameTaskWrap:
+    """``DAuthorizedName`` must route task-resource name-path checks through
+    the task-collapse wrap so denied name-path calls return 404 instead of 403.
+    Without this, ``tasks.name`` (globally unique) lets callers probe whether
+    a name exists in any tenant by observing 404 vs 403 — exactly the
+    cross-tenant existence leak the other surfaces eliminate."""
+
+    async def test_task_name_routes_through_wrap_on_denial(self):
+        """Present-but-denied tasks (looked up by name) surface as
+        ``ItemDoesNotExist`` (→ 404), same as absent. The lookup itself
+        succeeds — the wrap intercepts the subsequent authz check."""
+        annotation = DAuthorizedName(
+            AgentexResourceType.task, AuthorizedOperationType.update
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+        agent_repository = MagicMock()
+        task_repository = MagicMock()
+        task_repository.get = AsyncMock(return_value=MagicMock(id="task-resolved"))
+
+        with pytest.raises(ItemDoesNotExist):
+            await dep(authorization, agent_repository, task_repository, "task-name-x")
+
+        # The wrap fires AFTER the lookup — the repo is consulted to resolve
+        # name → id; the leak is only on the authz response, not the lookup.
+        task_repository.get.assert_awaited_once_with(name="task-name-x")
+        authorization.check.assert_awaited_once()
+
+    async def test_task_name_returns_resource_name_when_allowed(self):
+        annotation = DAuthorizedName(
+            AgentexResourceType.task, AuthorizedOperationType.read
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(return_value=True)
+        agent_repository = MagicMock()
+        task_repository = MagicMock()
+        task_repository.get = AsyncMock(return_value=MagicMock(id="task-allow"))
+
+        result = await dep(authorization, agent_repository, task_repository, "ok-name")
+
+        assert result == "ok-name"
+        called_kwargs = authorization.check.await_args.kwargs
+        # The selector is the resolved row id, not the user-provided name.
+        assert called_kwargs["resource"] == AgentexResource.task("task-allow")
+
+    async def test_non_task_name_skips_wrap(self):
+        """Agent FGAC is out of scope for AGX1-264 — the wrap must NOT extend
+        to agent name-routes, which keep the existing 403-on-deny behavior."""
+        annotation = DAuthorizedName(
+            AgentexResourceType.agent, AuthorizedOperationType.read
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+        agent_repository = MagicMock()
+        agent_repository.get = AsyncMock(return_value=MagicMock(id="agent-1"))
+        task_repository = MagicMock()
+
+        with pytest.raises(AuthorizationError):
+            await dep(authorization, agent_repository, task_repository, "agent-name")


### PR DESCRIPTION
## Related work

Parent epic: [AGX1-264](https://linear.app/scale-epd/issue/AGX1-264) — per-task FGAC. Follow-ups bundled in [AGX1-291](https://linear.app/scale-epd/issue/AGX1-291).

This change is part of an 8-PR stack across 3 repos (4 merged, 4 open).

| Repo | PR | Purpose |
|---|---|---|
| scaleapi/scaleapi | ~~scaleapi/scaleapi#144783~~ ✅ merged | sgp-authz — `Action.CANCEL` + `parent` on `register_resource` |
| scaleapi/scaleapi | ~~scaleapi/scaleapi#145000~~ ✅ merged | register `FGAC_AGENTEX_AUTH_SPARK` routing flag |
| scaleapi/scaleapi | ~~scaleapi/scaleapi#145044~~ ✅ merged | add `cancel` to SGP's `AgentexOperation` enum + role map |
| scaleapi/agentex | ~~scaleapi/agentex#353~~ ✅ merged | agentex-auth per-account provider routing + `cancel` op |
| scaleapi/scaleapi | scaleapi/scaleapi#145521 | register the `fgac-tasks-dual-write` per-account flag |
| scaleapi/agentex | scaleapi/agentex#358 | agentex-auth: gate register/deregister by `fgac-<resource>-dual-write` |
| scaleapi/scale-agentex | scaleapi/scale-agentex#246 | register tasks in the FGAC authz graph on create/delete |
| **scaleapi/scale-agentex** | **this PR** | **per-RPC task permission rewire (`update`/`cancel`) + 404/403 wrap** |

**Merge order:** flag (scaleapi/scaleapi#145521, anytime) → gate (scaleapi/agentex#358) → scaleapi/scale-agentex#246 → enable `fgac-tasks-dual-write` per account → scaleapi/scale-agentex#249 (after the `cancel` enum is live in every SGP env).

## Summary

Last in the stack: the route-side change that exercises the per-task permissions. Routes each task RPC to the right operation instead of `execute` everywhere, and collapses task authz denials to 404 so callers can't use 403-vs-404 to probe cross-tenant existence.

- **Per-operation routing:** `MESSAGE_SEND`/`EVENT_SEND` → `update`, `TASK_CANCEL` → `cancel`, `TASK_CREATE` stays `create`. The `execute → update` swap also lands on the message routes so an editor (not just an owner) can do routine mutations, matching the task schema's `update = editor + owner`.
- **404 collapse:** a shared `check_task_or_collapse_to_404` helper turns any task denial into `ItemDoesNotExist` (404) across the path / query / body / **name** routes — the name route most of all, since `tasks.name` is globally unique. (This is the canonical wrap #260 left a TODO to adopt; this PR adopts it.)
- **Fail-closed:** an unknown `AgentRPCMethod` now raises `NotImplementedError` instead of dispatching authz-free.
- The list surface (only return readable tasks) is already covered by existing `DAuthorizedResourceIds` wiring — no change here.

**Merge gate:** the `execute → update` swap is already satisfied by SGP's schema, but `cancel` must be live in every SGP env first (scaleapi/scaleapi#145044). Held until that ships.

Out of scope (AGX1-291): the agent name-route has the same 403/404 leak shape, and restoring the 403/404 split for same-tenant calls waits on task tenant-scoping (AGX1-290).

## Tests

`test_tasks_authz.py`: per-RPC operation routing, 404-collapse, body-id / name task wraps, fail-closed unknown method, and wire-format pins for `update`/`cancel`. Ruff + ruff-format clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the per-task FGAC rewire by routing each RPC method to its correct authorization operation (`MESSAGE_SEND`/`EVENT_SEND` → `update`, `TASK_CANCEL` → `cancel`, `TASK_CREATE` stays `create`) and collapsing all task authz denials to 404 across path/query/body/name surfaces via a new shared `check_task_or_collapse_to_404` helper.

- **Per-RPC operation routing** (`agents.py`): replaces the blanket `execute` check with operation-specific routing; the `MESSAGE_SEND` name-route uses `try/except/else` to ensure a denied `update` on an existing task cannot fall through to a `create` permission grant; unknown `AgentRPCMethod` values now raise `NotImplementedError` instead of silently bypassing authz.
- **404 collapse centralization** (`authorization_shortcuts.py`, `task_authorization.py`): four shortcut helpers deduplicated onto the shared helper, removing inline duplication of the same try/except pattern.
- **New `cancel` enum value** and full unit test coverage for routing, collapse behavior, body-id/name wraps, fail-closed unknown method, and wire-format contract pins.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge once the `cancel` operation is confirmed live in every SGP env per the documented merge gate.

The logic changes are narrow and well-reasoned: the `try/except/else` guard in the MESSAGE_SEND name-route correctly prevents a denied update from masquerading as task-absent, the fail-closed `NotImplementedError` is a clear improvement over the silent `pass`, and the 404-collapse centralization removes inline duplication without changing observable behavior. Test coverage is thorough across routing, collapse, and wire-format pinning. The only finding is a minor TODO missing a ticket reference.

No files require special attention beyond the documented merge-gate ordering in the PR description.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/api/routes/agents.py | Per-RPC operation routing: MESSAGE_SEND/EVENT_SEND wired to `update`, TASK_CANCEL to `cancel`, TASK_CREATE unchanged; fail-closed `NotImplementedError` replaces silent `pass`; MESSAGE_SEND try/except/else pattern correctly prevents denied-update masquerading as task-absent. |
| agentex/src/utils/authorization_shortcuts.py | DAuthorizedId, DAuthorizedQuery, DAuthorizedBodyId, and DAuthorizedName all updated to route direct task-type resources through the shared collapse helper; inline duplication removed cleanly. |
| agentex/src/utils/task_authorization.py | New helper that centralizes the 403→404 collapse for task-resource authz denials; logic is correct and well-documented, minor TODO missing ticket reference. |
| agentex/src/api/routes/messages.py | Four message-route body-id checks swapped from `execute` to `update`; straightforward change consistent with the broader rewire. |
| agentex/src/api/schemas/authorization_types.py | Adds `cancel = "cancel"` to `AuthorizedOperationType`; wire string pinned by the test suite. |
| agentex/tests/unit/api/test_tasks_authz.py | Comprehensive unit tests covering per-RPC routing, 404-collapse behavior, body-id/name wraps, fail-closed unknown method, and wire-format contract pins for `update`/`cancel`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Agent RPC] --> B{AgentRPCMethod}
    B -->|TASK_CREATE| C[check: create on task/*]
    B -->|MESSAGE_SEND| D{task_id or task_name?}
    B -->|EVENT_SEND| G{task_id or task_name?}
    B -->|TASK_CANCEL| J{task_id or task_name?}
    B -->|unknown| N[raise NotImplementedError - fail-closed]
    D -->|task_id| E[check_task_or_collapse_to_404 operation=update]
    D -->|task_name| F{get_task by name}
    D -->|neither| C2[check: create on task/*]
    F -->|exists| E2[check_task_or_collapse_to_404 operation=update]
    F -->|ItemDoesNotExist| C2
    G -->|task_id| H[check_task_or_collapse_to_404 operation=update]
    G -->|task_name| I[get_task then check_task_or_collapse_to_404 operation=update]
    G -->|neither| V[raise ValueError]
    J -->|task_id| K[check_task_or_collapse_to_404 operation=cancel]
    J -->|task_name| L[get_task then check_task_or_collapse_to_404 operation=cancel]
    J -->|neither| W[raise ValueError]
    E --> M{AuthorizationError?}
    E2 --> M
    H --> M
    I --> M
    K --> M
    L --> M
    M -->|yes| O[raise ItemDoesNotExist - 404]
    M -->|no| P[proceed]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Futils%2Ftask_authorization.py%3A329-331%0A**TODO%20missing%20Linear%20ticket%20reference**%0A%0AThe%20TODO%20on%20the%20403%2F404%20split%20restoration%20references%20the%20rationale%20but%20not%20the%20tracking%20ticket.%20Per%20project%20convention%2C%20TODOs%20should%20include%20the%20Linear%20issue%20that%20owns%20the%20work%20so%20it's%20easy%20to%20find%20and%20clean%20up.%20The%20PR%20description%20names%20%60AGX1-290%60%20as%20the%20task-tenant-scoping%20follow-up%20that%20would%20unblock%20this.%0A%0A&pr=249&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Futils%2Ftask_authorization.py%3A329-331%0A**TODO%20missing%20Linear%20ticket%20reference**%0A%0AThe%20TODO%20on%20the%20403%2F404%20split%20restoration%20references%20the%20rationale%20but%20not%20the%20tracking%20ticket.%20Per%20project%20convention%2C%20TODOs%20should%20include%20the%20Linear%20issue%20that%20owns%20the%20work%20so%20it's%20easy%20to%20find%20and%20clean%20up.%20The%20PR%20description%20names%20%60AGX1-290%60%20as%20the%20task-tenant-scoping%20follow-up%20that%20would%20unblock%20this.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=249&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22asher.fink%2Fagx1-275-task-route-migration%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22asher.fink%2Fagx1-275-task-route-migration%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Futils%2Ftask_authorization.py%3A329-331%0A**TODO%20missing%20Linear%20ticket%20reference**%0A%0AThe%20TODO%20on%20the%20403%2F404%20split%20restoration%20references%20the%20rationale%20but%20not%20the%20tracking%20ticket.%20Per%20project%20convention%2C%20TODOs%20should%20include%20the%20Linear%20issue%20that%20owns%20the%20work%20so%20it's%20easy%20to%20find%20and%20clean%20up.%20The%20PR%20description%20names%20%60AGX1-290%60%20as%20the%20task-tenant-scoping%20follow-up%20that%20would%20unblock%20this.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex/src/utils/task_authorization.py:329-331
**TODO missing Linear ticket reference**

The TODO on the 403/404 split restoration references the rationale but not the tracking ticket. Per project convention, TODOs should include the Linear issue that owns the work so it's easy to find and clean up. The PR description names `AGX1-290` as the task-tenant-scoping follow-up that would unblock this.

`````

</details>

<sub>Reviews (9): Last reviewed commit: ["feat(tasks): per-RPC task permission rew..."](https://github.com/scaleapi/scale-agentex/commit/ba00de159211cf54df65aff23fa882f1e3d09084) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34256131)</sub>

**Context used:**

- Rule used - Create Linear tasks for TODO comments in code and ... ([source](https://app.greptile.com/scale-ai/-/custom-context?memory=6328a8b3-afcc-487b-aac4-241716e05e94))

**Learned From**
[scaleapi/scaleapi#127117](https://github.com/scaleapi/scaleapi/pull/127117)

<!-- /greptile_comment -->