### PR TITLE
chore(deps): pin agentex-sdk[adk] for ADK surface access

### DIFF
--- a/agentex/pyproject.toml
+++ b/agentex/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
     "pre-commit>=4.2.0",
     "pytest>=8.3.3,<9",
     "pytest-asyncio>=1.0.0,<2",
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "pytest-cov>=5.0.0,<6",
     "vulture>=2.14",
     "ruff>=0.3.4",
@@ -58,11 +58,11 @@ docs = [
     "mkdocs-macros-plugin>=1.3.7,<2",
     "mkdocstrings-python>=1.16.12",
     "mkdocs>=1.6.1",
-    "agentex-sdk",
+    "agentex-sdk[adk]",
     "griffe-pydantic>=1.1.4",
     "pymdown-extensions>=10.0,<11",
     "Pygments>=2.19.2,<2.20",
-    "agentex-sdk",
+    "agentex-sdk[adk]",
 ]
 
 [tool.hatch.build.targets.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Felix Su", email = "felix.su@scale.com" }]
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    "agentex-sdk>=0.9.4",
+    "agentex-sdk[adk]>=0.9.4",
     "temporalio>=1.18.0",
 ]
 


### PR DESCRIPTION
## Summary

Migrates this repo's `agentex-sdk` pins to `agentex-sdk[adk]` ahead of the planned dep split in [scaleapi/scale-agentex-python#368](https://github.com/scaleapi/scale-agentex-python/pull/368) ([AGX1-292](https://linear.app/scale-epd/issue/AGX1-292/reduce-agentex-sdk-runtime-deps-47-6-base-move-adkserver-deps-to)).

After the split lands, bare `pip install agentex-sdk` will only install the Stainless REST client (6 deps). The `agentex.lib.*` ADK surface — CLI, ACP server, Temporal, LLM provider integrations, observability — will require `agentex-sdk[adk]`.

This repo uses `agentex.lib.*` for:
- `mkdocstrings` autodoc generation (`agentex/pyproject.toml` docs group)
- Local development tooling (dev group)
- Workspace consumer (`pyproject.toml`)

## Rollout safety

This PR is safe to land **at any time**, independent of [scaleapi/scale-agentex-python#368](https://github.com/scaleapi/scale-agentex-python/pull/368)'s status:
- **Before [scaleapi/scale-agentex-python#368](https://github.com/scaleapi/scale-agentex-python/pull/368) lands**: pip will warn "extra 'adk' not found" and install successfully — same install behavior as today.
- **After [scaleapi/scale-agentex-python#368](https://github.com/scaleapi/scale-agentex-python/pull/368) lands**: clean install via the new extra.

## Files

| File | Pins changed |
|---|---|
| `pyproject.toml` | 1 (workspace dep) |
| `agentex/pyproject.toml` | 3 (dev group + docs group ×2) |

The `# Override agentex-sdk's fastapi<0.116 pin ...` comment is intentionally unchanged.

## Test plan

- [ ] CI passes.
- [ ] Docs build (`mkdocs build`) still works.
- [ ] Dev environment still installs cleanly.