### PR TITLE
feat(schedules): register agent_schedule in authz on create/delete

### DIFF
--- a/agentex/src/api/schemas/authorization_types.py
+++ b/agentex/src/api/schemas/authorization_types.py
@@ -15,6 +15,7 @@ class AgentexResourceType(StrEnum):
     agent = "agent"
     task = "task"
     api_key = "api_key"
+    schedule = "schedule"
 
 
 # Resources that inherit permissions from their parent task
@@ -43,6 +44,10 @@ class AgentexResource(BaseModel):
     def api_key(cls, selector: str) -> "AgentexResource":
         return cls(type=AgentexResourceType.api_key, selector=selector)
 
+    @classmethod
+    def schedule(cls, selector: str) -> "AgentexResource":
+        return cls(type=AgentexResourceType.schedule, selector=selector)
+
 
 class AgentexResourceOptionalSelector(BaseModel):
     type: AgentexResourceType
@@ -59,3 +64,9 @@ class AgentexResourceOptionalSelector(BaseModel):
     @classmethod
     def api_key(cls, selector: str | None = None) -> "AgentexResourceOptionalSelector":
         return cls(type=AgentexResourceType.api_key, selector=selector)
+
+    @classmethod
+    def schedule(
+        cls, selector: str | None = None
+    ) -> "AgentexResourceOptionalSelector":
+        return cls(type=AgentexResourceType.schedule, selector=selector)

--- a/agentex/src/domain/services/schedule_service.py
+++ b/agentex/src/domain/services/schedule_service.py
@@ -5,6 +5,7 @@ from fastapi import Depends
 from temporalio.client import ScheduleActionStartWorkflow, ScheduleDescription
 
 from src.adapters.temporal.adapter_temporal import DTemporalAdapter
+from src.api.schemas.authorization_types import AgentexResource
 from src.api.schemas.schedules import (
     CreateScheduleRequest,
     ScheduleActionInfo,
@@ -15,6 +16,7 @@ from src.api.schemas.schedules import (
     ScheduleState,
 )
 from src.domain.entities.agents import AgentEntity
+from src.domain.services.authorization_service import DAuthorizationService
 from src.utils.logging import make_logger
 
 logger = make_logger(__name__)
@@ -44,8 +46,10 @@ class ScheduleService:
     def __init__(
         self,
         temporal_adapter: DTemporalAdapter,
+        authorization_service: DAuthorizationService,
     ):
         self.temporal_adapter = temporal_adapter
+        self.authorization_service = authorization_service
 
     async def create_schedule(
         self,
@@ -80,22 +84,104 @@ class ScheduleService:
             else None
         )
 
-        await self.temporal_adapter.create_schedule(
-            schedule_id=schedule_id,
-            workflow=request.workflow_name,
-            workflow_id=workflow_id_prefix,
-            args=args,
-            task_queue=request.task_queue,
-            cron_expressions=cron_expressions,
-            interval_seconds=request.interval_seconds,
-            execution_timeout=execution_timeout,
-            start_at=request.start_at,
-            end_at=request.end_at,
-            paused=request.paused,
+        # Schedules have no Postgres row — Temporal is the store and the auth
+        # selector is the schedule id ({agent_id}--{schedule_name}). Register
+        # the auth tuple (with the parent_agent edge) BEFORE the Temporal write
+        # (fail-closed), and compensate if the Temporal create fails so we never
+        # leave an orphan tuple. The read-back below is intentionally OUTSIDE
+        # the compensation scope: a describe failure must not deregister a
+        # schedule that was actually created.
+        registered = await self._register_schedule_in_auth(
+            schedule_id=schedule_id, agent_id=agent.id
         )
+        try:
+            await self.temporal_adapter.create_schedule(
+                schedule_id=schedule_id,
+                workflow=request.workflow_name,
+                workflow_id=workflow_id_prefix,
+                args=args,
+                task_queue=request.task_queue,
+                cron_expressions=cron_expressions,
+                interval_seconds=request.interval_seconds,
+                execution_timeout=execution_timeout,
+                start_at=request.start_at,
+                end_at=request.end_at,
+                paused=request.paused,
+            )
+        except Exception:
+            # Orphan-tuple guard: the tuple was written but the schedule never
+            # landed in Temporal. Best-effort compensating deregister, then
+            # re-raise the original error.
+            if registered:
+                await self._deregister_schedule_from_auth(schedule_id=schedule_id)
+            raise
 
         # Fetch and return the created schedule
         return await self.get_schedule(agent.id, request.name)
+
+    async def _register_schedule_in_auth(
+        self, *, schedule_id: str, agent_id: str
+    ) -> bool:
+        """Register a new agent_schedule with the auth service, including the
+        parent_agent edge so permissions cascade from the owning agent.
+
+        Called BEFORE the Temporal write — a failure raises and prevents the
+        schedule from being created. Skipped with a warning when no usable
+        creator identity is available on the principal context (e.g.
+        agent-bypass / internal paths without an authenticated user); this is
+        the interim behavior until on-behalf-of-user identity is threaded.
+
+        Returns True when a tuple was actually registered (so the caller knows
+        whether a compensating deregister is warranted), False when skipped.
+        """
+        principal_context = self.authorization_service.principal_context
+        user_id = getattr(principal_context, "user_id", None)
+        service_account_id = getattr(principal_context, "service_account_id", None)
+        if user_id is None and service_account_id is None:
+            logger.warning(
+                "Skipping auth registration for schedule: no creator resolvable",
+                extra={"schedule_id": schedule_id, "agent_id": agent_id},
+            )
+            return False
+        try:
+            await self.authorization_service.register_resource(
+                resource=AgentexResource.schedule(schedule_id),
+                parent=AgentexResource.agent(agent_id),
+            )
+        except Exception as exc:
+            # Fail closed: log + re-raise so the schedule is never created.
+            logger.exception(
+                "Auth register_resource failed for agent_schedule; aborting create",
+                extra={
+                    "schedule_id": schedule_id,
+                    "agent_id": agent_id,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            raise
+        return True
+
+    async def _deregister_schedule_from_auth(self, *, schedule_id: str) -> None:
+        """Best-effort deregistration of a schedule's auth tuples.
+
+        ``deregister_resource`` removes the resource and all of its
+        relationships (owner, parent, grantees) atomically. Used both on delete
+        and as the compensating action when a Temporal create fails. Failures
+        are logged but never propagate.
+        """
+        try:
+            await self.authorization_service.deregister_resource(
+                resource=AgentexResource.schedule(schedule_id),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Auth deregister failed for agent_schedule; tuple may be orphaned",
+                extra={
+                    "schedule_id": schedule_id,
+                    "error_type": type(exc).__name__,
+                },
+                exc_info=True,
+            )
 
     async def get_schedule(self, agent_id: str, schedule_name: str) -> ScheduleResponse:
         """
@@ -237,6 +323,9 @@ class ScheduleService:
         """
         schedule_id = build_schedule_id(agent_id, schedule_name)
         await self.temporal_adapter.delete_schedule(schedule_id)
+        # Best-effort: drop the auth tuple after the Temporal delete. A failure
+        # here is logged but never blocks the delete.
+        await self._deregister_schedule_from_auth(schedule_id=schedule_id)
 
     def _description_to_response(
         self, schedule_id: str, description: ScheduleDescription

--- a/agentex/tests/integration/services/test_schedule_service_dual_write.py
+++ b/agentex/tests/integration/services/test_schedule_service_dual_write.py
@@ -1,0 +1,257 @@
+"""Integration tests for ScheduleService dual-write to Spark AuthZ.
+
+scale-agentex calls ``register_resource`` / ``deregister_resource``
+unconditionally; per-account routing (Spark vs legacy SGP) is owned by
+agentex-auth so scale-agentex does NOT couple to a feature-flag service.
+
+Schedule-specific shape (vs the agent_api_key dual-write): schedules have no
+Postgres row — Temporal is the store and the auth selector is the schedule id
+``{agent_id}--{schedule_name}``. The dual-write is therefore Temporal + Spark,
+so the dual-write lives in ``ScheduleService`` (where the Temporal write is)
+rather than the use case, and the compensation boundary is scoped to the
+Temporal create only:
+
+- Create registers register_resource with parent=agent (the parent_agent edge
+  is load-bearing for the SpiceDB cascade) BEFORE the Temporal create.
+- Register failure prevents the Temporal create (fail-closed).
+- A Temporal create failure after a successful register triggers a
+  compensating deregister (best-effort), then the original error re-raises.
+- A post-create read-back (describe) failure does NOT compensate — the
+  schedule was actually created, so its tuple must survive.
+- Delete calls deregister_resource after the Temporal delete; a deregister
+  failure does not block the delete.
+- No creator → no register: if neither user_id nor service_account_id is
+  resolvable, the dual-write is a no-op (logged) and the schedule is still
+  created.
+
+The tests mock the Temporal adapter and authorization service and stub the
+post-create read-back; the behaviour under test is the call sequencing inside
+``ScheduleService`` — not Temporal or Spark itself.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from src.api.schemas.authorization_types import AgentexResource, AgentexResourceType
+from src.api.schemas.schedules import CreateScheduleRequest, ScheduleResponse
+from src.domain.entities.agents import ACPType, AgentEntity, AgentStatus
+from src.domain.services.schedule_service import ScheduleService, build_schedule_id
+from src.utils.ids import orm_id
+
+
+def _principal(
+    user_id: str | None = None, service_account_id: str | None = None
+) -> SimpleNamespace:
+    """Minimal stand-in for the auth principal context."""
+    return SimpleNamespace(
+        user_id=user_id, service_account_id=service_account_id, account_id="acct-1"
+    )
+
+
+def _agent() -> AgentEntity:
+    agent_id = orm_id()
+    return AgentEntity(
+        id=agent_id,
+        name=f"agent-{agent_id[:8]}",
+        description="dual-write test agent",
+        status=AgentStatus.READY,
+        acp_type=ACPType.SYNC,
+        acp_url="http://test-acp",
+    )
+
+
+def _request(name: str = "nightly") -> CreateScheduleRequest:
+    return CreateScheduleRequest(
+        name=name,
+        workflow_name="test-workflow",
+        task_queue="test-queue",
+        cron_expression="0 0 * * *",
+    )
+
+
+def _build_service(
+    *,
+    principal: SimpleNamespace | None,
+    register_resource: AsyncMock | None = None,
+    deregister_resource: AsyncMock | None = None,
+    create_raises: Exception | None = None,
+    delete_raises: Exception | None = None,
+    get_schedule_raises: Exception | None = None,
+) -> tuple[ScheduleService, Mock, AsyncMock, AsyncMock]:
+    temporal_adapter = Mock()
+    temporal_adapter.create_schedule = AsyncMock(
+        side_effect=create_raises, return_value=None
+    )
+    temporal_adapter.delete_schedule = AsyncMock(
+        side_effect=delete_raises, return_value=None
+    )
+
+    authorization_service = Mock()
+    authorization_service.principal_context = principal
+    authorization_service.register_resource = register_resource or AsyncMock(
+        return_value=None
+    )
+    authorization_service.deregister_resource = deregister_resource or AsyncMock(
+        return_value=None
+    )
+
+    service = ScheduleService(
+        temporal_adapter=temporal_adapter,
+        authorization_service=authorization_service,
+    )
+    # Stub the post-create read-back so create_schedule doesn't hit
+    # describe_schedule; tests covering a read-back failure pass get_schedule_raises.
+    if get_schedule_raises is not None:
+        service.get_schedule = AsyncMock(side_effect=get_schedule_raises)
+    else:
+        service.get_schedule = AsyncMock(return_value=Mock(spec=ScheduleResponse))
+
+    return (
+        service,
+        temporal_adapter,
+        authorization_service.register_resource,
+        authorization_service.deregister_resource,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_create_schedule_calls_register_resource_with_parent() -> None:
+    agent = _agent()
+    request = _request("nightly")
+    service, temporal_adapter, register, _ = _build_service(
+        principal=_principal(user_id="user-A"),
+    )
+
+    await service.create_schedule(agent, request)
+
+    register.assert_awaited_once()
+    registered_resource: AgentexResource = register.await_args.kwargs["resource"]
+    assert registered_resource.type == AgentexResourceType.schedule
+    assert registered_resource.selector == build_schedule_id(agent.id, request.name)
+    # parent_agent edge is load-bearing — without it the SpiceDB cascade
+    # `read = ... & parent_agent->read` fails closed for every reader.
+    registered_parent: AgentexResource = register.await_args.kwargs["parent"]
+    assert registered_parent is not None
+    assert registered_parent.type == AgentexResourceType.agent
+    assert registered_parent.selector == agent.id
+    temporal_adapter.create_schedule.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_delete_schedule_calls_deregister_resource() -> None:
+    agent = _agent()
+    service, temporal_adapter, _, deregister = _build_service(
+        principal=_principal(user_id="user-A"),
+    )
+
+    await service.delete_schedule(agent.id, "nightly")
+
+    schedule_id = build_schedule_id(agent.id, "nightly")
+    temporal_adapter.delete_schedule.assert_awaited_once_with(schedule_id)
+    deregister.assert_awaited_once()
+    deregistered_resource: AgentexResource = deregister.await_args.kwargs["resource"]
+    assert deregistered_resource.type == AgentexResourceType.schedule
+    assert deregistered_resource.selector == schedule_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_create_schedule_register_failure_prevents_temporal_create() -> None:
+    register = AsyncMock(side_effect=RuntimeError("spark unavailable"))
+    agent = _agent()
+    service, temporal_adapter, _, _ = _build_service(
+        principal=_principal(user_id="user-A"),
+        register_resource=register,
+    )
+
+    with pytest.raises(RuntimeError, match="spark unavailable"):
+        await service.create_schedule(agent, _request())
+
+    # Fail-closed: the Temporal create never runs when register fails.
+    temporal_adapter.create_schedule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_create_schedule_temporal_failure_triggers_compensating_deregister() -> (
+    None
+):
+    agent = _agent()
+    request = _request("nightly")
+    service, _, register, deregister = _build_service(
+        principal=_principal(user_id="user-A"),
+        create_raises=RuntimeError("temporal down"),
+    )
+
+    with pytest.raises(RuntimeError, match="temporal down"):
+        await service.create_schedule(agent, request)
+
+    register.assert_awaited_once()
+    # Orphan-tuple guard: the tuple was registered but the Temporal create
+    # failed, so the tuple is compensated away.
+    deregister.assert_awaited_once()
+    compensated: AgentexResource = deregister.await_args.kwargs["resource"]
+    assert compensated.type == AgentexResourceType.schedule
+    assert compensated.selector == build_schedule_id(agent.id, request.name)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_create_schedule_readback_failure_does_not_compensate() -> None:
+    # The Temporal create SUCCEEDS but the post-create describe read-back fails.
+    # The schedule genuinely exists, so its tuple must NOT be compensated away —
+    # deregistering here would fail-close the owner out of their own schedule.
+    agent = _agent()
+    service, temporal_adapter, register, deregister = _build_service(
+        principal=_principal(user_id="user-A"),
+        get_schedule_raises=RuntimeError("describe transient error"),
+    )
+
+    with pytest.raises(RuntimeError, match="describe transient error"):
+        await service.create_schedule(agent, _request())
+
+    temporal_adapter.create_schedule.assert_awaited_once()
+    register.assert_awaited_once()
+    deregister.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_delete_schedule_deregister_failure_does_not_block_delete() -> None:
+    deregister = AsyncMock(side_effect=RuntimeError("spark unavailable"))
+    agent = _agent()
+    service, temporal_adapter, _, _ = _build_service(
+        principal=_principal(user_id="user-A"),
+        deregister_resource=deregister,
+    )
+
+    # Best-effort: the deregister failure is swallowed, the delete completes.
+    await service.delete_schedule(agent.id, "nightly")
+
+    temporal_adapter.delete_schedule.assert_awaited_once_with(
+        build_schedule_id(agent.id, "nightly")
+    )
+    deregister.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_create_schedule_no_creator_skips_register() -> None:
+    agent = _agent()
+    request = _request("nightly")
+    # Neither user_id nor service_account_id — agent-bypass / internal path.
+    service, temporal_adapter, register, deregister = _build_service(
+        principal=_principal(user_id=None, service_account_id=None),
+    )
+
+    await service.create_schedule(agent, request)
+
+    register.assert_not_awaited()
+    deregister.assert_not_awaited()
+    # The schedule is still created — the dual-write is a no-op, not a block.
+    temporal_adapter.create_schedule.assert_awaited_once()

--- a/agentex/tests/unit/services/test_schedule_service.py
+++ b/agentex/tests/unit/services/test_schedule_service.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock
 from uuid import uuid4
 
 import pytest
@@ -49,9 +50,25 @@ def mock_temporal_adapter():
 
 
 @pytest.fixture
-def schedule_service(mock_temporal_adapter):
+def mock_authorization_service():
+    """Mock authorization service with a resolvable creator principal so the
+    dual-write register/deregister calls run as no-ops in these unit tests."""
+    mock = Mock()
+    mock.principal_context = SimpleNamespace(
+        user_id="user-test", service_account_id=None, account_id="acct-test"
+    )
+    mock.register_resource = AsyncMock(return_value=None)
+    mock.deregister_resource = AsyncMock(return_value=None)
+    return mock
+
+
+@pytest.fixture
+def schedule_service(mock_temporal_adapter, mock_authorization_service):
     """Create ScheduleService instance with mocked temporal adapter"""
-    return ScheduleService(temporal_adapter=mock_temporal_adapter)
+    return ScheduleService(
+        temporal_adapter=mock_temporal_adapter,
+        authorization_service=mock_authorization_service,
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Registers an `agent_schedule` resource in the authorization service on schedule
create (with the owning agent as its parent edge) and deregisters it on delete,
so schedules participate in fine-grained authorization.

Schedules have no Postgres row — Temporal is the store and the authz selector is
the schedule id (`{agent_id}--{schedule_name}`). The register/deregister calls
therefore live in `ScheduleService`, alongside the Temporal write, so the
compensation boundary can be scoped to the Temporal create only.

## Behavior
- **Create**: register the schedule (with `parent=agent`) **before** the
  Temporal create. Unconditional and **fail-closed** — a register failure
  aborts the create. If the Temporal create fails after a successful register,
  a **compensating deregister** removes the tuple so no orphan is left. The
  post-create read-back (describe) is outside the compensation scope: a describe
  failure must not deregister a schedule that was actually created.
- **Delete**: deregister after the Temporal delete, **best-effort** (logged,
  never blocks the delete).
- **No resolvable creator** (agent-bypass / internal paths with neither a user
  nor service-account identity): registration is skipped with a warning and the
  schedule is still created. Interim behavior until on-behalf-of-user identity
  is threaded.

Per-account routing (which authz backend the call lands on) is owned by the
authorization service; this repo calls register/deregister unconditionally.
Follows the `agent_api_key` register/deregister pattern (#248), which this PR is
stacked on.

## Requires
A companion change in the authorization service mapping the `schedule` resource
type to its SpiceDB `agent_schedule` definition; without it the
register/deregister call is rejected before reaching the backend.

## Changes
- `schedule_service.py`: register-before-create + compensate-on-temporal-failure;
  best-effort deregister on delete; `_register_schedule_in_auth` /
  `_deregister_schedule_from_auth` helpers; inject the authorization service.
- `authorization_types.py`: add the `schedule` resource type + factory.
- `tests/integration/services/test_schedule_service_dual_write.py`: 7 cases
  (parent-edge contract, fail-closed create, compensating deregister on Temporal
  failure, read-back failure does NOT compensate, best-effort deregister on
  delete, no-creator skip).
- `tests/unit/services/test_schedule_service.py`: fixture updated for the new
  constructor arg.

## Test plan
- [x] `pytest tests/integration/services/test_schedule_service_dual_write.py` — 7/7
- [x] `pytest tests/unit/services/test_schedule_service.py` — 27/27
- [x] `pytest tests/unit/use_cases/test_schedules_use_case.py` — 18/18
- [x] ruff clean

## Stacked on
#248 (base branch). Rebase onto the default branch once #248 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR integrates `agent_schedule` resources into the authorization service on create and delete, following the existing `agent_api_key` pattern. Register-before-create is fail-closed with a compensating deregister on Temporal failure; delete is best-effort post-Temporal.

- **`schedule_service.py`**: Injects `DAuthorizationService`, adds `_register_schedule_in_auth` (fail-closed, returns bool to drive compensation) and `_deregister_schedule_from_auth` (best-effort, never propagates). The post-create read-back is intentionally outside the compensation scope, which is correctly verified by a dedicated test case.
- **`authorization_types.py`**: Adds the `schedule` enum value and corresponding factory methods to both `AgentexResource` and `AgentexResourceOptionalSelector`, matching all existing resource types.
- **Tests**: 7 integration test cases cover the parent-edge contract, fail-closed create, compensating deregister, read-back-failure non-compensation, best-effort delete, and no-creator skip. Unit test fixture updated for the new constructor argument.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the compensation and bypass logic are correct and all edge cases are covered by the new test suite.

The register-before-create / compensate-on-Temporal-failure contract is correctly implemented: orphan tuples are prevented on create failures, and delete is best-effort so auth never blocks a Temporal delete. The read-back exclusion from compensation scope is explicitly tested. The no-creator skip and auth-bypass paths are both handled without leaving orphan state. The 7-case integration test suite directly mirrors the documented behavior contracts.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/api/schemas/authorization_types.py | Adds `schedule` to `AgentexResourceType` enum and factory methods to both `AgentexResource` and `AgentexResourceOptionalSelector`; directly mirrors the `api_key` pattern, no issues. |
| agentex/src/domain/services/schedule_service.py | Injects `DAuthorizationService`, adds register/deregister helpers with correct fail-closed/best-effort semantics, and scopes compensation to the Temporal create only (read-back is outside scope); logic is sound. |
| agentex/tests/integration/services/test_schedule_service_dual_write.py | New 7-case integration test file covering the full dual-write contract: parent-edge shape, fail-closed create, compensating deregister, read-back non-compensation, best-effort delete, and no-creator skip. |
| agentex/tests/unit/services/test_schedule_service.py | Minimal fixture update to supply the new `authorization_service` constructor argument; no behavioral changes to the existing 27 unit tests. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant ScheduleService
    participant AuthzService
    participant Temporal

    Note over ScheduleService: create_schedule()
    ScheduleService->>AuthzService: "register_resource(schedule, parent=agent)"
    alt register fails
        AuthzService-->>ScheduleService: raises Exception
        ScheduleService-->>Caller: raises (fail-closed, Temporal never called)
    else "register succeeds (registered=True)"
        AuthzService-->>ScheduleService: None
        ScheduleService->>Temporal: create_schedule(schedule_id)
        alt Temporal create fails
            Temporal-->>ScheduleService: raises Exception
            ScheduleService->>AuthzService: deregister_resource(schedule) [compensate]
            Note over ScheduleService: best-effort, swallows errors
            ScheduleService-->>Caller: re-raises original exception
        else Temporal create succeeds
            Temporal-->>ScheduleService: None
            ScheduleService->>Temporal: describe_schedule (read-back)
            Note right of ScheduleService: Outside compensation scope
            ScheduleService-->>Caller: ScheduleResponse
        end
    else no creator identity
        Note over ScheduleService: Skips register (warning logged)
        ScheduleService->>Temporal: create_schedule(schedule_id)
        Temporal-->>ScheduleService: None
        ScheduleService-->>Caller: ScheduleResponse
    end

    Note over ScheduleService: delete_schedule()
    ScheduleService->>Temporal: delete_schedule(schedule_id)
    Temporal-->>ScheduleService: None
    ScheduleService->>AuthzService: deregister_resource(schedule) [best-effort]
    ScheduleService-->>Caller: None
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(schedules): register agent\_schedule..."](https://github.com/scaleapi/scale-agentex/commit/a478b29d21662b591766655b8c3c0afadca8b8d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34945501)</sub>

<!-- /greptile_comment -->