### PR TITLE
fix(authz): treat None principal_context as unset, fall back to authenticated principal

### DIFF
--- a/agentex/src/domain/services/authorization_service.py
+++ b/agentex/src/domain/services/authorization_service.py
@@ -39,6 +39,21 @@ class AuthorizationService:
     def is_enabled(self) -> bool:
         return self.enabled
 
+    def _effective_principal(self, principal_context):
+        """Resolve the principal to authorize as.
+
+        Callers pass the ``...`` sentinel to mean "not supplied", in which case
+        we fall back to the request's authenticated principal. We treat an
+        explicit ``None`` the same way: ``None`` is never a valid principal for
+        the authz gateway (it rejects it with a 422), and callers that forward
+        an optional, unset request field (e.g. ``request.principal_context``)
+        would otherwise defeat the fallback and authorize as nobody. Falling
+        back to the authenticated principal is always the safe default.
+        """
+        if principal_context is ... or principal_context is None:
+            return self.principal_context
+        return principal_context
+
     async def grant(
         self, resource: AgentexResource, *, commit: bool = True, principal_context=...
     ) -> None:
@@ -56,9 +71,7 @@ class AuthorizationService:
             self.principal_context,
         )
         result = await self.gateway.grant(
-            principal_context
-            if principal_context is not ...
-            else self.principal_context,
+            self._effective_principal(principal_context),
             resource,
             AuthorizedOperationType.create,
         )
@@ -80,9 +93,7 @@ class AuthorizationService:
         )
 
         result = await self.gateway.revoke(
-            principal_context
-            if principal_context is not ...
-            else self.principal_context,
+            self._effective_principal(principal_context),
             resource,
             AuthorizedOperationType.delete,
         )
@@ -103,11 +114,7 @@ class AuthorizationService:
             return True
 
         # Determine which principal context to use
-        effective_principal = (
-            principal_context
-            if principal_context is not ...
-            else self.principal_context
-        )
+        effective_principal = self._effective_principal(principal_context)
 
         # Try to get cached result first
         auth_cache = await get_auth_cache()
@@ -177,9 +184,7 @@ class AuthorizationService:
             self.principal_context,
         )
         result = await self.gateway.list_resources(
-            principal_context
-            if principal_context is not ...
-            else self.principal_context,
+            self._effective_principal(principal_context),
             filter_resource,
             filter_operation,
         )
@@ -207,11 +212,7 @@ class AuthorizationService:
             logger.info(f"Authorization bypassed for register_resource on {resource}")
             return None
 
-        effective_principal = (
-            principal_context
-            if principal_context is not ...
-            else self.principal_context
-        )
+        effective_principal = self._effective_principal(principal_context)
         logger.info(
             "[authorization_service] Registering %s:%s for principal %s (parent=%s)",
             resource.type,
@@ -232,11 +233,7 @@ class AuthorizationService:
             logger.info(f"Authorization bypassed for deregister_resource on {resource}")
             return None
 
-        effective_principal = (
-            principal_context
-            if principal_context is not ...
-            else self.principal_context
-        )
+        effective_principal = self._effective_principal(principal_context)
         logger.info(
             "[authorization_service] Deregistering %s:%s for principal %s",
             resource.type,

--- a/agentex/tests/unit/services/test_authorization_service_principal.py
+++ b/agentex/tests/unit/services/test_authorization_service_principal.py
@@ -1,0 +1,120 @@
+"""Regression tests for principal resolution in ``AuthorizationService``.
+
+The service uses an Ellipsis (``...``) sentinel to mean "principal not
+supplied → authorize as the request's authenticated principal". A caller that
+forwards an *optional, unset* request field (e.g. ``register_build`` passing
+``request.principal_context``) hands the service an explicit ``None``. ``None``
+is never a valid principal for the authz gateway (it rejects it), so the
+service must treat ``None`` the same as the sentinel and fall back to the
+authenticated principal. Without that, build-time agent registration 422s.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from src.api.schemas.authorization_types import (
+    AgentexResource,
+    AgentexResourceType,
+    AuthorizedOperationType,
+)
+from src.domain.services.authorization_service import AuthorizationService
+
+AUTHED = "authenticated-principal"
+EXPLICIT = "explicit-principal"
+
+
+def _service(gateway):
+    """Build a service whose request carries an authenticated principal and
+    no agent identity (so authorization is not bypassed)."""
+    request = MagicMock()
+    request.state.principal_context = AUTHED
+    request.state.agent_identity = None
+    return AuthorizationService(enabled=True, gateway=gateway, request=request)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestEffectivePrincipalCoalescing:
+    """Both ``None`` and the sentinel fall back to the authenticated principal;
+    an explicit principal is honored."""
+
+    async def test_grant_none_falls_back_to_authenticated(self):
+        gateway = MagicMock()
+        gateway.grant = AsyncMock()
+        svc = _service(gateway)
+
+        await svc.grant(AgentexResource.agent("a-1"), principal_context=None)
+
+        # The failing build-registration path: body field is None, must NOT be
+        # forwarded as the principal.
+        assert gateway.grant.await_args.args[0] == AUTHED
+
+    async def test_grant_sentinel_uses_authenticated(self):
+        gateway = MagicMock()
+        gateway.grant = AsyncMock()
+        svc = _service(gateway)
+
+        await svc.grant(AgentexResource.agent("a-1"))
+
+        assert gateway.grant.await_args.args[0] == AUTHED
+
+    async def test_grant_explicit_principal_is_honored(self):
+        gateway = MagicMock()
+        gateway.grant = AsyncMock()
+        svc = _service(gateway)
+
+        await svc.grant(AgentexResource.agent("a-1"), principal_context=EXPLICIT)
+
+        assert gateway.grant.await_args.args[0] == EXPLICIT
+
+    async def test_revoke_none_falls_back_to_authenticated(self):
+        gateway = MagicMock()
+        gateway.revoke = AsyncMock()
+        svc = _service(gateway)
+
+        await svc.revoke(AgentexResource.agent("a-1"), principal_context=None)
+
+        assert gateway.revoke.await_args.args[0] == AUTHED
+
+    async def test_list_resources_none_falls_back_to_authenticated(self):
+        gateway = MagicMock()
+        gateway.list_resources = AsyncMock(return_value=[])
+        svc = _service(gateway)
+
+        await svc.list_resources(AgentexResourceType.agent, principal_context=None)
+
+        assert gateway.list_resources.await_args.args[0] == AUTHED
+
+    async def test_register_resource_none_falls_back_to_authenticated(self):
+        gateway = MagicMock()
+        gateway.register_resource = AsyncMock()
+        svc = _service(gateway)
+
+        await svc.register_resource(
+            AgentexResource.agent("a-1"), principal_context=None
+        )
+
+        assert gateway.register_resource.await_args.args[0] == AUTHED
+
+    async def test_check_none_falls_back_to_authenticated(self):
+        gateway = MagicMock()
+        gateway.check = AsyncMock(return_value=True)
+        svc = _service(gateway)
+
+        cache = MagicMock()
+        cache.get_authorization_check = AsyncMock(return_value=None)  # cache miss
+        cache.set_authorization_check = AsyncMock()
+
+        with patch(
+            "src.domain.services.authorization_service.get_auth_cache",
+            AsyncMock(return_value=cache),
+        ):
+            await svc.check(
+                AgentexResource.agent("*"),
+                AuthorizedOperationType.create,
+                principal_context=None,
+            )
+
+        assert gateway.check.await_args.args[0] == AUTHED


### PR DESCRIPTION
## Summary

`POST /agents/register-build` 500s for **every** cloud build with `Failed to register build agent <name> in agentex` (surfacing an underlying agentex **422**). This blocks all SGP cloud builds that go through build-time agent registration (introduced by #145545 on the egp-api-backend side).

### Root cause

`AuthorizationService.{grant,revoke,check,list_resources,register_resource,deregister_resource}` default `principal_context` to an Ellipsis (`...`) sentinel meaning *"not supplied → authorize as the request's authenticated principal"* (`self.principal_context = request.state.principal_context`).

The `register_build` / `register_agent` routes forward `principal_context=request.principal_context` — an **optional body field**. The build-flow caller (egp-api-backend) authenticates via headers and sends only `{name, description}`, so that body field is `None`. The route passes an explicit `None`, and `None is not ...` is `True`, so the sentinel fallback is bypassed and `None` is sent to the authz gateway as the principal. The gateway rejects a `None` principal with 422 → egp-api-backend wraps it as a 500.

This is why the failure is universal across builds (reproduced against the deployed pod for both a UUID-named agent and a normal name), not specific to any one agent — and why other endpoints are unaffected: they never forward a body `principal_context` (so they always hit the sentinel fallback), and `register_agent`'s self-registering callers populate the field with a real principal.

### Fix

Coalesce `None` to the authenticated principal via a shared `_effective_principal` helper, applied across all six methods. `None` is never a valid gateway principal (it always 422s), so this changes only the previously-broken path; explicit real principals are still honored, and the sentinel behavior is unchanged. This also closes the identical latent footgun in `register_agent`.

### Tests

Added `tests/unit/services/test_authorization_service_principal.py`: asserts `None` and the sentinel both resolve to the authenticated principal across `grant`/`revoke`/`check`/`list_resources`/`register_resource`, and that an explicit principal is preserved. All 7 new + existing authz tests pass; `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a universal 500 error on `POST /agents/register-build` caused by `None` being forwarded as the authz gateway principal when an optional body field (`principal_context`) is unset. The fix introduces a `_effective_principal` helper that coalesces both `None` and the existing `...` sentinel to the request's authenticated principal, applied consistently across all six `AuthorizationService` methods.

- **`authorization_service.py`**: Replaces six inline ternary sentinel checks with a single `_effective_principal` helper; `None` is now treated identically to the `...` sentinel, preventing 422s from the gateway when callers forward an unset optional field.
- **`test_authorization_service_principal.py`**: New regression test file asserting `None` and sentinel coalescing across `grant`, `revoke`, `check`, `list_resources`, and `register_resource`; `deregister_resource` is not covered.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the fix is narrowly scoped, only affects the previously-broken None path, and leaves all other call sites unchanged.

The _effective_principal helper is correct and applied uniformly across all six methods. The only gap is that deregister_resource has no corresponding test in the new regression file, leaving one method unverified by the new suite.

The test file is missing a deregister_resource case; the service implementation itself is clean.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/services/authorization_service.py | Adds _effective_principal helper that coalesces None to the request's authenticated principal, applied consistently across all 6 authz methods; logic is correct and well-documented. |
| agentex/tests/unit/services/test_authorization_service_principal.py | New regression test file covering 5 of the 6 methods that use _effective_principal; deregister_resource is not exercised. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as register_build route
    participant AS as AuthorizationService
    participant GW as Authz Gateway

    Note over Caller,GW: Before fix — body field absent, principal_context=None
    Caller->>AS: "register_resource(resource, principal_context=None)"
    AS->>GW: register_resource(None, resource, parent)
    GW-->>AS: 422 Unprocessable Entity
    AS-->>Caller: 500 Internal Server Error

    Note over Caller,GW: After fix — None coalesced to authenticated principal
    Caller->>AS: "register_resource(resource, principal_context=None)"
    AS->>AS: _effective_principal(None) → self.principal_context
    AS->>GW: register_resource(authed_principal, resource, parent)
    GW-->>AS: 200 OK
    AS-->>Caller: success
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Ftests%2Funit%2Fservices%2Ftest_authorization_service_principal.py%3A37-120%0A**Missing%20%60deregister_resource%60%20coverage**%0A%0AThe%20test%20class%20documents%20that%20it%20covers%20all%20principal-resolution%20paths%2C%20but%20%60deregister_resource%60%20is%20the%20one%20method%20in%20%60AuthorizationService%60%20that%20calls%20%60_effective_principal%60%20without%20a%20corresponding%20test%20here.%20The%20PR%20description%20lists%20%60grant%60%2F%60revoke%60%2F%60check%60%2F%60list_resources%60%2F%60register_resource%60%20%E2%80%94%20%60deregister_resource%60%20is%20explicitly%20absent.%20A%20%60deregister%60%20call%20with%20%60principal_context%3DNone%60%20would%20invoke%20the%20same%20helper%20and%20resolve%20correctly%2C%20but%20a%20counterpart%20test%20would%20complete%20the%20regression%20suite%20and%20guard%20against%20any%20future%20divergence%20in%20that%20method's%20signature.%0A%0A&pr=280&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Ftests%2Funit%2Fservices%2Ftest_authorization_service_principal.py%3A37-120%0A**Missing%20%60deregister_resource%60%20coverage**%0A%0AThe%20test%20class%20documents%20that%20it%20covers%20all%20principal-resolution%20paths%2C%20but%20%60deregister_resource%60%20is%20the%20one%20method%20in%20%60AuthorizationService%60%20that%20calls%20%60_effective_principal%60%20without%20a%20corresponding%20test%20here.%20The%20PR%20description%20lists%20%60grant%60%2F%60revoke%60%2F%60check%60%2F%60list_resources%60%2F%60register_resource%60%20%E2%80%94%20%60deregister_resource%60%20is%20explicitly%20absent.%20A%20%60deregister%60%20call%20with%20%60principal_context%3DNone%60%20would%20invoke%20the%20same%20helper%20and%20resolve%20correctly%2C%20but%20a%20counterpart%20test%20would%20complete%20the%20regression%20suite%20and%20guard%20against%20any%20future%20divergence%20in%20that%20method's%20signature.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=280&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22ronak%2Ffix-authz-none-principal%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ronak%2Ffix-authz-none-principal%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Ftests%2Funit%2Fservices%2Ftest_authorization_service_principal.py%3A37-120%0A**Missing%20%60deregister_resource%60%20coverage**%0A%0AThe%20test%20class%20documents%20that%20it%20covers%20all%20principal-resolution%20paths%2C%20but%20%60deregister_resource%60%20is%20the%20one%20method%20in%20%60AuthorizationService%60%20that%20calls%20%60_effective_principal%60%20without%20a%20corresponding%20test%20here.%20The%20PR%20description%20lists%20%60grant%60%2F%60revoke%60%2F%60check%60%2F%60list_resources%60%2F%60register_resource%60%20%E2%80%94%20%60deregister_resource%60%20is%20explicitly%20absent.%20A%20%60deregister%60%20call%20with%20%60principal_context%3DNone%60%20would%20invoke%20the%20same%20helper%20and%20resolve%20correctly%2C%20but%20a%20counterpart%20test%20would%20complete%20the%20regression%20suite%20and%20guard%20against%20any%20future%20divergence%20in%20that%20method's%20signature.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=280&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex/tests/unit/services/test_authorization_service_principal.py:37-120
**Missing `deregister_resource` coverage**

The test class documents that it covers all principal-resolution paths, but `deregister_resource` is the one method in `AuthorizationService` that calls `_effective_principal` without a corresponding test here. The PR description lists `grant`/`revoke`/`check`/`list_resources`/`register_resource` — `deregister_resource` is explicitly absent. A `deregister` call with `principal_context=None` would invoke the same helper and resolve correctly, but a counterpart test would complete the regression suite and guard against any future divergence in that method's signature.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(authz): treat None principal\_context..."](https://github.com/scaleapi/scale-agentex/commit/f3b876908aa32b5f99c8ba41d6c82323a2f3fd7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35882467)</sub>

<!-- /greptile_comment -->