### PR TITLE
fix(test): drop stale event_repository arg from DAuthorizedId test calls

### DIFF
--- a/agentex/tests/unit/api/test_agent_api_keys_authz.py
+++ b/agentex/tests/unit/api/test_agent_api_keys_authz.py
@@ -87,14 +87,12 @@ class TestDAuthorizedIdApiKeyWrap:
 
         authorization = MagicMock()
         authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
-        event_repository = MagicMock()
         state_repository = MagicMock()
-
         message_repository = MagicMock()
+
         with pytest.raises(ItemDoesNotExist):
             await dep(
                 authorization,
-                event_repository,
                 state_repository,
                 message_repository,
                 "api-key-7",
@@ -111,9 +109,7 @@ class TestDAuthorizedIdApiKeyWrap:
         authorization = MagicMock()
         authorization.check = AsyncMock(return_value=True)
 
-        result = await dep(
-            authorization, MagicMock(), MagicMock(), MagicMock(), "api-key-9"
-        )
+        result = await dep(authorization, MagicMock(), MagicMock(), "api-key-9")
 
         assert result == "api-key-9"
         called_kwargs = authorization.check.await_args.kwargs
@@ -131,7 +127,7 @@ class TestDAuthorizedIdApiKeyWrap:
         authorization = MagicMock()
         authorization.check = AsyncMock(return_value=True)
 
-        await dep(authorization, MagicMock(), MagicMock(), MagicMock(), "api-key-del")
+        await dep(authorization, MagicMock(), MagicMock(), "api-key-del")
 
         called_kwargs = authorization.check.await_args.kwargs
         assert called_kwargs["operation"] == AuthorizedOperationType.delete


### PR DESCRIPTION
## Summary

After the events route work landed on main, `_ensure_authorized_id` no longer takes `event_repository` as a positional FastAPI dep. Its current signature is:

```python
async def _ensure_authorized_id(
    authorization: DAuthorizationService,
    state_repository: DTaskStateRepository,
    message_repository: DTaskMessageRepository,
    resource_id: str = Path(..., alias=param_name),
) -> str:
```

Three `TestDAuthorizedIdApiKeyWrap` cases in `test_agent_api_keys_authz.py` were still passing a 4th `MagicMock` for the removed `event_repository`, triggering:

```
TypeError: DAuthorizedId.<locals>._ensure_authorized_id() takes from 3 to 4 positional arguments but 5 were given
```

This PR drops the extra positional at each site so the closure is called with exactly `(authorization, state_repository, message_repository, resource_id)`.

## Test plan

- [ ] `uv run pytest agentex/tests/unit/api/test_agent_api_keys_authz.py::TestDAuthorizedIdApiKeyWrap -x`
- [ ] Full file passes: `uv run pytest agentex/tests/unit/api/test_agent_api_keys_authz.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Three test calls in `TestDAuthorizedIdApiKeyWrap` were passing a stale `event_repository` `MagicMock` that no longer exists in `_ensure_authorized_id`'s signature, causing a `TypeError` at runtime. This PR removes that extra positional argument from each of the three affected call sites so they match the current `(authorization, state_repository, message_repository, resource_id)` signature.

- Removes `event_repository = MagicMock()` declaration and its positional use in `test_api_key_id_routes_through_wrap_on_denial`.
- Removes the extra inline `MagicMock()` positional from the two remaining `dep(...)` calls (`test_api_key_id_returns_resource_id_when_allowed` and `test_api_key_delete_op_propagated_to_check`).

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal test-only fix that removes a stale argument, and the updated calls match the production signature exactly.

Only the test file changes. The three call sites now pass exactly the four arguments expected by `_ensure_authorized_id`, verified against the implementation in `authorization_shortcuts.py`. No logic, routing, or production code is touched.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/tests/unit/api/test_agent_api_keys_authz.py | Drops stale `event_repository` positional argument from three `TestDAuthorizedIdApiKeyWrap` test calls to match the current 4-parameter `_ensure_authorized_id` signature; change is mechanically correct and no other issues found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as Test Case
    participant dep as _ensure_authorized_id
    participant auth as AuthorizationService
    participant state as StateRepository
    participant msg as MessageRepository

    Test->>dep: dep(authorization, state_repository, message_repository, resource_id)
    dep->>auth: authorization.check(resource, operation)
    alt AuthorizationError raised
        auth-->>dep: AuthorizationError
        dep-->>Test: raises ItemDoesNotExist (404)
    else Allowed
        auth-->>dep: True
        dep-->>Test: returns resource_id
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): drop stale event\_repository a..."](https://github.com/scaleapi/scale-agentex/commit/47195d250b3ef91ba3f5c7f81fd64f935e0f7fcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35245741)</sub>

<!-- /greptile_comment -->