### PR TITLE
fix(authz): register build agents as resources

### DIFF
--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -236,7 +236,7 @@ async def register_build(
     agents_use_case: DAgentsUseCase,
     authorization_service: DAuthorizationService,
 ) -> Agent:
-    """Create a build-only agent row and grant the caller access to it."""
+    """Create a build-only agent row and register its authz resource."""
     await authorization_service.check(
         AgentexResource.agent("*"),
         AuthorizedOperationType.create,
@@ -252,7 +252,7 @@ async def register_build(
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    await authorization_service.grant(
+    await authorization_service.register_resource(
         AgentexResource.agent(agent_entity.id),
         principal_context=request.principal_context,
     )

--- a/agentex/tests/unit/api/test_agents_register_build_authz.py
+++ b/agentex/tests/unit/api/test_agents_register_build_authz.py
@@ -1,0 +1,69 @@
+"""Route-level authz tests for agent build registration."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from src.api.routes.agents import register_build
+from src.api.schemas.agents import RegisterBuildRequest
+from src.api.schemas.authorization_types import AgentexResource, AuthorizedOperationType
+from src.domain.entities.agents import AgentEntity, AgentStatus
+
+
+def _agent() -> AgentEntity:
+    now = datetime.now(tz=UTC)
+    return AgentEntity(
+        id="agent-123",
+        name="build-agent",
+        description="Created from build",
+        status=AgentStatus.BUILD_ONLY,
+        status_reason="Agent build registered; not yet deployed.",
+        acp_url=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_register_build_registers_agent_resource() -> None:
+    """Build-time agent creation must call register_resource, not grant-only."""
+    agents_use_case = MagicMock()
+    agents_use_case.register_build = AsyncMock(return_value=_agent())
+    authorization_service = MagicMock()
+    authorization_service.check = AsyncMock(return_value=True)
+    authorization_service.register_resource = AsyncMock(return_value=None)
+    authorization_service.grant = AsyncMock(return_value=None)
+    principal_context = {
+        "account_id": "account-123",
+        "user_id": "user-123",
+        "api_key": "test-key",
+    }
+
+    result = await register_build(
+        request=RegisterBuildRequest(
+            name="build-agent",
+            description="Created from build",
+            principal_context=principal_context,
+        ),
+        agents_use_case=agents_use_case,
+        authorization_service=authorization_service,
+    )
+
+    assert result.id == "agent-123"
+    authorization_service.check.assert_awaited_once_with(
+        AgentexResource.agent("*"),
+        AuthorizedOperationType.create,
+        principal_context=principal_context,
+    )
+    agents_use_case.register_build.assert_awaited_once_with(
+        name="build-agent",
+        description="Created from build",
+        registration_metadata=None,
+        agent_input_type=None,
+    )
+    authorization_service.register_resource.assert_awaited_once_with(
+        AgentexResource.agent("agent-123"),
+        principal_context=principal_context,
+    )
+    authorization_service.grant.assert_not_awaited()

--- a/agentex/tests/unit/api/test_agents_register_build_authz.py
+++ b/agentex/tests/unit/api/test_agents_register_build_authz.py
@@ -67,3 +67,51 @@ async def test_register_build_registers_agent_resource() -> None:
         principal_context=principal_context,
     )
     authorization_service.grant.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_register_build_existing_agent_path_is_reentrant() -> None:
+    """Idempotent-by-name path returns an existing agent and re-registers safely.
+
+    The auth layer owns duplicate-resource idempotency; the route must keep
+    using the resource-registration path for the returned agent instead of
+    falling back to grant-only behavior.
+    """
+    existing_agent = _agent()
+    agents_use_case = MagicMock()
+    agents_use_case.register_build = AsyncMock(return_value=existing_agent)
+    authorization_service = MagicMock()
+    authorization_service.check = AsyncMock(return_value=True)
+    authorization_service.register_resource = AsyncMock(return_value=None)
+    authorization_service.grant = AsyncMock(return_value=None)
+    principal_context = {
+        "account_id": "account-123",
+        "user_id": "user-123",
+        "api_key": "test-key",
+    }
+    request = RegisterBuildRequest(
+        name="build-agent",
+        description="Created from build",
+        principal_context=principal_context,
+    )
+
+    first = await register_build(
+        request=request,
+        agents_use_case=agents_use_case,
+        authorization_service=authorization_service,
+    )
+    second = await register_build(
+        request=request,
+        agents_use_case=agents_use_case,
+        authorization_service=authorization_service,
+    )
+
+    assert first.id == existing_agent.id
+    assert second.id == existing_agent.id
+    assert agents_use_case.register_build.await_count == 2
+    assert authorization_service.register_resource.await_count == 2
+    for call in authorization_service.register_resource.await_args_list:
+        assert call.args == (AgentexResource.agent(existing_agent.id),)
+        assert call.kwargs == {"principal_context": principal_context}
+    authorization_service.grant.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Change `/agents/register-build` to call `authorization_service.register_resource(...)` for the returned agent resource instead of grant-only authz.
- Add a route-level unit test proving build-time agent registration writes the agent resource and does not fall back to `grant`.

## Why
`grant` maps to Spark `grant_resource_role`, while `register_resource` maps to Spark resource lifecycle registration. Build-created agents need the lifecycle registration so downstream resources such as agent builds can use the agent as their parent resource.

## Validation
- `uv run python scripts/run_tests.py tests/unit/api/test_agents_register_build_authz.py`
- `uv run ruff check src/api/routes/agents.py tests/unit/api/test_agents_register_build_authz.py`
- `uv run ruff format --check src/api/routes/agents.py tests/unit/api/test_agents_register_build_authz.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the authorization path for the `/agents/register-build` endpoint by replacing `authorization_service.grant(...)` with `authorization_service.register_resource(...)`, which maps to Spark's resource lifecycle registration instead of a role-assignment operation. A new test file is added to explicitly verify the correct call is made and that `grant` is never invoked.

- **`agents.py`**: Single-line swap from `grant` to `register_resource` at the end of `register_build`, plus an updated docstring.
- **`test_agents_register_build_authz.py`**: New test file with a happy-path test and a re-entrant idempotency test that assert `register_resource` is called (and `grant` is not) on every invocation, including repeated calls for an already-existing agent.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted one-line correction to the authz call, backed by a new test file that covers both the new-agent and re-entrant paths.

The route change is minimal and intentional: replacing grant with register_resource aligns the build-registration flow with Spark's resource lifecycle model. The new test file explicitly asserts the correct method is called and that grant is never invoked, including on repeated calls for the same agent. No logic outside the authz call was modified.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/api/routes/agents.py | Single-line change swapping `grant` for `register_resource` on the `register_build` endpoint, with a matching docstring update. Logic is minimal and correct. |
| agentex/tests/unit/api/test_agents_register_build_authz.py | New unit test file covering both the happy path (new agent) and the re-entrant path (existing agent returned by `register_build`), asserting `register_resource` is called and `grant` is never called. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant register_build route
    participant authorization_service
    participant agents_use_case

    Client->>register_build route: POST /agents/register-build
    register_build route->>authorization_service: check(agent("*"), create, principal_context)
    authorization_service-->>register_build route: OK
    register_build route->>agents_use_case: register_build(name, description, ...)
    agents_use_case-->>register_build route: agent_entity
    register_build route->>authorization_service: register_resource(agent(agent_entity.id), principal_context)
    note over authorization_service: Spark resource lifecycle registration<br/>(was: grant_resource_role)
    authorization_service-->>register_build route: OK
    register_build route-->>Client: Agent response
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(authz): cover reentrant build regis..."](https://github.com/scaleapi/scale-agentex/commit/a749e5e8374e694c9e27f0a55885d568042d3788) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36250684)</sub>

<!-- /greptile_comment -->