### PR TITLE
fix(states): update states by state ID only

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6629,20 +6629,12 @@ components:
       title: UpdateSpanRequest
     UpdateStateRequest:
       properties:
-        task_id:
-          type: string
-          title: The unique id of the task to update the state of
-        agent_id:
-          type: string
-          title: The unique id of the agent to update the state of
         state:
           additionalProperties: true
           type: object
           title: The state to update the state with.
       type: object
       required:
-      - task_id
-      - agent_id
       - state
       title: UpdateStateRequest
     UpdateTaskMessageRequest:

--- a/agentex/src/api/routes/states.py
+++ b/agentex/src/api/routes/states.py
@@ -113,7 +113,6 @@ async def update_task_state(
 ) -> State:
     state_entity = await states_use_case.update(
         id=state_id,
-        task_id=request.task_id,
         state=request.state,
     )
     return State.model_validate(state_entity)

--- a/agentex/src/api/schemas/states.py
+++ b/agentex/src/api/schemas/states.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import ConfigDict, Field
+from pydantic import Field
 
 from src.utils.model_utils import BaseModel
 
@@ -33,8 +33,6 @@ class GetStatesRequest(BaseModel):
 
 
 class UpdateStateRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
     state: dict[str, Any] = Field(
         ...,
         title="The state to update the state with.",

--- a/agentex/src/api/schemas/states.py
+++ b/agentex/src/api/schemas/states.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from src.utils.model_utils import BaseModel
 
@@ -33,14 +33,8 @@ class GetStatesRequest(BaseModel):
 
 
 class UpdateStateRequest(BaseModel):
-    task_id: str = Field(
-        ...,
-        title="The unique id of the task to update the state of",
-    )
-    agent_id: str = Field(
-        ...,
-        title="The unique id of the agent to update the state of",
-    )
+    model_config = ConfigDict(extra="forbid")
+
     state: dict[str, Any] = Field(
         ...,
         title="The state to update the state with.",

--- a/agentex/src/domain/use_cases/states_use_case.py
+++ b/agentex/src/domain/use_cases/states_use_case.py
@@ -2,6 +2,7 @@ from typing import Annotated, Any
 
 from fastapi import Depends
 
+from src.adapters.crud_store.exceptions import ItemDoesNotExist
 from src.domain.entities.states import StateEntity
 from src.domain.repositories.task_state_repository import DTaskStateRepository
 from src.utils.logging import make_logger
@@ -58,13 +59,14 @@ class StatesUseCase:
             order_direction=order_direction,
         )
 
-    async def update(self, id: str, task_id: str, state: dict[str, Any]) -> StateEntity:
+    async def update(self, id: str, state: dict[str, Any]) -> StateEntity:
         task_state = await self.task_state_repository.get(id=id)
-        if task_state and task_state.task_id == task_id:
-            # Update the state field but preserve other fields
-            task_state.state = state
-            return await self.task_state_repository.update(task_state)
-        return task_state
+        if task_state is None:
+            raise ItemDoesNotExist(f"State {id} not found")
+
+        # Update the state field but preserve other fields.
+        task_state.state = state
+        return await self.task_state_repository.update(task_state)
 
     async def delete(self, id: str) -> None:
         return await self.task_state_repository.delete(id=id)

--- a/agentex/tests/integration/api/states/test_states_api.py
+++ b/agentex/tests/integration/api/states/test_states_api.py
@@ -190,31 +190,14 @@ class TestStatesAPIIntegration:
         assert created_state["agent_id"] == state_data["agent_id"]
         assert created_state["state"] == state_value
 
-        # API-first validation: UPDATE rejects parent identifiers in the body
-        update_response = await isolated_client.put(
-            f"/states/{state_id}",
-            json={
-                "state": {},
-                "task_id": "some-other-task-id",
-                "agent_id": test_agent.id,
-            },
-        )
-        assert update_response.status_code == 422
-
-        unchanged_response = await isolated_client.get(f"/states/{state_id}")
-        assert unchanged_response.status_code == 200
-        unchanged_state = unchanged_response.json()
-        assert unchanged_state["id"] == state_id
-        assert unchanged_state["task_id"] == state_data["task_id"]
-        assert unchanged_state["agent_id"] == state_data["agent_id"]
-        assert unchanged_state["state"] == state_value
-
-        # API-first validation: UPDATE the created state
+        # API-first validation: UPDATE accepts legacy parent identifiers in the body
         state_value_updated = {"test": "updated"}
         update_response = await isolated_client.put(
             f"/states/{state_id}",
             json={
                 "state": state_value_updated,
+                "task_id": "some-other-task-id",
+                "agent_id": test_agent.id,
             },
         )
         assert update_response.status_code == 200

--- a/agentex/tests/integration/api/states/test_states_api.py
+++ b/agentex/tests/integration/api/states/test_states_api.py
@@ -190,7 +190,7 @@ class TestStatesAPIIntegration:
         assert created_state["agent_id"] == state_data["agent_id"]
         assert created_state["state"] == state_value
 
-        # API-first validation: UPDATE with wrong task_id does nothing
+        # API-first validation: UPDATE rejects parent identifiers in the body
         update_response = await isolated_client.put(
             f"/states/{state_id}",
             json={
@@ -199,13 +199,15 @@ class TestStatesAPIIntegration:
                 "agent_id": test_agent.id,
             },
         )
-        assert update_response.status_code == 200
-        updated_state = update_response.json()
+        assert update_response.status_code == 422
 
-        assert updated_state["id"] == state_id
-        assert updated_state["task_id"] == state_data["task_id"]
-        assert updated_state["agent_id"] == state_data["agent_id"]
-        assert updated_state["state"] == state_value
+        unchanged_response = await isolated_client.get(f"/states/{state_id}")
+        assert unchanged_response.status_code == 200
+        unchanged_state = unchanged_response.json()
+        assert unchanged_state["id"] == state_id
+        assert unchanged_state["task_id"] == state_data["task_id"]
+        assert unchanged_state["agent_id"] == state_data["agent_id"]
+        assert unchanged_state["state"] == state_value
 
         # API-first validation: UPDATE the created state
         state_value_updated = {"test": "updated"}
@@ -213,8 +215,6 @@ class TestStatesAPIIntegration:
             f"/states/{state_id}",
             json={
                 "state": state_value_updated,
-                "task_id": test_task.id,
-                "agent_id": test_agent.id,
             },
         )
         assert update_response.status_code == 200

--- a/agentex/tests/unit/api/test_states_schema.py
+++ b/agentex/tests/unit/api/test_states_schema.py
@@ -1,0 +1,26 @@
+import pytest
+from pydantic import ValidationError
+from src.api.schemas.states import UpdateStateRequest
+
+
+@pytest.mark.unit
+def test_update_state_request_accepts_state_only():
+    request = UpdateStateRequest.model_validate({"state": {"status": "new"}})
+
+    assert request.state == {"status": "new"}
+
+
+@pytest.mark.unit
+def test_update_state_request_rejects_parent_identifiers():
+    with pytest.raises(ValidationError) as exc_info:
+        UpdateStateRequest.model_validate(
+            {
+                "state": {"status": "new"},
+                "task_id": "task-1",
+                "agent_id": "agent-1",
+            }
+        )
+
+    errors = exc_info.value.errors()
+    assert {error["loc"] for error in errors} == {("task_id",), ("agent_id",)}
+    assert {error["type"] for error in errors} == {"extra_forbidden"}

--- a/agentex/tests/unit/api/test_states_schema.py
+++ b/agentex/tests/unit/api/test_states_schema.py
@@ -1,14 +1,6 @@
 import pytest
 from src.api.schemas.states import UpdateStateRequest
 
-
-@pytest.mark.unit
-def test_update_state_request_accepts_state_only():
-    request = UpdateStateRequest.model_validate({"state": {"status": "new"}})
-
-    assert request.state == {"status": "new"}
-
-
 @pytest.mark.unit
 def test_update_state_request_ignores_legacy_parent_identifiers():
     request = UpdateStateRequest.model_validate(

--- a/agentex/tests/unit/api/test_states_schema.py
+++ b/agentex/tests/unit/api/test_states_schema.py
@@ -1,5 +1,4 @@
 import pytest
-from pydantic import ValidationError
 from src.api.schemas.states import UpdateStateRequest
 
 
@@ -11,16 +10,13 @@ def test_update_state_request_accepts_state_only():
 
 
 @pytest.mark.unit
-def test_update_state_request_rejects_parent_identifiers():
-    with pytest.raises(ValidationError) as exc_info:
-        UpdateStateRequest.model_validate(
-            {
-                "state": {"status": "new"},
-                "task_id": "task-1",
-                "agent_id": "agent-1",
-            }
-        )
+def test_update_state_request_ignores_legacy_parent_identifiers():
+    request = UpdateStateRequest.model_validate(
+        {
+            "state": {"status": "new"},
+            "task_id": "task-1",
+            "agent_id": "agent-1",
+        }
+    )
 
-    errors = exc_info.value.errors()
-    assert {error["loc"] for error in errors} == {("task_id",), ("agent_id",)}
-    assert {error["type"] for error in errors} == {"extra_forbidden"}
+    assert request.model_dump() == {"state": {"status": "new"}}

--- a/agentex/tests/unit/use_cases/test_states_use_case.py
+++ b/agentex/tests/unit/use_cases/test_states_use_case.py
@@ -1,0 +1,65 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from src.adapters.crud_store.exceptions import ItemDoesNotExist
+from src.domain.entities.states import StateEntity
+from src.domain.repositories.task_state_repository import TaskStateRepository
+from src.domain.use_cases.states_use_case import StatesUseCase
+
+
+@pytest.fixture
+def task_state_repository():
+    repository = AsyncMock(spec=TaskStateRepository)
+    repository.get = AsyncMock()
+    repository.update = AsyncMock()
+    return repository
+
+
+@pytest.fixture
+def states_use_case(task_state_repository):
+    return StatesUseCase(task_state_repository=task_state_repository)
+
+
+@pytest.fixture
+def existing_state():
+    return StateEntity(
+        id="state-1",
+        task_id="task-1",
+        agent_id="agent-1",
+        state={"status": "old"},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestStatesUseCase:
+    async def test_update_mutates_state_by_id(
+        self, states_use_case, task_state_repository, existing_state
+    ):
+        task_state_repository.get.return_value = existing_state
+        task_state_repository.update.return_value = existing_state
+
+        result = await states_use_case.update(
+            id="state-1",
+            state={"status": "new"},
+        )
+
+        assert result is existing_state
+        assert result.state == {"status": "new"}
+        task_state_repository.get.assert_awaited_once_with(id="state-1")
+        task_state_repository.update.assert_awaited_once_with(existing_state)
+
+    async def test_update_raises_not_found_when_state_does_not_exist(
+        self, states_use_case, task_state_repository
+    ):
+        task_state_repository.get.return_value = None
+
+        with pytest.raises(ItemDoesNotExist) as exc_info:
+            await states_use_case.update(
+                id="state-1",
+                state={"status": "new"},
+            )
+
+        assert "State state-1 not found" in str(exc_info.value)
+        task_state_repository.get.assert_awaited_once_with(id="state-1")
+        task_state_repository.update.assert_not_awaited()


### PR DESCRIPTION
## Summary
- make state updates identify the row only by the path `state_id`
- keep legacy `task_id` and `agent_id` update payloads accepted but ignored
- rely on `DAuthorizedId(TaskChildResourceType.state, update)` to resolve `state_id` to the stored parent `task_id` and authorize against that task before the handler runs
- update only replaces the persisted state's `.state` field; stored `task_id` and `agent_id` are preserved by the read-modify-write flow
- return 404 when the state lookup fails, and collapse parent-task auth denial to 404 through the existing authorization helper

## Verification
- `uv run --group test pytest tests/unit/api/test_states_schema.py tests/unit/use_cases/test_states_use_case.py -q`

Note: the focused local state API integration test was attempted earlier, but Docker/Testcontainers could not reach the local Docker socket before executing the test body. GitHub Actions integration shards passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the state-update path by removing `task_id` / `agent_id` from `UpdateStateRequest` and relying solely on the `state_id` path parameter. Authorization is handled upstream by `DAuthorizedId(TaskChildResourceType.state, update)`, which looks up the parent task and checks the caller's permissions before the handler runs.

- **Schema cleanup**: `UpdateStateRequest` drops the two previously-required parent-identifier fields; extra fields sent by legacy clients are silently ignored (confirmed by the new unit test).
- **Use-case hardening**: `StatesUseCase.update` now raises `ItemDoesNotExist` (→ 404) instead of silently returning `None` when the state is not found, providing defensive protection for race conditions between the auth lookup and the handler.
- **Test coverage**: Two new unit-test modules cover the schema ignore-behaviour and the use-case not-found path; the integration test is updated to reflect that body-level parent identifiers are now ignored rather than enforced.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change correctly narrows the update contract to state_id-only routing, with authorization handled entirely by the existing DAuthorizedId dependency.

All changed files are consistent with each other: schema, route, use case, OpenAPI spec, and tests all agree on the new contract. The defensive ItemDoesNotExist guard in the use case correctly handles race conditions. Legacy clients sending task_id/agent_id in the request body continue to work without errors. New unit tests verify both the happy path and the not-found path.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/states_use_case.py | Removes task_id parameter from update(); adds ItemDoesNotExist guard for the not-found case. Logic is clean and tests cover both paths. |
| agentex/src/api/routes/states.py | Drops task_id forwarding to the use case; auth is fully delegated to DAuthorizedId. No issues. |
| agentex/src/api/schemas/states.py | task_id and agent_id removed from UpdateStateRequest; BaseModel ignores unknown extra fields, preserving backwards compatibility for legacy clients. |
| agentex/openapi.yaml | UpdateStateRequest schema updated to remove task_id/agent_id from both properties and required array; consistent with schema change. |
| agentex/tests/unit/use_cases/test_states_use_case.py | New unit tests cover update-by-id happy path and ItemDoesNotExist raise; well-structured with AsyncMock and pytest-asyncio. |
| agentex/tests/unit/api/test_states_schema.py | Validates that extra legacy fields in the request body are silently dropped by UpdateStateRequest. |
| agentex/tests/integration/api/states/test_states_api.py | Removes the stale 'wrong task_id is a no-op' test and replaces it with a test confirming legacy body fields are accepted but ignored. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant DAuthorizedId
    participant _get_parent_task_id
    participant StateRepo
    participant AuthService
    participant StatesUseCase

    Client->>DAuthorizedId: "PUT /states/{state_id}"
    DAuthorizedId->>_get_parent_task_id: resolve state_id
    _get_parent_task_id->>StateRepo: "get(id=state_id)"
    StateRepo-->>_get_parent_task_id: StateEntity
    _get_parent_task_id-->>DAuthorizedId: task_id
    DAuthorizedId->>AuthService: check_task_or_collapse_to_404
    AuthService-->>DAuthorizedId: authorized
    DAuthorizedId-->>Client: state_id resolved
    Client->>StatesUseCase: "update(id=state_id, state=new_state)"
    StatesUseCase->>StateRepo: "get(id=state_id)"
    StateRepo-->>StatesUseCase: StateEntity
    StatesUseCase->>StateRepo: update(task_state)
    StateRepo-->>StatesUseCase: updated StateEntity
    StatesUseCase-->>Client: 200 State
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(states): update OpenAPI spec"](https://github.com/scaleapi/scale-agentex/commit/d4566de69ac2194ce0346184f43721af767517ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35740604)</sub>

<!-- /greptile_comment -->