### PR TITLE
docs(agentex): use canonical agentex.protocol.acp import paths

### DIFF
--- a/agentex/docs/docs/acp/agentic/base.md
+++ b/agentex/docs/docs/acp/agentic/base.md
@@ -157,7 +157,7 @@ async def process_workflow_step(params: SendEventParams):
 
 Used in `@acp.on_task_create` for task initialization:
 
-::: agentex.lib.types.acp.CreateTaskParams
+::: agentex.protocol.acp.CreateTaskParams
     options:
       heading_level: 4
       show_root_heading: false
@@ -167,7 +167,7 @@ Used in `@acp.on_task_create` for task initialization:
 
 Used in `@acp.on_task_event_send` for processing events:
 
-::: agentex.lib.types.acp.SendEventParams
+::: agentex.protocol.acp.SendEventParams
     options:
       heading_level: 4
       show_root_heading: false
@@ -177,7 +177,7 @@ Used in `@acp.on_task_event_send` for processing events:
 
 Used in `@acp.on_task_cancel` for cleanup:
 
-::: agentex.lib.types.acp.CancelTaskParams
+::: agentex.protocol.acp.CancelTaskParams
     options:
       heading_level: 4
       show_root_heading: false

--- a/agentex/docs/docs/acp/agentic/temporal.md
+++ b/agentex/docs/docs/acp/agentic/temporal.md
@@ -48,7 +48,7 @@ Instead of ACP handlers, you implement standard Temporal workflows:
 ```python
 from temporalio import workflow
 from agentex import adk
-from agentex.lib.types.acp import CreateTaskParams, SendEventParams
+from agentex.protocol.acp import CreateTaskParams, SendEventParams
 from agentex.core.temporal.workflows.workflow import BaseWorkflow
 from agentex.core.temporal.types.workflow import SignalName
 from agentex.types.message_author import MessageAuthor

--- a/agentex/docs/docs/agent_types/async/base.md
+++ b/agentex/docs/docs/agent_types/async/base.md
@@ -39,7 +39,7 @@ sequenceDiagram
 ```python
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.lib.types.fastacp import AsyncACPConfig
-from agentex.lib.types.acp import CreateTaskParams, SendEventParams, CancelTaskParams
+from agentex.protocol.acp import CreateTaskParams, SendEventParams, CancelTaskParams
 from agentex.lib import adk
 
 # Create Base Async ACP server
@@ -78,7 +78,7 @@ async def handle_task_cancel(params: CancelTaskParams) -> None:
 
 Used in `@acp.on_task_create` for task initialization:
 
-::: agentex.lib.types.acp.CreateTaskParams
+::: agentex.protocol.acp.CreateTaskParams
     options:
       heading_level: 4
       show_root_heading: false
@@ -88,7 +88,7 @@ Used in `@acp.on_task_create` for task initialization:
 
 Used in `@acp.on_task_event_send` for processing events:
 
-::: agentex.lib.types.acp.SendEventParams
+::: agentex.protocol.acp.SendEventParams
     options:
       heading_level: 4
       show_root_heading: false
@@ -98,7 +98,7 @@ Used in `@acp.on_task_event_send` for processing events:
 
 Used in `@acp.on_task_cancel` for cleanup:
 
-::: agentex.lib.types.acp.CancelTaskParams
+::: agentex.protocol.acp.CancelTaskParams
     options:
       heading_level: 4
       show_root_heading: false

--- a/agentex/docs/docs/agent_types/async/temporal.md
+++ b/agentex/docs/docs/agent_types/async/temporal.md
@@ -51,7 +51,7 @@ sequenceDiagram
 ```python
 from temporalio import workflow
 from agentex import adk
-from agentex.lib.types.acp import CreateTaskParams, SendEventParams
+from agentex.protocol.acp import CreateTaskParams, SendEventParams
 from agentex.core.temporal.workflows.workflow import BaseWorkflow
 from agentex.core.temporal.types.workflow import SignalName
 from agentex.types.message_author import MessageAuthor
@@ -159,7 +159,7 @@ if __name__ == "__main__":
 
 Used in `@workflow.run` (replaces `@acp.on_task_create`):
 
-::: agentex.lib.types.acp.CreateTaskParams
+::: agentex.protocol.acp.CreateTaskParams
     options:
       heading_level: 4
       show_root_heading: false
@@ -169,7 +169,7 @@ Used in `@workflow.run` (replaces `@acp.on_task_create`):
 
 Used in `@workflow.signal(name=SignalName.RECEIVE_EVENT)` (replaces `@acp.on_task_event_send`):
 
-::: agentex.lib.types.acp.SendEventParams
+::: agentex.protocol.acp.SendEventParams
     options:
       heading_level: 4
       show_root_heading: false

--- a/agentex/docs/docs/agent_types/sync.md
+++ b/agentex/docs/docs/agent_types/sync.md
@@ -31,7 +31,7 @@ sequenceDiagram
 
 ```python
 from agentex.lib.sdk.fastacp.fastacp import FastACP
-from agentex.lib.types.acp import SendMessageParams
+from agentex.protocol.acp import SendMessageParams
 from agentex.types.text_content import TextContent
 from agentex.types.message_author import MessageAuthor
 
@@ -61,7 +61,7 @@ async def handle_message(params: SendMessageParams):
 
 The `@acp.on_message_send` handler receives:
 
-::: agentex.lib.types.acp.SendMessageParams
+::: agentex.protocol.acp.SendMessageParams
     options:
       heading_level: 4
       show_root_heading: false

--- a/agentex/docs/docs/api/overview.md
+++ b/agentex/docs/docs/api/overview.md
@@ -62,7 +62,7 @@ Python library for use **WITHIN** your agent code. The ADK provides high-level a
 from agentex.types.task_message_content import TaskMessageContent
 from agentex.types.text_content import TextContent
 from agentex.types.message_author import MessageAuthor
-from agentex.lib.types.acp import SendMessageParams, CreateTaskParams, SendEventParams
+from agentex.protocol.acp import SendMessageParams, CreateTaskParams, SendEventParams
 from agentex.types.task import Task
 from agentex.types.event import Event
 ```

--- a/agentex/docs/docs/api/types.md
+++ b/agentex/docs/docs/api/types.md
@@ -6,19 +6,19 @@ Comprehensive API reference for all core object types in Agentex. These types ar
 
 ### CreateTaskParams
 
-::: agentex.lib.types.acp.CreateTaskParams
+::: agentex.protocol.acp.CreateTaskParams
 
 ### SendMessageParams
 
-::: agentex.lib.types.acp.SendMessageParams
+::: agentex.protocol.acp.SendMessageParams
 
 ### SendEventParams
 
-::: agentex.lib.types.acp.SendEventParams
+::: agentex.protocol.acp.SendEventParams
 
 ### CancelTaskParams
 
-::: agentex.lib.types.acp.CancelTaskParams
+::: agentex.protocol.acp.CancelTaskParams
 
 ## Agent
 

--- a/agentex/docs/docs/concepts/streaming.md
+++ b/agentex/docs/docs/concepts/streaming.md
@@ -146,7 +146,7 @@ Here's a complete example showing how to stream content in an Async Agent:
 
 ```python
 from agentex.lib import adk
-from agentex.lib.types.acp import SendEventParams
+from agentex.protocol.acp import SendEventParams
 from agentex.types.text_content import TextContent
 from agentex.types.task_message_delta import TextDelta
 from agentex.types.task_message_update import (

--- a/agentex/docs/docs/getting_started/project_structure.md
+++ b/agentex/docs/docs/getting_started/project_structure.md
@@ -42,7 +42,7 @@ Your ACP server defines how the agent responds to incoming messages. For sync ag
 
 ```python
 from agentex.lib.sdk.fastacp.fastacp import FastACP
-from agentex.lib.types.acp import SendMessageParams
+from agentex.protocol.acp import SendMessageParams
 from agentex.types.task_message_content import TaskMessageContent
 from agentex.types.text_content import TextContent
 
@@ -111,7 +111,7 @@ The base async ACP server gives you a starting point for custom async implementa
 ```python
 from agentex.lib.sdk.fastacp.fastacp import FastACP
 from agentex.lib.types.fastacp import AgenticBaseACPConfig
-from agentex.lib.types.acp import CreateTaskParams, SendEventParams, CancelTaskParams
+from agentex.protocol.acp import CreateTaskParams, SendEventParams, CancelTaskParams
 
 # Create a base agentic ACP server
 acp = FastACP.create(
@@ -216,7 +216,7 @@ Your workflow is where all the agent logic lives. It's a class that Temporal man
 import json
 from temporalio import workflow
 from agentex.lib import adk
-from agentex.lib.types.acp import CreateTaskParams, SendEventParams
+from agentex.protocol.acp import CreateTaskParams, SendEventParams
 from agentex.lib.core.temporal.workflows.workflow import BaseWorkflow
 from agentex.lib.core.temporal.types.workflow import SignalName
 from agentex.types.text_content import TextContent

--- a/agentex/docs/docs/temporal_development/openai_integration.md
+++ b/agentex/docs/docs/temporal_development/openai_integration.md
@@ -146,7 +146,7 @@ The new streaming implementation uses Temporal's interceptor pattern to enable r
 # workflow.py
 from agents import Agent, Runner
 from agentex import adk
-from agentex.lib.types.acp import SendEventParams
+from agentex.protocol.acp import SendEventParams
 from agentex.lib.core.temporal.types.workflow import SignalName
 from agentex.types.text_content import TextContent
 from temporalio import workflow


### PR DESCRIPTION
> **Stacked on [#286](https://github.com/scaleapi/scale-agentex/pull/286)** (isolate docs build from the workspace lock) — merge that first. This PR is only the doc-path changes; #286 makes the doc build resolve `agentex-sdk>=0.12.0` in an isolated env, so `agentex.protocol.*` resolves without touching backend deps.

## Summary

Updates the agentex mkdocs site to use the new canonical `agentex.protocol.acp` import paths for protocol-shape types (`RPCMethod`, `CreateTaskParams`, `SendMessageParams`, `SendEventParams`, `CancelTaskParams`).

Companion to [scaleapi/scale-agentex-python#371](https://github.com/scaleapi/scale-agentex-python/pull/371), which moved these types out of `agentex.lib.types.*` into the new slim-safe `agentex.protocol.*` package. The old path still works via a back-compat shim — this PR isn't fixing a breakage, it's making sure scaffolded user code following these docs starts on the canonical path.

Requested in [a review comment on #371](https://github.com/scaleapi/scale-agentex-python/pull/371#pullrequestreview-3636614108).

## Changes

10 markdown files in `agentex/docs/`:

| Pattern | Count |
|---|---|
| `from agentex.lib.types.acp import ...` → `from agentex.protocol.acp import ...` | 8 code samples |
| `::: agentex.lib.types.acp.X` → `::: agentex.protocol.acp.X` | 2 mkdocstrings cross-refs (in `agent_types/sync.md` and `api/types.md`) |

No content / behavior changes; same classes, new import path.

## What's not touched

Other `agentex.lib.types.*` modules (`tracing`, `agent_card`, `credentials`, `fastacp`, `llm_messages`, `converters`) stay on the old path because they have heavier transitive deps and weren't migrated by #371. No doc references to those needed updates.

## Test plan

- [x] Isolated `mkdocs build` renders green against `agentex-sdk` 0.12.0 (verified locally via the #286 build path).
- [x] `::: agentex.protocol.acp.*` mkdocstrings directives resolve at the new path.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates all `agentex` mkdocs documentation to use the new canonical `agentex.protocol.acp` import path in place of the legacy `agentex.lib.types.acp` path for the five protocol-shape types (`CreateTaskParams`, `SendMessageParams`, `SendEventParams`, `CancelTaskParams`, and the referenced variants). No content or behavioral changes are made; only import paths in code samples and mkdocstrings directives are touched.

- **9 Python code snippets** across 8 files updated from `from agentex.lib.types.acp import ...` to `from agentex.protocol.acp import ...`.
- **13 mkdocstrings directives** across 5 files updated from `::: agentex.lib.types.acp.X` to `::: agentex.protocol.acp.X`.
- A post-diff grep confirms no remaining `agentex.lib.types.acp` references exist anywhere in the docs tree.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Purely mechanical doc-path update with no logic changes; all old references have been replaced and none remain in the docs tree.

Every changed line is a string substitution in markdown files — no executable code, no schema changes, no API surface changes. A post-diff grep confirms zero remaining agentex.lib.types.acp references in the docs directory, so the migration is complete and consistent.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/docs/docs/api/types.md | Updates 4 mkdocstrings directives in the comprehensive API types reference to the new canonical path. |
| agentex/docs/docs/acp/agentic/base.md | Updates 3 mkdocstrings directives (CreateTaskParams, SendEventParams, CancelTaskParams) to the new canonical path. |
| agentex/docs/docs/agent_types/async/base.md | Updates one Python import snippet and 3 mkdocstrings directives for the async base agent type to the new canonical path. |
| agentex/docs/docs/agent_types/async/temporal.md | Updates one Python import snippet and 2 mkdocstrings directives for the async Temporal agent type to the new canonical path. |
| agentex/docs/docs/getting_started/project_structure.md | Updates two Python import snippets (sync and async sections) to the new canonical path. |
| agentex/docs/docs/agent_types/sync.md | Updates one Python import snippet and one mkdocstrings directive for SendMessageParams to the new canonical path. |
| agentex/docs/docs/api/overview.md | Updates one Python import snippet for the API overview page to the new canonical path. |
| agentex/docs/docs/acp/agentic/temporal.md | Updates one Python import snippet from agentex.lib.types.acp to agentex.protocol.acp. |
| agentex/docs/docs/concepts/streaming.md | Updates one Python import snippet for SendEventParams in the streaming concept guide to the new canonical path. |
| agentex/docs/docs/temporal_development/openai_integration.md | Updates one Python import snippet for SendEventParams in the OpenAI integration guide to the new canonical path. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["10 markdown doc files\n(code samples + mkdocstrings directives)"]
    B["agentex.lib.types.acp\n(legacy path — back-compat shim)"]
    C["agentex.protocol.acp\n(canonical path — agentex-sdk ≥ 0.12.0)"]
    D["Types migrated:\nCreateTaskParams\nSendMessageParams\nSendEventParams\nCancelTaskParams"]

    A -->|"old import path"| B
    A -->|"new import path ✅"| C
    B -.->|"re-exports via shim"| C
    C --> D
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into maxparke/agx1-2..."](https://github.com/scaleapi/scale-agentex/commit/072a81f7348a796e4d494258d74e3c72a2124880) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34170925)</sub>

<!-- /greptile_comment -->