### PR TITLE
fix(tasks): clear stale FAILED status when a later task/create forward succeeds

### DIFF
--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -139,7 +139,7 @@ class AgentTaskService:
         task: TaskEntity,
         task_params: dict[str, Any] | None = None,
         acp_url: str | None = None,
-    ) -> None:
+    ) -> TaskEntity:
         try:
             await self.acp_client.create_task(
                 agent=agent,
@@ -151,6 +151,18 @@ class AgentTaskService:
             logger.error(f"Error creating task in ACP: {e}")
             await self.fail_task(task, str(e))
             raise e from e
+
+        # The forward succeeded: the agent has accepted the task. If this task
+        # was left FAILED by an earlier forward attempt (e.g. the agent was
+        # unavailable the first time task/create was called), clear that stale
+        # failure now that the agent has accepted it. Otherwise the task — and
+        # the task/create RPC response — would keep reporting the old error even
+        # though the task is actually running.
+        if task.status == TaskStatus.FAILED:
+            task.status = TaskStatus.RUNNING
+            task.status_reason = "Task forwarded to ACP server"
+            task = await self.update_task(task)
+        return task
 
     async def fail_task(self, task: TaskEntity, reason: str) -> None:
         task.status = TaskStatus.FAILED

--- a/agentex/src/domain/use_cases/agents_acp_use_case.py
+++ b/agentex/src/domain/use_cases/agents_acp_use_case.py
@@ -430,7 +430,7 @@ class AgentsACPUseCase(TaskMessageMixin):
         )
 
         if agent.acp_type in [ACPType.AGENTIC, ACPType.ASYNC]:
-            await self.task_service.forward_task_to_acp(
+            task = await self.task_service.forward_task_to_acp(
                 agent=agent,
                 task=task,
                 task_params=params.params,

--- a/agentex/tests/unit/services/test_task_service.py
+++ b/agentex/tests/unit/services/test_task_service.py
@@ -359,6 +359,72 @@ class TestAgentTaskService:
         assert updated_task.status == TaskStatus.FAILED
         assert updated_task.status_reason == reason
 
+    async def test_forward_task_to_acp_clears_stale_failed_status(
+        self,
+        task_service,
+        mock_acp_client,
+        task_repository,
+        agent_repository,
+        sample_agent,
+    ):
+        """A task left FAILED by a forward attempt while the agent was down is
+        reset to RUNNING once a later forward succeeds.
+
+        Regression test: previously forward_task_to_acp only ever wrote status
+        on failure, so a task that failed to forward while the agent was
+        unavailable stayed FAILED forever even after the agent recovered and the
+        workflow was actually created — making the task/create RPC response
+        report a misleading failure.
+        """
+        # Given - an agent and a task that fails to forward while the agent is down
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="recovering-task"
+        )
+        mock_acp_client.create_task.side_effect = Exception(
+            "All connection attempts failed"
+        )
+        with pytest.raises(Exception, match="All connection attempts failed"):
+            await task_service.forward_task_to_acp(agent=sample_agent, task=task)
+
+        failed = await task_service.get_task(id=task.id)
+        assert failed.status == TaskStatus.FAILED
+        assert failed.status_reason == "All connection attempts failed"
+
+        # When - the agent recovers and the same task is forwarded again
+        mock_acp_client.create_task.side_effect = None
+        mock_acp_client.create_task.return_value = None
+        result = await task_service.forward_task_to_acp(agent=sample_agent, task=failed)
+
+        # Then - the returned task and the persisted row reflect RUNNING again
+        assert result.status == TaskStatus.RUNNING
+        assert result.status_reason == "Task forwarded to ACP server"
+        refreshed = await task_service.get_task(id=task.id)
+        assert refreshed.status == TaskStatus.RUNNING
+        assert refreshed.status_reason == "Task forwarded to ACP server"
+
+    async def test_forward_task_to_acp_success_preserves_healthy_status(
+        self,
+        task_service,
+        mock_acp_client,
+        task_repository,
+        agent_repository,
+        sample_agent,
+    ):
+        """A successful forward returns the task and leaves a non-FAILED status
+        untouched (only a stale FAILED status is rewritten)."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="healthy-task"
+        )
+        mock_acp_client.create_task.return_value = None
+
+        result = await task_service.forward_task_to_acp(agent=sample_agent, task=task)
+
+        assert result.id == task.id
+        assert result.status == TaskStatus.RUNNING
+        assert result.status_reason == "Task created, forwarding to ACP server"
+
     async def test_get_task_by_id(
         self, task_service, task_repository, agent_repository, sample_agent
     ):


### PR DESCRIPTION
## Problem

When `task/create` is sent for an async/agentic agent whose ACP server is unavailable, the task row is persisted as `FAILED` (`status_reason` = the connection error). `forward_task_to_acp` only ever wrote task status on **failure** (`fail_task`), never on **success** — so once a task row was `FAILED`, nothing ever moved it back.

The consequence: if you call `task/create` again for the **same task name** after the agent is reachable again, the forward succeeds and the workflow is actually created, but the RPC response keeps returning the **stale `FAILED`** status (and `status_reason`) forever. A caller inspecting the response can't tell the task actually started, so it can't decide whether to follow up with `event/send`.

## Fix

- `forward_task_to_acp` now returns the `TaskEntity` and, on a successful forward, resets a stale `FAILED` status back to `RUNNING` with reason `"Task forwarded to ACP server"`. A non-`FAILED` status is left untouched (so genuine failures while the agent is down still report `FAILED`, and other states aren't clobbered).
- `_handle_task_create` returns that refreshed task.

`acp_client.create_task` is already idempotent (it attaches to the existing open workflow), so re-forwarding and re-stamping `RUNNING` is safe.

## Testing

**Live, end-to-end** (real platform + a registered async ACP agent, driving the RPC endpoint with `curl`):
- Reproduced on the pre-fix code: agent down → `task/create` returns the connection error and persists a `FAILED` row; agent up → `task/create` (same name) returns `status: FAILED` even though the agent log confirms it received the `TASK_CREATE` forward (workflow created).
- After the fix: the same recovered `task/create` returns `status: RUNNING`; a fresh down→recover cycle also recovers to `RUNNING`; the genuine agent-down case still returns `FAILED`.

**Unit:** added two regression tests in `test_task_service.py` covering the down→recover sequence and the healthy-status-preserved case. Full file: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a status-staleness bug where a task row left `FAILED` (due to an ACP connection error) would keep reporting `FAILED` forever, even after a subsequent `task/create` call successfully forwarded the task to the recovered agent.

- **`forward_task_to_acp`** now returns `TaskEntity` and, on a successful forward, checks whether the task is currently `FAILED`; if so, it resets the status to `RUNNING` with the reason `\"Task forwarded to ACP server\"` and persists the change — non-`FAILED` statuses are left untouched.
- **`_handle_task_create`** captures the returned (potentially refreshed) task entity so the RPC response reflects the correct post-forward state.
- Two focused regression tests cover the down→recover scenario and the healthy-status-preserved case.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrow, well-tested, and only activates when a task is currently FAILED on a successful forward.

The fix touches a single method signature and adds a small conditional write; it has no effect on tasks that are not FAILED. The only production caller is updated to capture the return value, and both the happy-path and recovery-path behavior are covered by new regression tests that pass.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/services/task_service.py | Return type of `forward_task_to_acp` changed from `None` to `TaskEntity`; stale `FAILED` status is now reset to `RUNNING` on successful forward via a conditional `update_task` call. |
| agentex/src/domain/use_cases/agents_acp_use_case.py | One-line change: `_handle_task_create` now captures the `TaskEntity` returned by `forward_task_to_acp` so the refreshed status propagates to the RPC response. |
| agentex/tests/unit/services/test_task_service.py | Two regression tests added: one verifies the down→recover flow resets status to `RUNNING`, another confirms a healthy task's status is not mutated on successful forward. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tasks): clear stale FAILED status wh..."](https://github.com/scaleapi/scale-agentex/commit/f4842d61882d1889dc0db54c66201bbcd3d5bea5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35865907)</sub>

<!-- /greptile_comment -->