### PR TITLE
chore(authz): scrub internal project references from comments and docstrings

### DIFF
--- a/agentex/src/adapters/authorization/port.py
+++ b/agentex/src/adapters/authorization/port.py
@@ -57,11 +57,11 @@ class AuthorizationGateway(Generic[PrincipalT], ABC):
         resource: AgentexResource,
         parent: AgentexResource | None = None,
     ) -> None:
-        """Register a newly created resource in SpiceDB with the principal as
-        owner. Optionally writes a lifecycle parent edge.
+        """Register a newly created resource with the principal as owner.
+        Optionally writes a lifecycle parent edge.
 
         Use this on resource create instead of ``grant`` when the resource
-        type's SpiceDB definition has a parent relation that permission
+        type's authorization schema has a parent relation that permission
         checks cascade through (e.g. ``agent_api_key`` declares
         ``parent_agent``). Without writing that edge here the cascade fails
         closed.

--- a/agentex/src/api/routes/agent_api_keys.py
+++ b/agentex/src/api/routes/agent_api_keys.py
@@ -57,8 +57,8 @@ async def create_api_key(
         )
     agent = await agent_use_case.get(id=request.agent_id, name=request.agent_name)
 
-    # No api_key resource exists yet, so SpiceDB can't gate transitively —
-    # gate on parent ``agent.update`` directly.
+    # No api_key resource exists yet, so the authorization service can't gate
+    # transitively — gate on parent ``agent.update`` directly.
     await authorization_service.check(
         resource=AgentexResource.agent(agent.id),
         operation=AuthorizedOperationType.update,
@@ -211,8 +211,8 @@ async def delete_agent_api_key(
         param_name="id",
     ),
 ) -> str:
-    # SpiceDB's ``api_key.delete`` expands transitively to
-    # ``parent_agent->update``, so the dep above enforces both factors.
+    # ``api_key.delete`` expands transitively to ``parent_agent->update``,
+    # so the dep above enforces both factors.
     await agent_api_key_use_case.delete(id=id)
     return f"Agent API key with ID {id} deleted"
 

--- a/agentex/src/domain/services/authorization_service.py
+++ b/agentex/src/domain/services/authorization_service.py
@@ -197,7 +197,7 @@ class AuthorizationService:
     ) -> None:
         """Register a newly created resource with the principal as owner.
 
-        Prefer this over ``grant`` when the resource's SpiceDB schema has
+        Prefer this over ``grant`` when the resource's authorization schema has
         a parent relation that permissions cascade through (e.g.
         ``agent_api_key`` declares ``parent_agent``). Pass ``parent`` to
         link the child to its parent atomically; without it the cascade

--- a/agentex/src/domain/use_cases/agent_api_keys_use_case.py
+++ b/agentex/src/domain/use_cases/agent_api_keys_use_case.py
@@ -90,8 +90,6 @@ class AgentAPIKeysUseCase:
 
         api_key_id = orm_id()
 
-        # Unconditional — agentex-auth decides per-account whether the call
-        # routes to Spark or the legacy backend.
         await self._register_api_key_in_auth(
             api_key_id=api_key_id,
             agent_id=agent.id,
@@ -157,9 +155,8 @@ class AgentAPIKeysUseCase:
 
         ``deregister_resource`` removes the resource and all of its
         relationships (owner, parent, grantees) atomically. Always invoked;
-        agentex-auth's per-account routing (#353) decides whether the call
-        targets Spark or the legacy backend. Failures are logged but do not
-        block the delete.
+        the authorization service decides how to route the call. Failures are
+        logged but do not block the delete.
         """
         try:
             await self.authorization_service.deregister_resource(
@@ -252,7 +249,7 @@ class AgentAPIKeysUseCase:
         page_number: int,
         id: list[str] | None = None,
     ) -> list[AgentAPIKeyEntity]:
-        # ``id`` is the FGAC-filter shape used by route deps (DAuthorizedResourceIds).
+        # ``id`` is the authorization-filter shape used by route deps (DAuthorizedResourceIds).
         # ``None`` means "no filter" (e.g. authz bypass); an empty list means
         # "caller can see no api_keys" and must short-circuit to avoid the
         # base repo translating ``id=[]`` into an unfiltered query.

--- a/agentex/src/utils/agent_api_key_authorization.py
+++ b/agentex/src/utils/agent_api_key_authorization.py
@@ -18,7 +18,7 @@ async def _check_api_key_or_collapse_to_404(
     """Check an api_key resource; collapse any denial to 404 to avoid leaking
     cross-tenant existence. Mirrors ``_check_task_or_collapse_to_404``.
 
-    TODO(AGX1-290): restore the 403/404 split once api_keys carry tenant scope.
+    TODO: Restore the 403/404 split once api_keys carry tenant scope.
     """
     try:
         await authorization.check(

--- a/agentex/src/utils/agent_authorization.py
+++ b/agentex/src/utils/agent_authorization.py
@@ -15,7 +15,7 @@ async def check_agent_or_collapse_to_404(
     cross-tenant existence. Mirrors ``check_task_or_collapse_to_404`` in
     ``task_authorization.py`` — see that docstring for the full rationale.
 
-    TODO(AGX1-290): restore 403/404 split once agents carry tenant scope.
+    TODO: Restore the 403/404 split once agents carry tenant scope.
     """
     try:
         await authorization.check(

--- a/agentex/tests/integration/api/checkpoints/test_checkpoints_authz_api.py
+++ b/agentex/tests/integration/api/checkpoints/test_checkpoints_authz_api.py
@@ -1,17 +1,15 @@
 """
 Integration tests for checkpoint-route authorization.
 
-Covers the AGX1-302 deliverable: checkpoint routes have no SpiceDB type of
-their own. Each route enforces on the owning task (``thread_id`` is the task id)
-via ``DAuthorizedBodyId(task, ...)``:
+Checkpoint routes have no authorization type of their own. Each route enforces
+on the owning task (``thread_id`` is the task id) via ``DAuthorizedBodyId(task, ...)``:
 
 * get-tuple / list -> ``task.read`` (view).
 * put / put-writes -> ``task.update`` (editor + owner); delete-thread -> ``task.delete``.
 
-Per the canonical ``DAuthorizedBodyId`` task wrap (the 404/403 collapse landed
-by AGX1-275 / #249), a denied check on the parent task collapses to 404 (not
-403) on every route — reads and writes alike — so callers cannot probe
-cross-tenant existence by comparing response codes.
+Per the canonical ``DAuthorizedBodyId`` task wrap, a denied check on the parent
+task collapses to 404 (not 403) on every route — reads and writes alike — so
+callers cannot probe cross-tenant existence by comparing response codes.
 """
 
 from typing import Any

--- a/agentex/tests/integration/api/events/test_events_authz_api.py
+++ b/agentex/tests/integration/api/events/test_events_authz_api.py
@@ -1,4 +1,4 @@
-"""AGX1-244: event routes delegate authz to the parent agent."""
+"""Tests for event route authorization — routes delegate checks to the parent agent."""
 
 from typing import Any
 from unittest.mock import patch

--- a/agentex/tests/integration/api/messages/test_messages_authz_api.py
+++ b/agentex/tests/integration/api/messages/test_messages_authz_api.py
@@ -1,9 +1,9 @@
 """
 Integration tests for message-route authorization.
 
-Covers the AGX1-277 deliverable: list/get messages enforce ``task.read`` on
-the parent task, with denied checks collapsing to 404 (not 403) so callers
-cannot probe cross-tenant existence by comparing response codes.
+List/get message routes enforce ``task.read`` on the parent task, with denied
+checks collapsing to 404 (not 403) so callers cannot probe cross-tenant
+existence by comparing response codes.
 """
 
 from typing import Any

--- a/agentex/tests/integration/services/test_agent_api_key_service_dual_write.py
+++ b/agentex/tests/integration/services/test_agent_api_key_service_dual_write.py
@@ -1,15 +1,14 @@
-"""Integration tests for AgentAPIKeysUseCase dual-write to Spark AuthZ.
+"""Integration tests for AgentAPIKeysUseCase dual-write to the authorization service.
 
-These cover the AGX1-272 dual-write path. scale-agentex calls
-``register_resource`` / ``deregister_resource`` unconditionally; per-account
-routing (Spark vs legacy SGP) is owned by agentex-auth (scaleapi/agentex#353)
-so scale-agentex does NOT couple to egp-api-backend's feature-flag service.
+scale-agentex calls ``register_resource`` / ``deregister_resource``
+unconditionally; per-account routing is owned by the authorization gateway,
+so scale-agentex does NOT couple to the authorization flag service.
 
 - Create calls register_resource with parent=agent (the parent_agent edge
-  is load-bearing for the SpiceDB cascade).
+  is load-bearing for the authorization cascade).
 - Delete calls deregister_resource after the Postgres row is gone.
-- Spark failure prevents row: when register_resource raises, the api_key
-  is NOT persisted.
+- Registration failure prevents row: when register_resource raises, the
+  api_key is NOT persisted.
 - Deregister failure does not block delete: when deregister_resource
   raises, the DB delete still completes and the failure is logged.
 - No creator → no register: if neither user_id nor service_account_id is
@@ -17,9 +16,10 @@ so scale-agentex does NOT couple to egp-api-backend's feature-flag service.
 
 The tests intentionally mock the repository, authorization service, agent
 repository, and HTTP client. The behaviour under test is the call sequencing
-inside ``AgentAPIKeysUseCase`` — not Postgres or Spark itself.
+inside ``AgentAPIKeysUseCase`` — not the underlying persistence or authorization
+cluster itself.
 
-Note on structural divergence from the task PR (AGX1-274): tasks live behind
+Note on structural divergence from the task dual-write: tasks live behind
 ``AgentTaskService``; agent_api_keys have no service layer, so the dual-write
 logic is colocated in ``AgentAPIKeysUseCase``.
 """
@@ -154,7 +154,7 @@ async def test_create_api_key_calls_register_resource_with_parent(
     registered_resource: AgentexResource = register.await_args.kwargs["resource"]
     assert registered_resource.type == AgentexResourceType.api_key
     assert registered_resource.selector == api_key.id
-    # parent_agent edge is load-bearing — without it the SpiceDB cascade
+    # parent_agent edge is load-bearing — without it the authorization cascade
     # `read = ... & parent_agent->read & ...` fails closed for every reader.
     registered_parent: AgentexResource = register.await_args.kwargs["parent"]
     assert registered_parent is not None

--- a/agentex/tests/integration/services/test_schedule_service_dual_write.py
+++ b/agentex/tests/integration/services/test_schedule_service_dual_write.py
@@ -1,18 +1,18 @@
-"""Integration tests for ScheduleService dual-write to Spark AuthZ.
+"""Integration tests for ScheduleService dual-write to the authorization service.
 
 scale-agentex calls ``register_resource`` / ``deregister_resource``
-unconditionally; per-account routing (Spark vs legacy SGP) is owned by
-agentex-auth so scale-agentex does NOT couple to a feature-flag service.
+unconditionally; per-account routing is owned by the authorization gateway,
+so scale-agentex does NOT couple to a feature-flag service.
 
 Schedule-specific shape (vs the agent_api_key dual-write): schedules have no
 Postgres row — Temporal is the store and the auth selector is the schedule id
-``{agent_id}--{schedule_name}``. The dual-write is therefore Temporal + Spark,
+``{agent_id}--{schedule_name}``. The dual-write is therefore Temporal + authorization,
 so the dual-write lives in ``ScheduleService`` (where the Temporal write is)
 rather than the use case, and the compensation boundary is scoped to the
 Temporal create only:
 
 - Create registers register_resource with parent=agent (the parent_agent edge
-  is load-bearing for the SpiceDB cascade) BEFORE the Temporal create.
+  is load-bearing for the authorization cascade) BEFORE the Temporal create.
 - Register failure prevents the Temporal create (fail-closed).
 - A Temporal create failure after a successful register triggers a
   compensating deregister (best-effort), then the original error re-raises.
@@ -26,7 +26,7 @@ Temporal create only:
 
 The tests mock the Temporal adapter and authorization service and stub the
 post-create read-back; the behaviour under test is the call sequencing inside
-``ScheduleService`` — not Temporal or Spark itself.
+``ScheduleService`` — not Temporal or the authorization cluster itself.
 """
 
 from __future__ import annotations
@@ -132,7 +132,7 @@ async def test_create_schedule_calls_register_resource_with_parent() -> None:
     registered_resource: AgentexResource = register.await_args.kwargs["resource"]
     assert registered_resource.type == AgentexResourceType.schedule
     assert registered_resource.selector == build_schedule_id(agent.id, request.name)
-    # parent_agent edge is load-bearing — without it the SpiceDB cascade
+    # parent_agent edge is load-bearing — without it the authorization cascade
     # `read = ... & parent_agent->read` fails closed for every reader.
     registered_parent: AgentexResource = register.await_args.kwargs["parent"]
     assert registered_parent is not None

--- a/agentex/tests/unit/api/test_agent_api_keys_authz.py
+++ b/agentex/tests/unit/api/test_agent_api_keys_authz.py
@@ -1,7 +1,8 @@
-"""AGX1-263 — agent_api_keys route migration to Spark AuthZ.
+"""Tests for agent_api_keys route authorization.
 
 Asserts the route layer issues correct ``check`` calls and collapses denials
-to 404. Two-factor SpiceDB expansion is owned by spark-authz; not tested here.
+to 404. Two-factor expansion is owned by the authorization service;
+not tested here.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Scrubs internal references (Linear ticket IDs, internal service names, internal flag names) from comments and docstrings across already-landed authorization code. Fixes issues introduced by #248, #252, #255, #257, #259, and #260.

No behavior changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scrubs internal project references — Linear ticket IDs, internal service names (`SpiceDB`, `Spark`, `agentex-auth`, `spark-authz`), and internal flag identifiers — from comments and docstrings across authorization code landed in PRs #248–#260. There are zero behavior changes.

- **Comments/docstrings only**: Every diff hunk is a text-only change; no imports, logic, call sites, or test assertions are touched.
- **Terminology generalized**: Internal names like \"SpiceDB\" and \"Spark AuthZ\" are replaced with generic terms (`authorization schema`, `authorization service`, `authorization cascade`) that remain accurate without leaking implementation details.
- **TODO tickets removed**: Two `TODO(AGX1-290):` markers are simplified to bare `TODO:` comments, preserving the intent while dropping the internal tracker reference.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — every change is comment or docstring text only with no effect on runtime behavior.

All twelve files receive purely textual edits to comments and docstrings. No logic, imports, call sites, or test assertions are modified, so there is no risk of a behavioral regression.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/adapters/authorization/port.py | Replaced 'SpiceDB' with 'authorization schema' in two docstring phrases — no logic changes. |
| agentex/src/api/routes/agent_api_keys.py | Scrubbed 'SpiceDB' from two inline comments; logic and call sites unchanged. |
| agentex/src/domain/services/authorization_service.py | Single docstring word swap ('SpiceDB schema' → 'authorization schema') — no logic changes. |
| agentex/src/domain/use_cases/agent_api_keys_use_case.py | Removed unconditional-routing comment, replaced 'agentex-auth' and 'FGAC' references with generic names — no logic changes. |
| agentex/src/utils/agent_api_key_authorization.py | Removed Linear ticket ID from TODO comment, preserving the intent — no logic changes. |
| agentex/src/utils/agent_authorization.py | Removed Linear ticket ID from TODO comment, preserving the intent — no logic changes. |
| agentex/tests/integration/api/checkpoints/test_checkpoints_authz_api.py | Removed Linear ticket references and 'SpiceDB' from module docstring — tests and assertions unchanged. |
| agentex/tests/integration/api/events/test_events_authz_api.py | Module docstring updated to remove Linear ticket ID; no test logic changes. |
| agentex/tests/integration/api/messages/test_messages_authz_api.py | Module docstring updated to remove Linear ticket reference; no test logic changes. |
| agentex/tests/integration/services/test_agent_api_key_service_dual_write.py | Replaced 'Spark AuthZ', 'agentex-auth', 'SpiceDB', and Linear ticket IDs throughout docstrings and inline comments — tests and assertions unchanged. |
| agentex/tests/integration/services/test_schedule_service_dual_write.py | Replaced 'Spark AuthZ', 'SpiceDB', and internal service names throughout docstrings — tests and assertions unchanged. |
| agentex/tests/unit/api/test_agent_api_keys_authz.py | Module docstring scrubbed of Linear ticket ID and 'Spark AuthZ' references — no test logic changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #268 – comment scrub] --> B[Source files\nagentex/src/]
    A --> C[Test files\nagentex/tests/]
    B --> D[adapters/authorization/port.py\nSpiceDB → authorization schema]
    B --> E[api/routes/agent_api_keys.py\nSpiceDB → authorization service]
    B --> F[domain/services/authorization_service.py\nSpiceDB schema → authorization schema]
    B --> G[domain/use_cases/agent_api_keys_use_case.py\nRemove internal routing comment]
    B --> H[utils/agent_api_key_authorization.py\nTODO ticket ID removed]
    B --> I[utils/agent_authorization.py\nTODO ticket ID removed]
    C --> J[integration/api – 3 files\nLinear IDs + SpiceDB removed from docstrings]
    C --> K[integration/services – 2 files\nSpark AuthZ → authorization service]
    C --> L[unit/api – 1 file\nModule docstring scrubbed]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore(authz): scrub internal project ref..."](https://github.com/scaleapi/scale-agentex/commit/628e8fbf15206eb0f9b0cd90b5354ce34328569b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35250665)</sub>

<!-- /greptile_comment -->