### PR TITLE
feat(e2e): AGX1-325 — agent_api_keys authz black-box suite

### DIFF
--- a/scripts/spark-authz-e2e-tests/MANUAL_SMOKE.md
+++ b/scripts/spark-authz-e2e-tests/MANUAL_SMOKE.md
@@ -1,0 +1,327 @@
+# Manual `agent_api_keys` smoke — pubsec-dev
+
+Copy-paste manual smoke for the `agent_api_keys` routes against
+`agentex.sgp-pubsec-dev.scale.com`. **No e2e suite. No venv. Just `curl`.**
+
+Set the four env vars at the top, then paste any case block.
+
+Companion to the automated suite in this directory — same coverage, but
+each case is one independent `curl` you can run from any shell.
+
+## Prereqs
+
+- A real pubsec-dev API key (`ssk_is_…`).
+- The agentex-compatible `account_id` used for `x-selected-account-id`.
+- An existing `agent_id` where you have `api_key.create` permission.
+- (Optional) A second user's API key for tenant-isolation cases (15–17).
+
+```bash
+export KEY="ssk_is_..."                                  # your api key
+export ACCT="69c69407ee5d19e1dce57d57"                   # x-selected-account-id
+export AGENT="811a4c69-e86d-46b3-9293-0bc8443f599d"      # parent agent (golden-agent works)
+export BASE="https://agentex.sgp-pubsec-dev.scale.com"
+H() { echo "-H"; echo "x-api-key: $KEY"; echo "-H"; echo "x-selected-account-id: $ACCT"; }
+```
+
+---
+
+## Case 1 — Reachability + auth sanity
+
+Confirm the API is reachable and your headers authenticate. **Expected:**
+`200` + JSON array of agents.
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" $(H) "$BASE/agents"
+```
+
+✅ Pass if `HTTP 200` and you see agents.
+
+---
+
+## Case 2 — OpenAPI shape
+
+Confirm `agent_api_key` routes are published. **Expected:** five paths
+under `/agent_api_keys`.
+
+```bash
+curl -sS "$BASE/openapi.json" | python3 -c "
+import json,sys
+print('\n'.join(sorted(p for p in json.load(sys.stdin)['paths'] if 'api_key' in p)))
+"
+```
+
+✅ Pass if you see `/agent_api_keys`, `/agent_api_keys/{id}`,
+`/agent_api_keys/name/{name}`, `/agent_api_keys/name/{api_key_name}`.
+
+---
+
+## Case 3 — Create happy path
+
+Mint an api_key. **Expected:** `200` with `id` + `api_key` in body.
+
+```bash
+NAME="manual-smoke-$(date +%s)"
+RESP=$(curl -sS -w "\nHTTP %{http_code}" -X POST $(H) \
+  -H "Content-Type: application/json" \
+  -d "{\"agent_id\":\"$AGENT\",\"name\":\"$NAME\",\"api_key_type\":\"external\"}" \
+  "$BASE/agent_api_keys")
+echo "$RESP"
+export KID=$(echo "$RESP" | head -n -1 | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
+echo "KID=$KID"
+```
+
+✅ Pass if `HTTP 200` and `KID` is a UUID. Save `$KID` for later cases.
+
+---
+
+## Case 4 — Validation: enum is lowercase
+
+Payload uses `EXTERNAL` (uppercase). **Expected:** `422` rejection.
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" -X POST $(H) \
+  -H "Content-Type: application/json" \
+  -d "{\"agent_id\":\"$AGENT\",\"name\":\"x\",\"api_key_type\":\"EXTERNAL\"}" \
+  "$BASE/agent_api_keys"
+```
+
+✅ Pass if `HTTP 422`.
+
+---
+
+## Case 5 — Validation: requires id OR name
+
+Payload omits both `agent_id` and `agent_name`. **Expected:** `400`.
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" -X POST $(H) \
+  -H "Content-Type: application/json" \
+  -d '{"name":"x","api_key_type":"external"}' \
+  "$BASE/agent_api_keys"
+```
+
+✅ Pass if `HTTP 400`.
+
+---
+
+## Case 6 — Validation: rejects both id AND name
+
+Payload includes both. **Expected:** `400`.
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" -X POST $(H) \
+  -H "Content-Type: application/json" \
+  -d "{\"agent_id\":\"$AGENT\",\"agent_name\":\"some-name\",\"name\":\"x\",\"api_key_type\":\"external\"}" \
+  "$BASE/agent_api_keys"
+```
+
+✅ Pass if `HTTP 400`.
+
+---
+
+## Case 7 — Duplicate-name conflict
+
+Create the same `(agent_id, name, type)` twice. **Expected:** second call
+returns `409`.
+
+```bash
+DUP="dup-$(date +%s)"
+for i in 1 2; do
+  echo "--- attempt $i ---"
+  curl -sS -w "\nHTTP %{http_code}\n" -X POST $(H) \
+    -H "Content-Type: application/json" \
+    -d "{\"agent_id\":\"$AGENT\",\"name\":\"$DUP\",\"api_key_type\":\"external\"}" \
+    "$BASE/agent_api_keys"
+done
+```
+
+✅ Pass if attempt 1 = `200`, attempt 2 = `409`.
+
+---
+
+## Case 8 — Missing auth
+
+No headers. **Expected:** `401`.
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" "$BASE/agent_api_keys/anything"
+```
+
+✅ Pass if `HTTP 401`.
+
+---
+
+## Case 9 — Bogus API key
+
+Garbage `x-api-key`. **Expected:** `401`.
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" \
+  -H "x-api-key: bogus" -H "x-selected-account-id: $ACCT" \
+  "$BASE/agents"
+```
+
+✅ Pass if `HTTP 401`.
+
+---
+
+## Case 10 — Owner GET by id
+
+Read the key you just created (Case 3). **Expected (healthy env):** `200`
+with the same id. **Today on pubsec-dev:** `422` (agentex-auth is still
+configured with `AUTH_PROVIDER=sgp`, so the route-level FGAC check routes
+to legacy SGP-authz which doesn't know about `api_key`).
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" $(H) "$BASE/agent_api_keys/$KID"
+```
+
+Today: ❌ `422`. After the `AUTH_PROVIDER=spark` rollout: ✅ `200`.
+
+---
+
+## Case 11 — Owner GET by name
+
+Same row, looked up by name. **Expected (healthy):** `200`.
+**Today:** `422`.
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" $(H) \
+  "$BASE/agent_api_keys/name/$NAME?agent_id=$AGENT&api_key_type=external"
+```
+
+---
+
+## Case 12 — Owner LIST under agent
+
+Confirm the list includes `$KID`. **Expected (healthy):** `200` + array
+containing it. **Today:** `422`.
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" $(H) \
+  "$BASE/agent_api_keys?agent_id=$AGENT" | python3 -c "
+import json, sys, os
+body = sys.stdin.read()
+try:
+    arr = json.loads(body)
+    print('count:', len(arr))
+    print('contains target:', any(k.get('id') == os.environ['KID'] for k in arr))
+except Exception:
+    print(body)
+"
+```
+
+---
+
+## Case 13 — GET nonexistent
+
+Read a UUID that doesn't exist. **Expected (healthy):** `404`.
+**Today:** likely `422` (same Gap-1 wrap).
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" $(H) \
+  "$BASE/agent_api_keys/00000000-0000-0000-0000-000000000000"
+```
+
+---
+
+## Case 14 — Owner DELETE
+
+Delete the key, then confirm it's gone. **Expected (healthy):** `200`,
+then `404` on re-read. **Today:** both calls return `422`.
+
+```bash
+curl -sS -w "\nHTTP %{http_code}\n" -X DELETE $(H) "$BASE/agent_api_keys/$KID"
+echo "--- re-fetch ---"
+curl -sS -w "\nHTTP %{http_code}\n" $(H) "$BASE/agent_api_keys/$KID"
+```
+
+---
+
+## Case 15 — Non-owner GET → 404 (no existence leak)
+
+Requires `KEY_B` for a second user in the same tenant.
+
+```bash
+export KEY_B="ssk_is_..."   # second user's key
+curl -sS -w "\nHTTP %{http_code}\n" \
+  -H "x-api-key: $KEY_B" -H "x-selected-account-id: $ACCT" \
+  "$BASE/agent_api_keys/$KID"
+```
+
+✅ Pass if `HTTP 404`. **Critical:** must NOT be `403` (leaks existence).
+
+---
+
+## Case 16 — Non-owner LIST is filtered
+
+Requires `KEY_B`.
+
+```bash
+curl -sS -H "x-api-key: $KEY_B" -H "x-selected-account-id: $ACCT" \
+  "$BASE/agent_api_keys?agent_id=$AGENT" | python3 -c "
+import json, sys, os
+body = sys.stdin.read()
+try:
+    arr = json.loads(body)
+    print('user_b list count:', len(arr))
+    print('contains user_a key:', any(k.get('id') == os.environ['KID'] for k in arr))
+except Exception:
+    print(body)
+"
+```
+
+✅ Pass if `contains user_a key: False`.
+
+---
+
+## Case 17 — Non-owner DELETE preserves row
+
+Requires `KEY_B`.
+
+```bash
+# user_b attempts delete
+curl -sS -w "\nHTTP %{http_code}\n" -X DELETE \
+  -H "x-api-key: $KEY_B" -H "x-selected-account-id: $ACCT" \
+  "$BASE/agent_api_keys/$KID"
+# user_a re-fetches
+curl -sS -w "\nHTTP %{http_code}\n" $(H) "$BASE/agent_api_keys/$KID"
+```
+
+✅ Pass if user_b's call = `404` AND user_a's re-fetch = `200`
+(row not deleted).
+
+---
+
+## Quick scorecard
+
+| | Today on pubsec-dev | After `AUTH_PROVIDER=spark` rollout |
+|---|---|---|
+| **Cases 1–9** — HTTP + validation | ✅ All pass | ✅ Still pass |
+| **Cases 10–14** — owner FGAC paths | ❌ All `422` | ✅ All pass |
+| **Cases 15–17** — tenant isolation | ❌ Same `422` blocker; also needs second user | ✅ Pass with `KEY_B` |
+
+**Run Cases 1–9 today.** They confirm the route layer is healthy and the
+contract (validation, auth, conflict handling) holds.
+
+**Cases 10–17 are the rollout-verification kit.** Re-run them after the
+`AUTH_PROVIDER=spark` flip on pubsec-dev's `agentex-auth` deployment to
+confirm the FGAC dual-write works end-to-end.
+
+## Background: the rollout blocker
+
+Pubsec-dev's `agentex-auth` deployment has `AUTH_PROVIDER=sgp`. Every
+`register_resource` / `deregister_resource` call from scale-agentex's
+dual-write code lands on legacy SGP-authz instead of `spark-authz`
+(which IS deployed in the cluster — `ns/spark`, `svc/spark-authz`, ports
+50052/8090 — verified reachable via port-forward + `/healthz` returning
+`SERVING`).
+
+To unblock: redeploy `agentex-auth` in pubsec-dev with
+`AUTH_PROVIDER=spark` plus
+`SPARK_AUTHZ_GRPC_TARGET=spark-authz.spark.svc.cluster.local:50052`. No
+new infra needed — just a value change in the Helm chart that
+`sgp-system-manager` renders for pubsec-dev.
+
+The Jinja template that hardcodes this lives at
+`sgp/services/sgp-system-manager/sgp_system_manager/packs/agentex-auth/values.yaml.jinja2:20`.

--- a/scripts/spark-authz-e2e-tests/Makefile
+++ b/scripts/spark-authz-e2e-tests/Makefile
@@ -28,16 +28,21 @@ PYTEST := $(VENV)/bin/pytest
 
 # Test-file globs. Update these (NOT individual case targets) when adding
 # a new test file for an existing resource.
-EVENT_TESTS := tests/test_event_authz.py
+API_KEY_TESTS := tests/test_api_key_create.py tests/test_api_key_get.py tests/test_api_key_list.py tests/test_api_key_delete.py
+EVENT_TESTS   := tests/test_event_authz.py
 
 # Aggregate groupings — extend these as resources are added.
-# Direct-resource targets land with their own PRs (e.g. api_key).
+DIRECT_RESOURCE_TESTS := $(API_KEY_TESTS)
+# Future direct-resource additions go here:
+#   DIRECT_RESOURCE_TESTS += $(AGENT_TESTS) $(TASK_TESTS)
+
 SUB_RESOURCE_TESTS := $(EVENT_TESTS)
 # Future sub-resource additions go here:
 #   SUB_RESOURCE_TESTS += $(STATE_TESTS) $(MESSAGE_TESTS) $(TRACKER_TESTS) $(CHECKPOINT_TESTS)
 
 .PHONY: install test \
-        test-sub-resources \
+        test-direct-resources test-sub-resources \
+        test-api-key test-api-key-create test-api-key-get test-api-key-list test-api-key-delete \
         test-event \
         clean help
 
@@ -51,10 +56,15 @@ help:
 	@echo "  make test                    all tests"
 	@echo ""
 	@echo "Run a logical group:"
+	@echo "  make test-direct-resources   resources with their own SpiceDB type"
 	@echo "  make test-sub-resources      resources that delegate to a parent"
 	@echo ""
 	@echo "Run one resource:"
+	@echo "  make test-api-key            all AGX1-325 cases"
 	@echo "  make test-event              all AGX1-331 cases"
+	@echo ""
+	@echo "Run one case:"
+	@echo "  make test-api-key-{create,get,list,delete}"
 
 install:
 	$(PYTHON) -m venv $(VENV)
@@ -67,8 +77,31 @@ test:
 # Logical groupings
 # ---------------------------------------------------------------------------
 
+test-direct-resources:
+	$(PYTEST) $(DIRECT_RESOURCE_TESTS) -v
+
 test-sub-resources:
 	$(PYTEST) $(SUB_RESOURCE_TESTS) -v
+
+# ---------------------------------------------------------------------------
+# Direct resources
+# ---------------------------------------------------------------------------
+
+# AGX1-325 — agent_api_keys
+test-api-key:
+	$(PYTEST) $(API_KEY_TESTS) -v
+
+test-api-key-create:
+	$(PYTEST) tests/test_api_key_create.py -v
+
+test-api-key-get:
+	$(PYTEST) tests/test_api_key_get.py -v
+
+test-api-key-list:
+	$(PYTEST) tests/test_api_key_list.py -v
+
+test-api-key-delete:
+	$(PYTEST) tests/test_api_key_delete.py -v
 
 # ---------------------------------------------------------------------------
 # Sub-resources (delegate authz to a parent)

--- a/scripts/spark-authz-e2e-tests/README.md
+++ b/scripts/spark-authz-e2e-tests/README.md
@@ -10,10 +10,14 @@ Modeled after the equivalent KB suite in
 
 ## Scope
 
-This PR establishes the e2e test scaffolding (clients, conftest, factories,
-cleanup) and ships the first resource: **events**. Subsequent PRs add new
-resource test files on top of this infrastructure (e.g. AGX1-325 api_keys
-in a follow-up).
+### AGX1-325 — `agent_api_keys`
+
+Routes: create / get / get-by-name / list / delete / delete-by-name.
+
+- **create** dual-writes to SpiceDB with the `parent_agent` edge populated.
+- **get** / **get-by-name** are gated by `api_key.read`; denial collapses to 404.
+- **list** filters to the api_keys the caller has `read` on.
+- **delete** / **delete-by-name** dual-write deregisters; denial collapses to 404.
 
 ### AGX1-331 — `events` (read-only, parent-agent-delegated)
 
@@ -25,20 +29,10 @@ Routes: `GET /events/{id}` and `GET /events?task_id=...&agent_id=...`.
   `tests/test_event_authz.py`); only the denied paths are exercised, which
   is what the ticket asks for.
 
-### Scaffolding shipped with this PR
-
-- `clients/agentex_client.py` — HTTP client for `scale-agentex` routes
-  (agent + api_key + event surfaces; api_key methods land here ahead of
-  AGX1-325's tests so the client doesn't grow in two places).
-- `clients/spark_authz_client.py` — direct SpiceDB-state client (HTTP-
-  transcoded). Copied verbatim from the EGP suite — repo-agnostic.
-- `conftest.py` — config loader, identity credentials, two `AgentexClient`
-  instances (user_a / user_b), a `SparkAuthzClient`, an `authz_reachable`
-  probe with graceful-skip semantics, `parent_agent` fixture that falls
-  back to a pre-existing `agentex.agent_id` when the test user lacks
-  `agent.create` on the tenant, function-scoped `cleanup` tracker.
-- `helpers/cleanup.py` + `helpers/factories.py` — LIFO teardown +
-  unique-name generators.
+This PR layers the api_key test files on top of the scaffolding established
+in [#277](https://github.com/scaleapi/scale-agentex/pull/277). The clients,
+conftest, factories, and cleanup tracker all live there; this PR is purely
+the AGX1-325 test cases + `MANUAL_SMOKE.md`.
 
 ## Setup
 
@@ -121,10 +115,18 @@ resource, all tests in a logical category, or the whole suite.
 make test
 
 # Logical groups
+make test-direct-resources    # resources with their own SpiceDB type (api_key, …)
 make test-sub-resources       # resources that delegate to a parent (event, …)
 
 # One resource (all cases)
+make test-api-key             # AGX1-325 — all api_key cases
 make test-event               # AGX1-331 — all event cases
+
+# One case
+make test-api-key-create
+make test-api-key-get
+make test-api-key-list
+make test-api-key-delete
 ```
 
 Adding a new resource? Add a `<RESOURCE>_TESTS` variable in the Makefile,
@@ -139,10 +141,10 @@ for direct permission assertions. The suite degrades gracefully:
 
 - Tests that **only hit scale-agentex HTTP routes** (most of the suite) run
   normally and assert on response codes + bodies.
-- Tests that **assert directly against SpiceDB** skip with a clear reason
-  when `spark_authz.host` doesn't answer `/healthz` with 2xx. The event
-  suite this PR ships doesn't have any SpiceDB-asserting tests, but the
-  scaffolding is here so future resource PRs land cleanly.
+- Tests that **assert directly against SpiceDB** (currently:
+  `test_api_key_create.py` and `test_owner_delete_deregisters_in_spicedb`)
+  skip with a clear reason when `spark_authz.host` doesn't answer `/healthz`
+  with 2xx.
 - The factory cleanup falls back to REST-only when spark-authz isn't
   reachable (no SpiceDB delete-resource call). Tuples may leak in this
   mode, but routes are the unit under test.
@@ -160,6 +162,10 @@ helpers/
   cleanup.py               # LIFO cleanup tracker honoring config knobs
   factories.py             # unique_agent_name, unique_api_key_name
 tests/
+  test_api_key_create.py   # AGX1-325: dual-write + parent_agent edge
+  test_api_key_get.py      # AGX1-325: 200 owner / 404 non-owner on id + name
+  test_api_key_list.py     # AGX1-325: FGAC list filter
+  test_api_key_delete.py   # AGX1-325: deregister on delete + non-owner 404
   test_event_authz.py      # AGX1-331: GET /events/{id} + /events denied paths
 conftest.py                # config, identities, clients, factories, cleanup
 config.json.example        # template — copy to config.json and fill in

--- a/scripts/spark-authz-e2e-tests/tests/test_api_key_create.py
+++ b/scripts/spark-authz-e2e-tests/tests/test_api_key_create.py
@@ -1,0 +1,41 @@
+"""AGX1-325 — Create: dual-write to SpiceDB with parent_agent edge.
+
+Verifies that ``POST /agent_api_keys`` calls ``register_resource`` on the
+authorization service, including the ``parent_agent`` edge so the cascade
+``api_key.read = ... & parent_agent->read`` resolves end-to-end.
+"""
+
+import pytest
+
+API_KEY_RESOURCE_TYPE = "api_key"
+
+
+@pytest.mark.e2e
+class TestApiKeyCreate:
+    def test_create_registers_owner_in_spicedb(
+        self, create_agent, create_api_key, authz_client, user_a
+    ):
+        """Owner has ``read`` and ``delete`` on the api_key right after create."""
+        agent_id, _ = create_agent()
+        api_key_id, _, _ = create_api_key(agent_id)
+
+        # Owner cascade: register_resource(parent=agent) wrote the parent_agent
+        # edge; without it, every read/delete check fails closed.
+        assert authz_client.check_permission_bool(
+            user_a.identity_id, API_KEY_RESOURCE_TYPE, api_key_id, "read"
+        )
+        assert authz_client.check_permission_bool(
+            user_a.identity_id, API_KEY_RESOURCE_TYPE, api_key_id, "delete"
+        )
+
+    def test_non_owner_has_no_permissions(
+        self, create_agent, create_api_key, authz_client, user_b
+    ):
+        """A same-tenant user with no grant sees no permissions on the api_key."""
+        agent_id, _ = create_agent()
+        api_key_id, _, _ = create_api_key(agent_id)
+
+        for permission in ("read", "delete"):
+            assert not authz_client.check_permission_bool(
+                user_b.identity_id, API_KEY_RESOURCE_TYPE, api_key_id, permission
+            ), f"user_b should not have {permission} on api_key {api_key_id}"

--- a/scripts/spark-authz-e2e-tests/tests/test_api_key_delete.py
+++ b/scripts/spark-authz-e2e-tests/tests/test_api_key_delete.py
@@ -1,0 +1,88 @@
+"""AGX1-325 — Delete: dual-write deregisters; non-owner 404.
+
+Verifies ``DELETE /agent_api_keys/{id}``:
+ 1. Deregisters the api_key from SpiceDB (owner permissions vanish post-delete).
+ 2. Returns 404 for a non-owner — never 403, never deletes the row.
+"""
+
+import pytest
+
+API_KEY_RESOURCE_TYPE = "api_key"
+
+
+@pytest.mark.e2e
+class TestApiKeyDelete:
+    def test_owner_delete_deregisters_in_spicedb(
+        self,
+        create_agent,
+        agentex_client_a,
+        authz_client,
+        user_a,
+    ):
+        """After delete, SpiceDB no longer reports the owner relationship.
+
+        Built without the ``create_api_key`` factory because that fixture
+        registers its own teardown, which would race against the explicit
+        delete inside the test.
+        """
+        from helpers.factories import unique_api_key_name
+
+        agent_id, _ = create_agent()
+        resp = agentex_client_a.create_api_key(
+            agent_id=agent_id, name=unique_api_key_name()
+        )
+        assert resp.status_code in (200, 201), resp.text
+        api_key_id = resp.json()["id"]
+
+        # Sanity: owner has read pre-delete.
+        assert authz_client.check_permission_bool(
+            user_a.identity_id, API_KEY_RESOURCE_TYPE, api_key_id, "read"
+        )
+
+        del_resp = agentex_client_a.delete_api_key(api_key_id)
+        assert del_resp.status_code in (200, 204), del_resp.text
+
+        # Deregister happened: owner no longer has any permission.
+        assert not authz_client.check_permission_bool(
+            user_a.identity_id, API_KEY_RESOURCE_TYPE, api_key_id, "read"
+        ), "owner still has read after delete — deregister did not fire"
+        assert not authz_client.check_permission_bool(
+            user_a.identity_id, API_KEY_RESOURCE_TYPE, api_key_id, "delete"
+        )
+
+    def test_non_owner_delete_returns_404_and_preserves_row(
+        self,
+        parent_agent,
+        create_api_key,
+        agentex_client_a,
+        agentex_client_b,
+    ):
+        """user_b's denied delete must collapse to 404 and leave the row intact."""
+        agent_id, _ = parent_agent
+        api_key_id, _, _ = create_api_key(agent_id)
+
+        denied = agentex_client_b.delete_api_key(api_key_id)
+        assert (
+            denied.status_code == 404
+        ), f"expected 404 (collapsed), got {denied.status_code}: {denied.text}"
+
+        # Row still exists: owner can still fetch it.
+        owner_get = agentex_client_a.get_api_key(api_key_id)
+        assert owner_get.status_code == 200, (
+            f"api_key was deleted despite the auth check failing — "
+            f"got {owner_get.status_code}: {owner_get.text}"
+        )
+
+    def test_non_owner_delete_by_name_returns_404(
+        self,
+        parent_agent,
+        create_api_key,
+        agentex_client_b,
+    ):
+        agent_id, _ = parent_agent
+        _, api_key_name, _ = create_api_key(agent_id)
+
+        resp = agentex_client_b.delete_api_key_by_name(api_key_name, agent_id=agent_id)
+        assert (
+            resp.status_code == 404
+        ), f"expected 404 (collapsed), got {resp.status_code}: {resp.text}"

--- a/scripts/spark-authz-e2e-tests/tests/test_api_key_get.py
+++ b/scripts/spark-authz-e2e-tests/tests/test_api_key_get.py
@@ -1,0 +1,56 @@
+"""AGX1-325 — Get: owner 200, non-owner 404 (collapsed from 403).
+
+Verifies the id-path and name-path GET handlers route the auth check through
+``_check_api_key_or_collapse_to_404`` so denials surface as 404, hiding
+cross-tenant existence.
+"""
+
+import pytest
+
+
+@pytest.mark.e2e
+class TestApiKeyGet:
+    def test_owner_get_by_id_returns_200(
+        self, parent_agent, create_api_key, agentex_client_a
+    ):
+        agent_id, _ = parent_agent
+        api_key_id, _, _ = create_api_key(agent_id)
+
+        resp = agentex_client_a.get_api_key(api_key_id)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["id"] == api_key_id
+
+    def test_owner_get_by_name_returns_200(
+        self, parent_agent, create_api_key, agentex_client_a
+    ):
+        agent_id, _ = parent_agent
+        api_key_id, api_key_name, _ = create_api_key(agent_id)
+
+        resp = agentex_client_a.get_api_key_by_name(api_key_name, agent_id=agent_id)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["id"] == api_key_id
+
+    def test_non_owner_get_by_id_returns_404(
+        self, parent_agent, create_api_key, agentex_client_b
+    ):
+        """Denial collapses to 404, not 403 — no existence leak."""
+        agent_id, _ = parent_agent
+        api_key_id, _, _ = create_api_key(agent_id)
+
+        resp = agentex_client_b.get_api_key(api_key_id)
+        assert (
+            resp.status_code == 404
+        ), f"expected 404 (collapsed), got {resp.status_code}: {resp.text}"
+
+    def test_non_owner_get_by_name_returns_404(
+        self, parent_agent, create_api_key, agentex_client_b
+    ):
+        """Name-route denial must also collapse to 404 with the identifier-free
+        body so the absent-row and denied-row responses are indistinguishable."""
+        agent_id, _ = parent_agent
+        _, api_key_name, _ = create_api_key(agent_id)
+
+        resp = agentex_client_b.get_api_key_by_name(api_key_name, agent_id=agent_id)
+        assert (
+            resp.status_code == 404
+        ), f"expected 404 (collapsed), got {resp.status_code}: {resp.text}"

--- a/scripts/spark-authz-e2e-tests/tests/test_api_key_list.py
+++ b/scripts/spark-authz-e2e-tests/tests/test_api_key_list.py
@@ -1,0 +1,48 @@
+"""AGX1-325 — List: owner sees own, non-owner sees filtered.
+
+``GET /agent_api_keys?agent_id=...`` forwards ``DAuthorizedResourceIds`` into
+the use-case as an ``id`` filter, so the SQL ``WHERE id IN (...)`` clause
+restricts results to api_keys the caller has ``read`` on.
+"""
+
+import pytest
+
+
+@pytest.mark.e2e
+class TestApiKeyList:
+    def test_owner_list_includes_own_api_key(
+        self, parent_agent, create_api_key, agentex_client_a
+    ):
+        agent_id, _ = parent_agent
+        api_key_id, _, _ = create_api_key(agent_id)
+
+        resp = agentex_client_a.list_api_keys(agent_id=agent_id)
+        assert resp.status_code == 200, resp.text
+        ids = [k["id"] for k in resp.json()]
+        assert api_key_id in ids, f"owner missing own api_key in list: {ids}"
+
+    def test_non_owner_list_excludes_user_a_api_key(
+        self, parent_agent, create_api_key, agentex_client_b
+    ):
+        """user_b can hit the route (they have ``read`` on the agent in the
+        same tenant) but receives a list filtered to their own authorized
+        api_keys — which is empty for resources owned solely by user_a."""
+        agent_id, _ = parent_agent
+        api_key_id, _, _ = create_api_key(agent_id)
+
+        resp = agentex_client_b.list_api_keys(agent_id=agent_id)
+        # If user_b lacks ``read`` on the agent itself the route 404s before
+        # the list filter runs — the assertion below would never execute. Skip
+        # explicitly so this shows as SKIPPED (not PASSED) and the gap is
+        # visible in reports. To actually exercise the list filter, user_b
+        # needs ``read`` on the agent but no ``read`` on user_a's api_keys.
+        if resp.status_code == 404:
+            pytest.skip(
+                "user_b lacks read on the parent agent — route 404s before the "
+                "list filter runs; FGAC list-filter behavior not exercised."
+            )
+        assert resp.status_code == 200, resp.text
+        ids = [k["id"] for k in resp.json()]
+        assert (
+            api_key_id not in ids
+        ), f"user_b saw user_a's api_key in list — FGAC filter leak: {ids}"


### PR DESCRIPTION
## Summary

Layers the `agent_api_keys` test cases (AGX1-325) on top of the scaffolding established in [#277](https://github.com/scaleapi/scale-agentex/pull/277). This PR is purely the new test files + `MANUAL_SMOKE.md`; the clients, conftest, cleanup tracker, `parent_agent` fixture, and graceful-skip wiring all live in #277.

Linear: [AGX1-325](https://linear.app/scale-epd/issue/AGX1-325). Depends on: [#277](https://github.com/scaleapi/scale-agentex/pull/277).

## What this PR adds

- `tests/test_api_key_create.py` (2 tests) — dual-write registers owner with `parent_agent` edge; non-owner has no permissions.
- `tests/test_api_key_get.py` (4 tests) — owner 200 (id + name); non-owner 404 (collapsed from 403) on both id and name routes.
- `tests/test_api_key_list.py` (2 tests) — owner sees own; non-owner doesn't see user_a's api_key in the filtered list.
- `tests/test_api_key_delete.py` (3 tests) — delete deregisters from SpiceDB; non-owner delete returns 404 and leaves the row intact.
- `MANUAL_SMOKE.md` — 17 copy-paste curl cases for verifying api_key routes against any deployed env, no venv or pytest required. Doubles as a rollout-verification checklist.
- Small `Makefile` / `README.md` adjustments to re-expose the api_key targets and scope section now that the test files exist.

## Status against pubsec-dev

Today: **0 passed / 11 failed**. All 11 fail with the same shape:

```
POST /agent_api_keys            -> 200 (DB row lands)
GET  /agent_api_keys/{just_id}  -> 422 wrapping 403 from agentex-auth
```

Root cause: pubsec-dev's `agentex-auth` deployment has `AUTH_PROVIDER=sgp`. Every `register_resource` / `check` call routes to legacy SGP-authz, which doesn't know about the `api_key` resource type. Tracked separately in [scaleapi/sgp#3334](https://github.com/scaleapi/sgp/pull/3334) (parameterizes `AUTH_PROVIDER` in the agentex-auth Helm chart + system-manager pack so a per-env override can flip pubsec-dev to spark).

After that rollout: expect ~11/12 passing (the 1 skipped is `test_get_event_with_view_returns_200` from #277, which depends on event seeding out of scope).

## When spark-authz isn't reachable

The two create-time tests and `test_owner_delete_deregisters_in_spicedb` assert directly against spark-authz. They skip cleanly when `spark_authz.host` doesn't answer `/healthz` with 2xx — see #277's `authz_reachable` fixture for the graceful-skip logic. To run them, port-forward spark-authz from the target cluster:

```bash
kubectl --context <cluster> -n spark port-forward svc/spark-authz 8090:8090
```

Set `spark_authz.host = "localhost:8090"` in `config.json`.

## Why this is split from #277

Honest call: AGX1-331 (events) ships clean against pubsec-dev today — 3/3 of its assertions pass. The api_key suite is correct code but blocked on a deployment-config change in another repo. Splitting them lets the scaffolding + events ship as a green PR; the api_key cases sit here ready to flip green the moment the SGP rollout lands. Same review surface, smaller blast radius per PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a black-box FGAC end-to-end test suite (`scripts/spark-authz-e2e-tests`) for `agent_api_keys` routes, modeled after the equivalent KB suite. Every test hits the real `scale-agentex` HTTP API and verifies state in SpiceDB via a separate `SparkAuthzClient`.

- **Four test files** cover the AGX1-325 deliverables: `POST` dual-write registration, owner `GET` (200) vs. non-owner `GET` (404), FGAC-filtered `LIST`, and `DELETE` deregistration — plus the AGX1-331 denied-path event tests from #277.
- **Shared scaffolding** includes session-scoped HTTP clients, a LIFO `CleanupTracker` with REST-then-SpiceDB fallback, a `parent_agent` fixture that falls back to a config-provided agent ID, and a `healthz`-gated `authz_client` fixture that gracefully skips SpiceDB-asserting tests when spark-authz isn't reachable.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a new scripts-only test suite with no changes to production code.

All changes are confined to `scripts/spark-authz-e2e-tests`. The suite is well-structured: the healthz probe correctly uses `resp.is_success`, the prior silent-return issue in the list test has been fixed with `pytest.skip`, and the cleanup tracker handles errors without masking test results. No production code is touched.

No files require special attention for merge safety.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/spark-authz-e2e-tests/conftest.py | Session-scoped fixtures for config, identities, and HTTP clients; the healthz probe now correctly uses `resp.is_success` (addressing the prior review concern); cleanup logic correctly guards on `rep_call` and respects `on_success`/`on_failure` knobs. |
| scripts/spark-authz-e2e-tests/tests/test_api_key_delete.py | Tests owner-deregister and non-owner 404 collapse; the `test_owner_delete_deregisters_in_spicedb` test manually creates an api_key without a cleanup entry — if the pre-delete SpiceDB assertion fails the api_key leaks (noted in the prior review's outside-diff comment). |
| scripts/spark-authz-e2e-tests/tests/test_api_key_list.py | Owner sees own key; non-owner 404-on-agent now correctly uses `pytest.skip` instead of a silent `return` (prior feedback addressed); no new issues. |
| scripts/spark-authz-e2e-tests/tests/test_event_authz.py | Denied-path event tests pass; the skipped happy-path test references "Linear: TODO follow-up" without a ticket number. |
| scripts/spark-authz-e2e-tests/Makefile | Well-structured with logical groupings; `make test-sub-resources` / `make test-event` reference `tests/test_event_authz.py` which does not exist in this PR — noted in prior review. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Test
    participant CA as AgentexClient (user_a)
    participant CB as AgentexClient (user_b)
    participant SAX as scale-agentex API
    participant AUTHZ as spark-authz (SpiceDB)

    Note over T,AUTHZ: create test
    T->>CA: POST /agents/register-build
    CA->>SAX: HTTP POST
    SAX-->>CA: "200 {id: agent_id}"
    T->>CA: "POST /agent_api_keys {agent_id}"
    CA->>SAX: HTTP POST
    SAX->>AUTHZ: "register_resource(api_key, parent=agent)"
    SAX-->>CA: "200 {id, api_key}"
    T->>AUTHZ: check_permission(user_a, api_key, read)
    AUTHZ-->>T: true

    Note over T,AUTHZ: get/delete negative path
    T->>CB: "GET /agent_api_keys/{id}"
    CB->>SAX: HTTP GET
    SAX->>AUTHZ: check(user_b, api_key.read)
    AUTHZ-->>SAX: denied
    SAX-->>CB: 404 (collapsed from 403)
    CB-->>T: assert 404

    Note over T,AUTHZ: delete dual-write
    T->>CA: "DELETE /agent_api_keys/{id}"
    CA->>SAX: HTTP DELETE
    SAX->>AUTHZ: deregister_resource(api_key)
    SAX-->>CA: 200
    T->>AUTHZ: check_permission(user_a, api_key, read)
    AUTHZ-->>T: false
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/spark-authz-e2e-tests/tests/test_api_key_delete.py`, line 1207-1212 ([link](https://github.com/scaleapi/scale-agentex/blob/d8c737b1d534570e0e2c179c405daa716d6f783e/scripts/spark-authz-e2e-tests/tests/test_api_key_delete.py#L1207-L1212)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unregistered api_key leaks if pre-delete assertion fails**

   The test intentionally bypasses the `create_api_key` factory to avoid a teardown race, but that means the freshly-created api_key has no cleanup entry. If the pre-delete `check_permission_bool` assertion fails, the api_key is never deleted and leaks in both the DB and SpiceDB, potentially contaminating subsequent runs. The factory teardown actually handles the 404 case gracefully (it checks `not in (200, 204, 404)`), so the race concern is minimal. If keeping the factory out is intentional, registering a raw `cleanup.add(...)` call after the create would prevent the leak without the race issue.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/spark-authz-e2e-tests/tests/test_api_key_delete.py
   Line: 1207-1212

   Comment:
   **Unregistered api_key leaks if pre-delete assertion fails**

   The test intentionally bypasses the `create_api_key` factory to avoid a teardown race, but that means the freshly-created api_key has no cleanup entry. If the pre-delete `check_permission_bool` assertion fails, the api_key is never deleted and leaks in both the DB and SpiceDB, potentially contaminating subsequent runs. The factory teardown actually handles the 404 case gracefully (it checks `not in (200, 204, 404)`), so the race concern is minimal. If keeping the factory out is intentional, registering a raw `cleanup.add(...)` call after the create would prevent the leak without the race issue.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fspark-authz-e2e-tests%2Ftests%2Ftest_api_key_delete.py%0ALine%3A%201207-1212%0A%0AComment%3A%0A**Unregistered%20api_key%20leaks%20if%20pre-delete%20assertion%20fails**%0A%0AThe%20test%20intentionally%20bypasses%20the%20%60create_api_key%60%20factory%20to%20avoid%20a%20teardown%20race%2C%20but%20that%20means%20the%20freshly-created%20api_key%20has%20no%20cleanup%20entry.%20If%20the%20pre-delete%20%60check_permission_bool%60%20assertion%20fails%2C%20the%20api_key%20is%20never%20deleted%20and%20leaks%20in%20both%20the%20DB%20and%20SpiceDB%2C%20potentially%20contaminating%20subsequent%20runs.%20The%20factory%20teardown%20actually%20handles%20the%20404%20case%20gracefully%20%28it%20checks%20%60not%20in%20%28200%2C%20204%2C%20404%29%60%29%2C%20so%20the%20race%20concern%20is%20minimal.%20If%20keeping%20the%20factory%20out%20is%20intentional%2C%20registering%20a%20raw%20%60cleanup.add%28...%29%60%20call%20after%20the%20create%20would%20prevent%20the%20leak%20without%20the%20race%20issue.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=276&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fspark-authz-e2e-tests%2Ftests%2Ftest_api_key_delete.py%0ALine%3A%201207-1212%0A%0AComment%3A%0A**Unregistered%20api_key%20leaks%20if%20pre-delete%20assertion%20fails**%0A%0AThe%20test%20intentionally%20bypasses%20the%20%60create_api_key%60%20factory%20to%20avoid%20a%20teardown%20race%2C%20but%20that%20means%20the%20freshly-created%20api_key%20has%20no%20cleanup%20entry.%20If%20the%20pre-delete%20%60check_permission_bool%60%20assertion%20fails%2C%20the%20api_key%20is%20never%20deleted%20and%20leaks%20in%20both%20the%20DB%20and%20SpiceDB%2C%20potentially%20contaminating%20subsequent%20runs.%20The%20factory%20teardown%20actually%20handles%20the%20404%20case%20gracefully%20%28it%20checks%20%60not%20in%20%28200%2C%20204%2C%20404%29%60%29%2C%20so%20the%20race%20concern%20is%20minimal.%20If%20keeping%20the%20factory%20out%20is%20intentional%2C%20registering%20a%20raw%20%60cleanup.add%28...%29%60%20call%20after%20the%20create%20would%20prevent%20the%20leak%20without%20the%20race%20issue.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=276&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22dhruv%2Fagx1-325-e2e-api-key-authz%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dhruv%2Fagx1-325-e2e-api-key-authz%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fspark-authz-e2e-tests%2Ftests%2Ftest_api_key_delete.py%0ALine%3A%201207-1212%0A%0AComment%3A%0A**Unregistered%20api_key%20leaks%20if%20pre-delete%20assertion%20fails**%0A%0AThe%20test%20intentionally%20bypasses%20the%20%60create_api_key%60%20factory%20to%20avoid%20a%20teardown%20race%2C%20but%20that%20means%20the%20freshly-created%20api_key%20has%20no%20cleanup%20entry.%20If%20the%20pre-delete%20%60check_permission_bool%60%20assertion%20fails%2C%20the%20api_key%20is%20never%20deleted%20and%20leaks%20in%20both%20the%20DB%20and%20SpiceDB%2C%20potentially%20contaminating%20subsequent%20runs.%20The%20factory%20teardown%20actually%20handles%20the%20404%20case%20gracefully%20%28it%20checks%20%60not%20in%20%28200%2C%20204%2C%20404%29%60%29%2C%20so%20the%20race%20concern%20is%20minimal.%20If%20keeping%20the%20factory%20out%20is%20intentional%2C%20registering%20a%20raw%20%60cleanup.add%28...%29%60%20call%20after%20the%20create%20would%20prevent%20the%20leak%20without%20the%20race%20issue.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fspark-authz-e2e-tests%2Ftests%2Ftest_event_authz.py%3A1854-1860%0A**TODO%20without%20a%20Linear%20ticket%20number**%0A%0AThe%20skip%20reason%20includes%20%22Linear%3A%20TODO%20follow-up%22%20but%20no%20actual%20ticket%20number.%20Without%20a%20linked%20ticket%2C%20this%20placeholder%20is%20hard%20to%20search%20for%20across%20the%20repo%20and%20easy%20to%20forget.%20Per%20the%20team%20convention%2C%20the%20follow-up%20should%20reference%20a%20specific%20Linear%20ID%20%28e.g.%2C%20%60Linear%3A%20AGX1-XXX%60%29.%0A%0A&pr=276&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fspark-authz-e2e-tests%2Ftests%2Ftest_event_authz.py%3A1854-1860%0A**TODO%20without%20a%20Linear%20ticket%20number**%0A%0AThe%20skip%20reason%20includes%20%22Linear%3A%20TODO%20follow-up%22%20but%20no%20actual%20ticket%20number.%20Without%20a%20linked%20ticket%2C%20this%20placeholder%20is%20hard%20to%20search%20for%20across%20the%20repo%20and%20easy%20to%20forget.%20Per%20the%20team%20convention%2C%20the%20follow-up%20should%20reference%20a%20specific%20Linear%20ID%20%28e.g.%2C%20%60Linear%3A%20AGX1-XXX%60%29.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=276&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22dhruv%2Fagx1-325-e2e-api-key-authz%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dhruv%2Fagx1-325-e2e-api-key-authz%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fspark-authz-e2e-tests%2Ftests%2Ftest_event_authz.py%3A1854-1860%0A**TODO%20without%20a%20Linear%20ticket%20number**%0A%0AThe%20skip%20reason%20includes%20%22Linear%3A%20TODO%20follow-up%22%20but%20no%20actual%20ticket%20number.%20Without%20a%20linked%20ticket%2C%20this%20placeholder%20is%20hard%20to%20search%20for%20across%20the%20repo%20and%20easy%20to%20forget.%20Per%20the%20team%20convention%2C%20the%20follow-up%20should%20reference%20a%20specific%20Linear%20ID%20%28e.g.%2C%20%60Linear%3A%20AGX1-XXX%60%29.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=276&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/spark-authz-e2e-tests/tests/test_event_authz.py:1854-1860
**TODO without a Linear ticket number**

The skip reason includes "Linear: TODO follow-up" but no actual ticket number. Without a linked ticket, this placeholder is hard to search for across the repo and easy to forget. Per the team convention, the follow-up should reference a specific Linear ID (e.g., `Linear: AGX1-XXX`).


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["feat(e2e): AGX1-325 — agent\_api\_key auth..."](https://github.com/scaleapi/scale-agentex/commit/a302d06dd8741502ba89b577c7cf329c8aee0846) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35731929)</sub>

**Context used:**

- Rule used - Include ticket numbers in TODO comments to make cl... ([source](https://app.greptile.com/scale-ai/-/custom-context?memory=60a8285f-4fe2-4f02-9b88-5ea4ff033fb8))

**Learned From**
[scaleapi/scaleapi#126926](https://github.com/scaleapi/scaleapi/pull/126926)

<!-- /greptile_comment -->