### PR TITLE
feat(ui): add agent-configs page backed by SGP

### DIFF
--- a/agentex-ui/app/agent-configs/page.tsx
+++ b/agentex-ui/app/agent-configs/page.tsx
@@ -1,0 +1,413 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import AgentexSDK from 'agentex';
+import { agentRPCNonStreaming } from 'agentex/lib';
+
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+type AgentConfig = {
+  id: string;
+  name: string;
+  description: string | null;
+  system_prompt: string;
+  harness: string;
+  allowed_tools: string[];
+  model: string;
+  created_at: string;
+  updated_at: string;
+};
+
+const DEFAULT_AGENT_NAME = 'golden-agent';
+
+const AGENTEX_API_BASE_URL =
+  process.env.NEXT_PUBLIC_AGENTEX_API_BASE_URL ?? 'http://localhost:5004';
+
+export default function AgentConfigsPage() {
+  const router = useRouter();
+
+  const agentexClient = useMemo(
+    () =>
+      new AgentexSDK({
+        baseURL: AGENTEX_API_BASE_URL,
+        fetchOptions: { credentials: 'include' },
+      }),
+    []
+  );
+
+  const [configs, setConfigs] = useState<AgentConfig[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  // Per-config launcher state — keyed by config id so each card has its own
+  // textarea + agent-name input + busy flag.
+  const [launchState, setLaunchState] = useState<
+    Record<string, { message: string; agentName: string; busy: boolean }>
+  >({});
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/agent-configs');
+      if (!res.ok) throw new Error(await res.text());
+      const data = await res.json();
+      setConfigs(Array.isArray(data?.items) ? data.items : []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load agent configs');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  function updateLaunch(
+    id: string,
+    patch: Partial<{ message: string; agentName: string; busy: boolean }>
+  ) {
+    setLaunchState(prev => ({
+      ...prev,
+      [id]: {
+        message: prev[id]?.message ?? '',
+        agentName: prev[id]?.agentName ?? DEFAULT_AGENT_NAME,
+        busy: false,
+        ...patch,
+      },
+    }));
+  }
+
+  async function launchWithConfig(config: AgentConfig) {
+    const state = launchState[config.id];
+    const message = (state?.message ?? '').trim();
+    const agentName = (state?.agentName ?? DEFAULT_AGENT_NAME).trim();
+    if (!message) {
+      setError('Enter a message before launching.');
+      return;
+    }
+    setError(null);
+    updateLaunch(config.id, { busy: true });
+
+    try {
+      // task/create — pass the agent config as params. The golden agent reads
+      // system_prompt / allowed_tools / harness / model off task params.
+      const createResp = await agentRPCNonStreaming(
+        agentexClient,
+        { agentName },
+        'task/create',
+        {
+          params: {
+            system_prompt: config.system_prompt,
+            allowed_tools: config.allowed_tools,
+            harness: config.harness,
+            model: config.model,
+            // attach the source config id so traces can be cross-referenced.
+            agent_config_id: config.id,
+          },
+        }
+      );
+      if (createResp.error) throw new Error(createResp.error.message);
+      const task = createResp.result as { id: string };
+
+      // First user message — agent's acp_type is `async`, so use event/send.
+      const sendResp = await agentRPCNonStreaming(
+        agentexClient,
+        { agentName },
+        'event/send',
+        {
+          task_id: task.id,
+          content: {
+            type: 'text',
+            author: 'user',
+            format: 'plain',
+            attachments: [],
+            content: message,
+          },
+        }
+      );
+      if (sendResp.error) throw new Error(sendResp.error.message);
+
+      // Hand off to the main UI so the user can watch streaming output.
+      // useSafeSearchParams reads agent_name + task_id from the URL.
+      const params = new URLSearchParams({
+        agent_name: agentName,
+        task_id: task.id,
+      });
+      router.push(`/?${params.toString()}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Launch failed');
+      updateLaunch(config.id, { busy: false });
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-10 px-6 py-10">
+      <header>
+        <h1 className="text-2xl font-semibold">Agent configs</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Pick a config from pubsec-dev SGP (via the forwarded{' '}
+          <code>egp-api-backend</code>), type a message, and dispatch it to a
+          locally running agent through your local agentex (
+          <code>{AGENTEX_API_BASE_URL}</code>). Default target is{' '}
+          <code>{DEFAULT_AGENT_NAME}</code>.
+        </p>
+      </header>
+
+      {error && (
+        <div
+          role="alert"
+          className="border-destructive bg-destructive/10 text-destructive rounded-md border p-3 text-sm whitespace-pre-wrap"
+        >
+          {error}
+        </div>
+      )}
+
+      <section>
+        <h2 className="mb-3 text-lg font-medium">Launch a session</h2>
+        {loading ? (
+          <p className="text-muted-foreground text-sm">Loading…</p>
+        ) : configs.length === 0 ? (
+          <p className="text-muted-foreground text-sm">No configs yet.</p>
+        ) : (
+          <ul className="space-y-4">
+            {configs.map(c => {
+              const s = launchState[c.id] ?? {
+                message: '',
+                agentName: DEFAULT_AGENT_NAME,
+                busy: false,
+              };
+              return (
+                <li
+                  key={c.id}
+                  className="border-border space-y-3 rounded-md border p-4"
+                >
+                  <div className="flex items-baseline justify-between gap-3">
+                    <div>
+                      <div className="font-medium">{c.name}</div>
+                      {c.description && (
+                        <div className="text-muted-foreground mt-1 text-sm">
+                          {c.description}
+                        </div>
+                      )}
+                    </div>
+                    <code className="text-muted-foreground text-xs">
+                      {c.id}
+                    </code>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2 text-xs">
+                    <span className="bg-muted rounded px-2 py-0.5">
+                      harness: {c.harness}
+                    </span>
+                    <span className="bg-muted rounded px-2 py-0.5">
+                      model: {c.model}
+                    </span>
+                    {c.allowed_tools.map(t => (
+                      <span
+                        key={t}
+                        className="bg-muted text-muted-foreground rounded px-2 py-0.5"
+                      >
+                        {t}
+                      </span>
+                    ))}
+                  </div>
+
+                  <details className="text-xs">
+                    <summary className="text-muted-foreground cursor-pointer">
+                      System prompt
+                    </summary>
+                    <pre className="bg-muted mt-2 rounded p-2 text-xs whitespace-pre-wrap">
+                      {c.system_prompt}
+                    </pre>
+                  </details>
+
+                  <div className="grid grid-cols-[1fr_auto] items-end gap-3">
+                    <div className="space-y-1">
+                      <Label htmlFor={`msg-${c.id}`}>First message</Label>
+                      <Textarea
+                        id={`msg-${c.id}`}
+                        value={s.message}
+                        onChange={e =>
+                          updateLaunch(c.id, { message: e.target.value })
+                        }
+                        rows={3}
+                        placeholder="What should the agent do?"
+                      />
+                    </div>
+                    <div className="w-56 space-y-1">
+                      <Label htmlFor={`agent-${c.id}`}>Agent name</Label>
+                      <input
+                        id={`agent-${c.id}`}
+                        value={s.agentName}
+                        onChange={e =>
+                          updateLaunch(c.id, { agentName: e.target.value })
+                        }
+                        className="border-input w-full rounded-md border px-3 py-2 text-sm"
+                      />
+                      <Button
+                        type="button"
+                        className="mt-2 w-full"
+                        disabled={s.busy || !s.message.trim()}
+                        onClick={() => launchWithConfig(c)}
+                      >
+                        {s.busy ? 'Launching…' : 'Launch'}
+                      </Button>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section>
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-medium">Create a config</h2>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setShowCreate(s => !s)}
+          >
+            {showCreate ? 'Hide' : 'Show'}
+          </Button>
+        </div>
+        {showCreate && <CreateForm onCreated={refresh} setError={setError} />}
+      </section>
+    </div>
+  );
+}
+
+// ----- Create form (secondary; collapsed by default) -----------------------
+
+function CreateForm({
+  onCreated,
+  setError,
+}: {
+  onCreated: () => void;
+  setError: (e: string | null) => void;
+}) {
+  const EMPTY = {
+    name: '',
+    description: '',
+    system_prompt: '',
+    harness: 'claude-code',
+    model: 'claude-opus-4-6',
+    allowed_tools: 'Read,Write,Bash,WebFetch',
+  };
+  const [form, setForm] = useState(EMPTY);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const allowed_tools = form.allowed_tools
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+      const res = await fetch('/api/agent-configs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          description: form.description || undefined,
+          system_prompt: form.system_prompt,
+          harness: form.harness,
+          model: form.model,
+          allowed_tools,
+        }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setForm(EMPTY);
+      onCreated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Create failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleCreate} className="mt-3 space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1">
+          <Label htmlFor="name">Name</Label>
+          <input
+            id="name"
+            value={form.name}
+            onChange={e => setForm({ ...form, name: e.target.value })}
+            required
+            className="border-input w-full rounded-md border px-3 py-2 text-sm"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="model">Model</Label>
+          <input
+            id="model"
+            value={form.model}
+            onChange={e => setForm({ ...form, model: e.target.value })}
+            required
+            className="border-input w-full rounded-md border px-3 py-2 text-sm"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="harness">Harness</Label>
+          <input
+            id="harness"
+            value={form.harness}
+            onChange={e => setForm({ ...form, harness: e.target.value })}
+            required
+            className="border-input w-full rounded-md border px-3 py-2 text-sm"
+            placeholder="claude-code | codex | litellm"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="tools">Allowed tools (comma-separated)</Label>
+          <input
+            id="tools"
+            value={form.allowed_tools}
+            onChange={e => setForm({ ...form, allowed_tools: e.target.value })}
+            className="border-input w-full rounded-md border px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="description">Description</Label>
+        <input
+          id="description"
+          value={form.description}
+          onChange={e => setForm({ ...form, description: e.target.value })}
+          className="border-input w-full rounded-md border px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor="system_prompt">System prompt</Label>
+        <Textarea
+          id="system_prompt"
+          value={form.system_prompt}
+          onChange={e => setForm({ ...form, system_prompt: e.target.value })}
+          required
+          rows={6}
+        />
+      </div>
+
+      <div className="flex justify-end">
+        <Button type="submit" disabled={submitting}>
+          {submitting ? 'Creating…' : 'Create'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/agentex-ui/app/api/agent-configs/route.ts
+++ b/agentex-ui/app/api/agent-configs/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+
+import {
+  createAgentConfig,
+  isSGPConfigured,
+  listAgentConfigs,
+  type CreateAgentConfigRequest,
+} from '@/lib/sgp-client';
+
+function notConfigured() {
+  return NextResponse.json(
+    {
+      error:
+        'SGP is not configured. Set NEXT_PUBLIC_SGP_API_URL (e.g. http://localhost:5003/public) and restart the UI.',
+    },
+    { status: 503 }
+  );
+}
+
+export async function GET(request: Request) {
+  if (!isSGPConfigured()) return notConfigured();
+  try {
+    const data = await listAgentConfigs(request);
+    return NextResponse.json(data);
+  } catch (error) {
+    return forwardError(error);
+  }
+}
+
+export async function POST(request: Request) {
+  if (!isSGPConfigured()) return notConfigured();
+
+  let body: CreateAgentConfigRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  if (!body.name || !body.system_prompt || !body.harness || !body.model) {
+    return NextResponse.json(
+      { error: 'name, system_prompt, harness, model are required' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const created = await createAgentConfig(request, {
+      ...body,
+      allowed_tools: body.allowed_tools ?? [],
+    });
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    return forwardError(error);
+  }
+}
+
+function forwardError(error: unknown) {
+  if (
+    typeof error === 'object' &&
+    error &&
+    'status' in error &&
+    'body' in error
+  ) {
+    const e = error as { status: number; body: string };
+    return NextResponse.json({ error: e.body }, { status: e.status });
+  }
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  return NextResponse.json({ error: message }, { status: 502 });
+}

--- a/agentex-ui/components/task-sidebar/task-sidebar-header.tsx
+++ b/agentex-ui/components/task-sidebar/task-sidebar-header.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
-import { PanelLeftClose, MessageSquarePlus } from 'lucide-react';
+import { PanelLeftClose, MessageSquarePlus, Settings2 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -55,6 +55,15 @@ export function TaskSidebarHeader({
         <kbd className="bg-muted text-muted-foreground pointer-events-none inline-flex h-5 items-center gap-1 rounded border px-1.5 font-mono text-[10px] font-medium opacity-100 select-none">
           <span className="text-xs/snug">⌘</span>K
         </kbd>
+      </ResizableSidebar.Button>
+      <ResizableSidebar.Button
+        onClick={() => router.push('/agent-configs')}
+        className="text-foreground flex items-center gap-2 p-2"
+        aria-label="Agent configs"
+        disableAnimation={true}
+      >
+        <Settings2 className="size-5" />
+        Agent configs
       </ResizableSidebar.Button>
     </div>
   );

--- a/agentex-ui/lib/sgp-client.ts
+++ b/agentex-ui/lib/sgp-client.ts
@@ -1,0 +1,170 @@
+/**
+ * Thin server-side SGP REST client. Lives in lib/ because it's called from
+ * Next.js route handlers (app/api/...), not the browser — keeps the SGP
+ * base URL + outgoing auth headers off the client bundle.
+ */
+
+const SGP_BASE_URL =
+  process.env.NEXT_PUBLIC_SGP_API_URL ??
+  (process.env.NEXT_PUBLIC_SGP_APP_URL
+    ? `${process.env.NEXT_PUBLIC_SGP_APP_URL}/api`
+    : undefined);
+
+export type SGPClientError = {
+  status: number;
+  body: string;
+};
+
+export function isSGPConfigured(): boolean {
+  return Boolean(SGP_BASE_URL);
+}
+
+export function sgpHeadersFromRequest(
+  request: Request
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const forwarded = [
+    'cookie',
+    'authorization',
+    'x-api-key',
+    'x-selected-account-id',
+  ];
+  for (const key of forwarded) {
+    const value = request.headers.get(key);
+    if (value) headers[key] = value;
+  }
+
+  // Server-side fallbacks: the browser fetch to /api/agent-configs carries no
+  // SGP credentials, so when nothing was forwarded fall back to the API key +
+  // account id configured for this UI instance. Forwarded headers (e.g. a real
+  // logged-in SGP session) take precedence over the env defaults.
+  if (!headers['x-api-key'] && process.env.SGP_API_KEY) {
+    headers['x-api-key'] = process.env.SGP_API_KEY;
+  }
+  if (!headers['x-selected-account-id'] && process.env.SGP_ACCOUNT_ID) {
+    headers['x-selected-account-id'] = process.env.SGP_ACCOUNT_ID;
+  }
+
+  return headers;
+}
+
+async function sgpFetch(
+  path: string,
+  init: RequestInit,
+  headers: Record<string, string>
+): Promise<Response> {
+  if (!SGP_BASE_URL) {
+    throw new Error(
+      'SGP is not configured. Set NEXT_PUBLIC_SGP_API_URL or NEXT_PUBLIC_SGP_APP_URL.'
+    );
+  }
+  return fetch(`${SGP_BASE_URL}${path}`, { ...init, headers });
+}
+
+async function parseOrThrow<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const body = await res.text();
+    const err: SGPClientError = { status: res.status, body };
+    throw err;
+  }
+  return res.json() as Promise<T>;
+}
+
+// ----- Agent configs --------------------------------------------------------
+
+export type AgentConfig = {
+  object: 'agent_config';
+  id: string;
+  name: string;
+  description: string | null;
+  system_prompt: string;
+  harness: string;
+  allowed_tools: string[];
+  model: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AgentConfigListResponse = {
+  items: AgentConfig[];
+  // SGP paginated list may include cursors/total — keeping loose to avoid
+  // over-fitting the type to one shape.
+  [k: string]: unknown;
+};
+
+export type CreateAgentConfigRequest = {
+  name: string;
+  description?: string;
+  system_prompt: string;
+  harness: string;
+  allowed_tools: string[];
+  model: string;
+};
+
+export type UpdateAgentConfigRequest = Partial<CreateAgentConfigRequest>;
+
+export async function listAgentConfigs(
+  request: Request
+): Promise<AgentConfigListResponse> {
+  const res = await sgpFetch(
+    '/v5/agent_configs',
+    { method: 'GET' },
+    sgpHeadersFromRequest(request)
+  );
+  return parseOrThrow<AgentConfigListResponse>(res);
+}
+
+export async function createAgentConfig(
+  request: Request,
+  body: CreateAgentConfigRequest
+): Promise<AgentConfig> {
+  const res = await sgpFetch(
+    '/v5/agent_configs',
+    { method: 'POST', body: JSON.stringify(body) },
+    sgpHeadersFromRequest(request)
+  );
+  return parseOrThrow<AgentConfig>(res);
+}
+
+export async function getAgentConfig(
+  request: Request,
+  id: string
+): Promise<AgentConfig> {
+  const res = await sgpFetch(
+    `/v5/agent_configs/${encodeURIComponent(id)}`,
+    { method: 'GET' },
+    sgpHeadersFromRequest(request)
+  );
+  return parseOrThrow<AgentConfig>(res);
+}
+
+export async function updateAgentConfig(
+  request: Request,
+  id: string,
+  body: UpdateAgentConfigRequest
+): Promise<AgentConfig> {
+  const res = await sgpFetch(
+    `/v5/agent_configs/${encodeURIComponent(id)}`,
+    { method: 'PATCH', body: JSON.stringify(body) },
+    sgpHeadersFromRequest(request)
+  );
+  return parseOrThrow<AgentConfig>(res);
+}
+
+export async function deleteAgentConfig(
+  request: Request,
+  id: string
+): Promise<void> {
+  const res = await sgpFetch(
+    `/v5/agent_configs/${encodeURIComponent(id)}`,
+    { method: 'DELETE' },
+    sgpHeadersFromRequest(request)
+  );
+  if (!res.ok) {
+    const body = await res.text();
+    const err: SGPClientError = { status: res.status, body };
+    throw err;
+  }
+}


### PR DESCRIPTION
Adds an agent-configs page that lists/creates SGP agent configs through a server-side Next.js route handler and a thin SGP REST client, plus a sidebar nav entry to reach it. The route forwards SGP auth headers from the request and falls back to server-side SGP_API_KEY / SGP_ACCOUNT_ID env vars when the browser supplies none, so the UI-driven flow authenticates without a logged-in SGP session.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an `/agent-configs` UI page backed by a new thin SGP REST client and a Next.js route handler that forwards browser auth headers to SGP, falling back to server-side env-var credentials when none are present. A sidebar button in `TaskSidebarHeader` provides navigation to the new page.

- **`sgp-client.ts`**: New server-side wrapper around `/v5/agent_configs`; exposes list, create, get, update, delete — only list and create are wired to the route handler today.
- **`/api/agent-configs` route**: Proxies SGP requests and validates required POST fields; the credential fallback to `SGP_API_KEY` has no caller authentication gate, so any network-reachable request executes under the server's identity.
- **`agent-configs/page.tsx`**: Client-side page with per-card launch state (message + agent name), a collapsible create form, and post-launch redirect to the main task view.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The route handler's credential-fallback design lets any unauthenticated caller act under the server's SGP API key; worth resolving before deploying to any shared environment.

The core logic is straightforward and the client-side page is well-structured. The main concern is the route handler: with SGP_API_KEY set, unauthenticated GET and POST requests to /api/agent-configs will execute against SGP under the server's credentials, with no check on the caller's identity.

agentex-ui/app/api/agent-configs/route.ts — the credential fallback path needs a caller-identity check before this is deployed to any shared server.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Unauthenticated access via server credentials** (`agentex-ui/app/api/agent-configs/route.ts`): When no browser auth headers are present, both the GET and POST handlers fall back to the server's `SGP_API_KEY` without any check on who the caller is. Any user who can reach the Next.js server can list or create SGP agent configs under the server's identity.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex-ui/lib/sgp-client.ts | New server-side SGP REST client; well-structured with proper error typing, but the file comment incorrectly claims NEXT_PUBLIC_ env vars are kept off the client bundle. |
| agentex-ui/app/api/agent-configs/route.ts | New Next.js route handler for listing/creating SGP agent configs; falls back to server-side SGP_API_KEY for unauthenticated requests with no access check, allowing any reachable caller to act under the server's credentials. |
| agentex-ui/app/agent-configs/page.tsx | New client page for listing, launching, and creating agent configs; per-card state management is clean, but refresh and launchWithConfig lack useCallback wrappers per team convention. |
| agentex-ui/components/task-sidebar/task-sidebar-header.tsx | Adds a Settings2 icon button to the sidebar header that navigates to /agent-configs; minimal, consistent with existing router.push usage in this component. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant NextRoute as /api/agent-configs (Next.js)
    participant SGPClient as sgp-client.ts
    participant SGP as SGP API

    Browser->>NextRoute: GET /api/agent-configs (with or without auth cookies)
    NextRoute->>SGPClient: listAgentConfigs(request)
    SGPClient->>SGPClient: sgpHeadersFromRequest() forward cookie/auth if present else use SGP_API_KEY env var
    SGPClient->>SGP: GET /v5/agent_configs
    SGP-->>SGPClient: "{ items: [...] }"
    SGPClient-->>NextRoute: AgentConfigListResponse
    NextRoute-->>Browser: JSON response

    Browser->>NextRoute: POST /api/agent-configs (config body)
    NextRoute->>SGPClient: createAgentConfig(request, body)
    SGPClient->>SGP: POST /v5/agent_configs
    SGP-->>SGPClient: AgentConfig
    SGPClient-->>NextRoute: created config
    NextRoute-->>Browser: 201 JSON

    Browser->>Browser: launchWithConfig()
    Browser->>AgentexAPI: agentRPCNonStreaming task/create
    AgentexAPI-->>Browser: "{ id: taskId }"
    Browser->>AgentexAPI: agentRPCNonStreaming event/send
    AgentexAPI-->>Browser: ok
    Browser->>Browser: "router.push(/?agent_name=...&task_id=...)"
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aagentex-ui%2Fapp%2Fapi%2Fagent-configs%2Froute.ts%3A19-28%0A**Unauthenticated%20access%20uses%20server-side%20SGP%20credentials**%0A%0A%60sgpHeadersFromRequest%60%20falls%20back%20to%20%60SGP_API_KEY%60%20%2F%20%60SGP_ACCOUNT_ID%60%20when%20no%20browser%20credentials%20are%20forwarded%2C%20so%20any%20unauthenticated%20request%20to%20this%20route%20%28GET%20or%20POST%29%20will%20silently%20execute%20against%20SGP%20under%20the%20server's%20API%20key.%20If%20this%20Next.js%20server%20is%20reachable%20by%20more%20than%20one%20person%20%28a%20shared%20dev%20box%2C%20a%20staging%20deploy%29%2C%20any%20visitor%20can%20enumerate%20or%20create%20agent%20configs%20without%20holding%20their%20own%20SGP%20session.%20Consider%20adding%20a%20minimal%20check%20%E2%80%94%20e.g.%20401%20when%20both%20the%20forwarded%20%60x-api-key%60%2F%60authorization%60%2F%60cookie%60%20are%20absent%20AND%20%60SGP_API_KEY%60%20is%20set%20%E2%80%94%20so%20the%20fallback%20only%20activates%20for%20explicitly%20allowed%20callers.%0A%0A%23%23%23%20Issue%202%20of%203%0Aagentex-ui%2Flib%2Fsgp-client.ts%3A1-5%0AThe%20file%20header%20says%20this%20module%20%22keeps%20the%20SGP%20base%20URL%20%2B%20outgoing%20auth%20headers%20off%20the%20client%20bundle%2C%22%20but%20%60NEXT_PUBLIC_%60%20variables%20are%20statically%20inlined%20by%20Next.js%20into%20every%20bundle%20that%20references%20them%20%E2%80%94%20including%20the%20client.%20The%20SGP%20base%20URL%20is%20therefore%20visible%20in%20the%20browser.%20If%20the%20intent%20really%20is%20to%20keep%20it%20server-only%2C%20remove%20the%20%60NEXT_PUBLIC_%60%20prefix%20%28and%20update%20%60route.ts%60's%20503%20message%20accordingly%29%3B%20if%20the%20URL%20is%20intentionally%20public%2C%20just%20drop%20the%20misleading%20comment.%0A%0A%60%60%60suggestion%0A%2F**%0A%20*%20Thin%20server-side%20SGP%20REST%20client.%20Lives%20in%20lib%2F%20because%20it's%20called%20from%0A%20*%20Next.js%20route%20handlers%20%28app%2Fapi%2F...%29%2C%20not%20the%20browser.%20Note%3A%20SGP_BASE_URL%0A%20*%20is%20derived%20from%20NEXT_PUBLIC_%20env%20vars%20and%20is%20therefore%20visible%20in%20the%0A%20*%20client%20bundle%3B%20only%20auth%20headers%20and%20the%20API%20key%20remain%20server-side.%0A%20*%2F%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aagentex-ui%2Fapp%2Fagent-configs%2Fpage.tsx%3A60-72%0A**%60refresh%60%20and%20%60launchWithConfig%60%20not%20wrapped%20in%20%60useCallback%60**%0A%0APer%20the%20team's%20rule%2C%20helper%20functions%20used%20in%20component%20render%20logic%20should%20be%20wrapped%20in%20%60useCallback%60%20to%20prevent%20unnecessary%20re-creation%20on%20each%20render.%20%60refresh%60%20is%20passed%20as%20%60onCreated%60%20to%20%60CreateForm%60%20and%20would%20cause%20that%20child%20to%20re-render%20on%20every%20parent%20state%20update%3B%20%60launchWithConfig%60%20is%20called%20inside%20an%20inline%20%60onClick%60%20but%20similarly%20changes%20identity%20on%20every%20render.%20Both%20should%20use%20%60useCallback%60%20with%20the%20appropriate%20dependencies.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=274&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
agentex-ui/app/api/agent-configs/route.ts:19-28
**Unauthenticated access uses server-side SGP credentials**

`sgpHeadersFromRequest` falls back to `SGP_API_KEY` / `SGP_ACCOUNT_ID` when no browser credentials are forwarded, so any unauthenticated request to this route (GET or POST) will silently execute against SGP under the server's API key. If this Next.js server is reachable by more than one person (a shared dev box, a staging deploy), any visitor can enumerate or create agent configs without holding their own SGP session. Consider adding a minimal check — e.g. 401 when both the forwarded `x-api-key`/`authorization`/`cookie` are absent AND `SGP_API_KEY` is set — so the fallback only activates for explicitly allowed callers.

### Issue 2 of 3
agentex-ui/lib/sgp-client.ts:1-5
The file header says this module "keeps the SGP base URL + outgoing auth headers off the client bundle," but `NEXT_PUBLIC_` variables are statically inlined by Next.js into every bundle that references them — including the client. The SGP base URL is therefore visible in the browser. If the intent really is to keep it server-only, remove the `NEXT_PUBLIC_` prefix (and update `route.ts`'s 503 message accordingly); if the URL is intentionally public, just drop the misleading comment.

```suggestion
/**
 * Thin server-side SGP REST client. Lives in lib/ because it's called from
 * Next.js route handlers (app/api/...), not the browser. Note: SGP_BASE_URL
 * is derived from NEXT_PUBLIC_ env vars and is therefore visible in the
 * client bundle; only auth headers and the API key remain server-side.
 */
```

### Issue 3 of 3
agentex-ui/app/agent-configs/page.tsx:60-72
**`refresh` and `launchWithConfig` not wrapped in `useCallback`**

Per the team's rule, helper functions used in component render logic should be wrapped in `useCallback` to prevent unnecessary re-creation on each render. `refresh` is passed as `onCreated` to `CreateForm` and would cause that child to re-render on every parent state update; `launchWithConfig` is called inside an inline `onClick` but similarly changes identity on every render. Both should use `useCallback` with the appropriate dependencies.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): add agent-configs page backed ..."](https://github.com/scaleapi/scale-agentex/commit/95cfd69e3d69e5d1a5e12d4985704be9712f60b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35666269)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->