### PR TITLE
feat(agentex-ui): filter out build-only agents from the agents list

### DIFF
--- a/agentex-ui/components/agents-list/agents-list.tsx
+++ b/agentex-ui/components/agents-list/agents-list.tsx
@@ -15,6 +15,12 @@ type AgentsListProps = {
   isLoading?: boolean;
 };
 
+// Agents registered at build time (AGX1-308) have a row but no acp_url and are
+// not routable. Deploy-time registration flips them to `Ready`. Hide these from
+// the list so they don't clutter the deployed, routable agents. Typed as
+// `string` because the `agentex` SDK's Agent.status union doesn't include it yet.
+const BUILD_ONLY_STATUS: string = 'BuildOnly';
+
 export function AgentsList({ agents, isLoading = false }: AgentsListProps) {
   const { agentName: selectedAgentName } = useSafeSearchParams();
   const hasMounted = useRef(false);
@@ -23,9 +29,13 @@ export function AgentsList({ agents, isLoading = false }: AgentsListProps) {
     hasMounted.current = true;
   }, []);
 
+  const routableAgents = agents.filter(
+    agent => agent.status !== BUILD_ONLY_STATUS
+  );
+
   const displayedAgents = selectedAgentName
-    ? agents.filter(agent => agent.name === selectedAgentName)
-    : agents;
+    ? routableAgents.filter(agent => agent.name === selectedAgentName)
+    : routableAgents;
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary

Fast follow to the build-time-agent-creation work. [AGX1-308](https://linear.app/scale-epd/issue/AGX1-308) added a `BUILD_ONLY` (`"BuildOnly"`) value to `AgentStatus`: agents registered at build time have an `agents` row but no `acp_url` and are not routable until deploy-time registration flips them to `Ready`.

Before this change those rows rendered in the agents list as a greyed-out, disabled badge, cluttering the list of deployed, routable agents. This PR filters them out.

## Changes

- `agentex-ui/components/agents-list/agents-list.tsx`: filter agents with the `BuildOnly` status out of the displayed list, alongside the existing `selectedAgentName` filter.

## Notes

- **Where the filter lives:** done in the presentation component rather than the `useAgents` hook, which is documented as fetching "the complete list of agents." Keeps the hook pure and does display filtering at the view layer.
- **SDK type gap:** the published `agentex` SDK (`0.1.0-alpha.9`) is stale: its `Agent.status` union doesn't include `'BuildOnly'` yet. The constant is typed as `string` so the comparison type-checks cleanly without a cast, with a comment flagging the gap. When the SDK is regenerated to include `BuildOnly`, the constant can be narrowed.
- **Dependency:** relies on the SDK actually returning `BuildOnly` to the frontend ([AGX1-310](https://linear.app/scale-epd/issue/AGX1-310)). Harmless before then since no agent carries that status.

## Verification

- `tsc --noEmit` → clean
- `next lint` → no warnings/errors
- pre-commit hooks → passed

Closes AGX1-311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR filters agents with a `BuildOnly` status out of the agents list in `agents-list.tsx`, preventing un-routable build-time-registered agents from appearing in the UI alongside deployed agents. The filter is applied at the presentation layer, keeping the `useAgents` hook's contract unchanged.

- Introduces a module-level `BUILD_ONLY_STATUS` constant typed as `string` (rather than narrowing to `AgentStatus`) because the published `agentex` SDK (`0.1.0-alpha.9`) does not yet include `BuildOnly` in the `Agent.status` union; a code comment calls this out and points to AGX1-308.
- Chains the new `routableAgents` pre-filter before the existing `selectedAgentName` filter, so both filter paths benefit from the exclusion without duplicating logic.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow, additive filter at the view layer with no side effects on data fetching or routing logic.

The diff touches one file, adds a single pre-filter step, and correctly chains it with the existing name filter. The string type for BUILD_ONLY_STATUS is intentional and documented, and the filtering logic is straightforward with no edge cases that could silently drop valid agents.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex-ui/components/agents-list/agents-list.tsx | Adds a BUILD_ONLY_STATUS constant and filters agents with that status out of the displayed list before applying the selectedAgentName filter; well-scoped, clean change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[agents prop from useAgents] --> B[routableAgents filter\nagent.status !== 'BuildOnly']
    B --> C{selectedAgentName?}
    C -- Yes --> D[filter by agent.name === selectedAgentName]
    C -- No --> E[use all routableAgents]
    D --> F[displayedAgents]
    E --> F
    F --> G{isLoading?}
    G -- Yes --> H[Skeleton placeholders]
    G -- No --> I{displayedAgents.length > 0?}
    I -- Yes --> J[Render AgentBadge list]
    I -- No --> K[No agents found message]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ronakpatel/agx1..."](https://github.com/scaleapi/scale-agentex/commit/4091b1f946c7401617e27494ab3a556496348644) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35237524)</sub>

<!-- /greptile_comment -->