### PR TITLE
build(docs): isolate docs build from the workspace lock

### DIFF
--- a/.github/workflows/build-agentex.yml
+++ b/.github/workflows/build-agentex.yml
@@ -75,10 +75,9 @@ jobs:
       - name: Build documentation
         working-directory: ./agentex
         run: |
-          # Install docs dependencies
-          uv sync --group docs
-          # Build documentation
-          cd docs && uv run mkdocs build
+          # Build docs in an isolated env (deps from docs/requirements.txt),
+          # decoupled from the workspace lock so it never forces backend dep bumps.
+          cd docs && uv run --isolated --no-project --with-requirements requirements.txt mkdocs build
 
       # Build and push server image to GHCR
       - name: Build and push AgentEx server image to GHCR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,9 @@ jobs:
       working-directory: ./agentex
       run: |
         echo "📚 Building documentation..."
-        # Install docs dependencies
-        uv sync --group docs
-        # Build documentation
-        cd docs && uv run mkdocs build
+        # Build docs in an isolated env (deps from docs/requirements.txt),
+        # decoupled from the workspace lock so it never forces backend dep bumps.
+        cd docs && uv run --isolated --no-project --with-requirements requirements.txt mkdocs build
         echo "✅ Documentation built successfully"
 
     # Verify docs were built

--- a/agentex/Dockerfile
+++ b/agentex/Dockerfile
@@ -65,18 +65,14 @@ FROM base AS docs-builder
 ARG SOURCE_DIR=agentex
 ARG UV_INDEX_URL=
 
-# Install docs dependencies to system Python
-RUN if [ -n "${UV_INDEX_URL}" ]; then \
-        uv export --frozen --group docs --no-emit-project --package agentex-backend \
-            -o /tmp/requirements.txt && \
-        uv pip install --system --index-url "${UV_INDEX_URL}" \
-            -r /tmp/requirements.txt && \
-        rm /tmp/requirements.txt; \
-    else \
-        uv sync --frozen --group docs --package agentex-backend; \
-    fi
-
 COPY ${SOURCE_DIR}/docs/ docs/
+# Docs build is decoupled from the workspace lock: install the toolchain + latest
+# SDK from docs/requirements.txt so doc generation tracks SDK releases.
+RUN if [ -n "${UV_INDEX_URL}" ]; then \
+        uv pip install --system --index-url "${UV_INDEX_URL}" -r docs/requirements.txt; \
+    else \
+        uv pip install --system -r docs/requirements.txt; \
+    fi
 COPY ${SOURCE_DIR}/src/ src/
 RUN cd docs && mkdocs build
 

--- a/agentex/Makefile
+++ b/agentex/Makefile
@@ -6,7 +6,7 @@
 # Development Commands
 #
 
-.PHONY: install install-dev install-docs clean help
+.PHONY: install install-dev clean help
 
 help: ## Show this help message
 	@echo "AgentEx Development Commands:"
@@ -24,10 +24,6 @@ install-dev: ../repo-setup ## Install dependencies including dev group
 
 ../repo-setup:
 	@$(MAKE) -C .. repo-setup
-
-install-docs: ## Install docs dependencies
-	@echo "🚀 Installing docs dependencies..."
-	uv sync --group docs
 
 clean: ## Clean virtual environment and lock file
 	@echo "🧹 Cleaning virtual environment..."

--- a/agentex/Makefile
+++ b/agentex/Makefile
@@ -80,14 +80,12 @@ gen-openapi: ## Regenerate openapi.yaml from the FastAPI app
 #
 
 serve-docs: ## Serve documentation locally
-	@echo "📚 Installing docs dependencies..."
-	uv sync --group docs
-	cd docs && uv run mkdocs serve -a localhost:8001
+	@echo "📚 Serving documentation..."
+	cd docs && uv run --isolated --no-project --with-requirements requirements.txt mkdocs serve -a localhost:8001
 
 build-docs: ## Build documentation
 	@echo "📚 Building documentation..."
-	uv sync --group docs
-	cd docs && uv run mkdocs build
+	cd docs && uv run --isolated --no-project --with-requirements requirements.txt mkdocs build
 
 docker-build: ## Build production Docker image
 	@echo "🐳 Building production Docker image..."

--- a/agentex/docs/requirements.txt
+++ b/agentex/docs/requirements.txt
@@ -1,14 +1,16 @@
-# Documentation build dependencies.
+# Docs build deps — resolved independently of the workspace uv.lock so docs
+# track the latest published SDK without forcing backend dep bumps. Consumed via
+# `uv run --isolated --no-project --with-requirements` (CI, Makefile) and
+# `uv pip install -r` (Dockerfile docs-builder stage).
 #
-# Resolved independently of the workspace uv.lock so the docs always render
-# against the latest published SDK without forcing backend dependency bumps.
-# Consumed via `uv run --isolated --no-project --with-requirements` (CI, Makefile)
-# and `uv pip install -r` (Dockerfile docs-builder stage).
+# agentex-sdk floats by design (docs track the latest SDK release); the mkdocs
+# toolchain is pinned for reproducible builds — Dependabot keeps the pins current.
 agentex-sdk>=0.12.0
-mkdocs
-mkdocs-material
-mkdocs-macros-plugin
-mkdocstrings-python
-griffe-pydantic
-pymdown-extensions
-Pygments
+
+mkdocs==1.6.1
+mkdocs-material==9.7.6
+mkdocs-macros-plugin==1.5.0
+mkdocstrings-python==2.0.4
+griffe-pydantic==1.3.1
+pymdown-extensions==10.21.3
+Pygments==2.20.0

--- a/agentex/docs/requirements.txt
+++ b/agentex/docs/requirements.txt
@@ -1,0 +1,14 @@
+# Documentation build dependencies.
+#
+# Resolved independently of the workspace uv.lock so the docs always render
+# against the latest published SDK without forcing backend dependency bumps.
+# Consumed via `uv run --isolated --no-project --with-requirements` (CI, Makefile)
+# and `uv pip install -r` (Dockerfile docs-builder stage).
+agentex-sdk>=0.12.0
+mkdocs
+mkdocs-material
+mkdocs-macros-plugin
+mkdocstrings-python
+griffe-pydantic
+pymdown-extensions
+Pygments

--- a/agentex/pyproject.toml
+++ b/agentex/pyproject.toml
@@ -53,17 +53,6 @@ test = [
     "greenlet>=3.2.3",
     "asyncpg>=0.29.0",
 ]
-docs = [
-    "mkdocs-material>=9.6.14,<10",
-    "mkdocs-macros-plugin>=1.3.7,<2",
-    "mkdocstrings-python>=1.16.12",
-    "mkdocs>=1.6.1",
-    "agentex-sdk",
-    "griffe-pydantic>=1.1.4",
-    "pymdown-extensions>=10.0,<11",
-    "Pygments>=2.19.2,<2.20",
-    "agentex-sdk",
-]
 
 [tool.hatch.build.targets.sdist]
 include = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,6 @@ dev = [
     "pre-commit>=3.0.0",
     "ruff>=0.3.4",
 ]
-docs = [
-    "agentex[docs]",
-]
 
 [tool.uv]
 environments = [

--- a/uv.lock
+++ b/uv.lock
@@ -39,9 +39,6 @@ dev = [
     { name = "pre-commit", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "ruff", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-docs = [
-    { name = "agentex", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
 
 [package.metadata]
 requires-dist = [
@@ -55,7 +52,6 @@ dev = [
     { name = "pre-commit", specifier = ">=3.0.0" },
     { name = "ruff", specifier = ">=0.3.4" },
 ]
-docs = [{ name = "agentex", extras = ["docs"] }]
 
 [[package]]
 name = "agentex-backend"
@@ -98,16 +94,6 @@ dev = [
     { name = "pytest-cov", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "ruff", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "vulture", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-docs = [
-    { name = "agentex-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "griffe-pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs-macros-plugin", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs-material", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocstrings-python", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pymdown-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 test = [
     { name = "asyncpg", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -158,16 +144,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0,<6" },
     { name = "ruff", specifier = ">=0.3.4" },
     { name = "vulture", specifier = ">=2.14" },
-]
-docs = [
-    { name = "agentex-sdk" },
-    { name = "griffe-pydantic", specifier = ">=1.1.4" },
-    { name = "mkdocs", specifier = ">=1.6.1" },
-    { name = "mkdocs-macros-plugin", specifier = ">=1.3.7,<2" },
-    { name = "mkdocs-material", specifier = ">=9.6.14,<10" },
-    { name = "mkdocstrings-python", specifier = ">=1.16.12" },
-    { name = "pygments", specifier = ">=2.19.2,<2.20" },
-    { name = "pymdown-extensions", specifier = ">=10.0,<11" },
 ]
 test = [
     { name = "asyncpg", specifier = ">=0.29.0" },
@@ -402,27 +378,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
-]
-
-[[package]]
-name = "babel"
-version = "2.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
-]
-
-[[package]]
-name = "backrefs"
-version = "5.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/a7/312f673df6a79003279e1f55619abbe7daebbb87c17c976ddc0345c04c7b/backrefs-5.9.tar.gz", hash = "sha256:808548cb708d66b82ee231f962cb36faaf4f2baab032f2fbb783e9c2fdddaa59", size = 5765857, upload-time = "2025-06-22T19:34:13.97Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/4d/798dc1f30468134906575156c089c492cf79b5a5fd373f07fe26c4d046bf/backrefs-5.9-py310-none-any.whl", hash = "sha256:db8e8ba0e9de81fcd635f440deab5ae5f2591b54ac1ebe0550a2ca063488cd9f", size = 380267, upload-time = "2025-06-22T19:34:05.252Z" },
-    { url = "https://files.pythonhosted.org/packages/55/07/f0b3375bf0d06014e9787797e6b7cc02b38ac9ff9726ccfe834d94e9991e/backrefs-5.9-py311-none-any.whl", hash = "sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf", size = 392072, upload-time = "2025-06-22T19:34:06.743Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/12/4f345407259dd60a0997107758ba3f221cf89a9b5a0f8ed5b961aef97253/backrefs-5.9-py312-none-any.whl", hash = "sha256:7fdf9771f63e6028d7fee7e0c497c81abda597ea45d6b8f89e8ad76994f5befa", size = 397947, upload-time = "2025-06-22T19:34:08.172Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ff/392bff89415399a979be4a65357a41d92729ae8580a66073d8ec8d810f98/backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60", size = 380265, upload-time = "2025-06-22T19:34:12.405Z" },
 ]
 
 [[package]]
@@ -845,18 +800,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ghp-import"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
-]
-
-[[package]]
 name = "google-auth"
 version = "2.40.3"
 source = { registry = "https://pypi.org/simple" }
@@ -913,18 +856,6 @@ wheels = [
 ]
 
 [[package]]
-name = "griffe-pydantic"
-version = "1.1.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griffe", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/d7/b5b74da7cd07bb7807609efc171508acf8a804bb190f190ff7d7dee710e4/griffe_pydantic-1.1.7.tar.gz", hash = "sha256:76328423a557f50391d77aaf27c82c86647e996e09ce1db3b098fadb8f312e40", size = 43148, upload-time = "2025-09-05T16:11:38.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/bd/63e56c639e7a2f60955bbfd061a232a7c744f105f60b6ea4621d6d079beb/griffe_pydantic-1.1.7-py3-none-any.whl", hash = "sha256:516d6dbb6a6587bd0f70c2d23f1dc1b6e2e06eff7d9d37c2db9f0f60ea527af8", size = 12673, upload-time = "2025-09-05T16:11:37.542Z" },
-]
-
-[[package]]
 name = "grpcio"
 version = "1.76.0"
 source = { registry = "https://pypi.org/simple" }
@@ -977,15 +908,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/a7/0b2e242b918cc30e1f91980f3c4b026ff2eedaf1e2ad96933bca164b2869/hf_xet-1.1.10-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eae7c1fc8a664e54753ffc235e11427ca61f4b0477d757cc4eb9ae374b69f09c", size = 3087167, upload-time = "2025-09-12T20:10:17.255Z" },
     { url = "https://files.pythonhosted.org/packages/4a/25/3e32ab61cc7145b11eee9d745988e2f0f4fafda81b25980eebf97d8cff15/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0a0005fd08f002180f7a12d4e13b22be277725bc23ed0529f8add5c7a6309c06", size = 3248612, upload-time = "2025-09-12T20:10:24.093Z" },
     { url = "https://files.pythonhosted.org/packages/2c/3d/ab7109e607ed321afaa690f557a9ada6d6d164ec852fd6bf9979665dc3d6/hf_xet-1.1.10-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f900481cf6e362a6c549c61ff77468bd59d6dd082f3170a36acfef2eb6a6793f", size = 3353360, upload-time = "2025-09-12T20:10:25.563Z" },
-]
-
-[[package]]
-name = "hjson"
-version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541, upload-time = "2022-08-13T02:53:01.919Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018, upload-time = "2022-08-13T02:52:59.899Z" },
 ]
 
 [[package]]
@@ -1449,15 +1371,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown"
-version = "3.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/37/02347f6d6d8279247a5837082ebc26fc0d5aaeaf75aa013fcbb433c777ab/markdown-3.9.tar.gz", hash = "sha256:d2900fe1782bd33bdbbd56859defef70c2e78fc46668f8eb9df3128138f2cb6a", size = 364585, upload-time = "2025-09-04T20:25:22.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ae/44c4a6a4cbb496d93c6257954260fe3a6e91b7bed2240e5dad2a717f5111/markdown-3.9-py3-none-any.whl", hash = "sha256:9f4d91ed810864ea88a6f32c07ba8bee1346c0cc1f6b1f9f6c822f2a9667d280", size = 107441, upload-time = "2025-09-04T20:25:21.784Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1534,149 +1447,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "mergedeep"
-version = "1.3.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
-]
-
-[[package]]
-name = "mkdocs"
-version = "1.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "ghp-import", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "markupsafe", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mergedeep", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs-get-deps", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pathspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pyyaml-env-tag", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "watchdog", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
-]
-
-[[package]]
-name = "mkdocs-autorefs"
-version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "markupsafe", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/51/fa/9124cd63d822e2bcbea1450ae68cdc3faf3655c69b455f3a7ed36ce6c628/mkdocs_autorefs-1.4.3.tar.gz", hash = "sha256:beee715b254455c4aa93b6ef3c67579c399ca092259cc41b7d9342573ff1fc75", size = 55425, upload-time = "2025-08-26T14:23:17.223Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl", hash = "sha256:469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9", size = 25034, upload-time = "2025-08-26T14:23:15.906Z" },
-]
-
-[[package]]
-name = "mkdocs-get-deps"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mergedeep", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "platformdirs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
-]
-
-[[package]]
-name = "mkdocs-macros-plugin"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hjson", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pathspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "super-collections", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "termcolor", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/8a/1be9f663fff066d68598762e91a9a9e9e4ff901ef1a49fea506847b3b1f5/mkdocs_macros_plugin-1.4.0.tar.gz", hash = "sha256:687e710988736731d1a059633fc34cf66d21e57a07801bdd1991419199e0677c", size = 34758, upload-time = "2025-09-22T14:18:07.258Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/88/d20e962f7fddf46094e0e9365bf8167a82a32e3086851b32ef25978ac6cf/mkdocs_macros_plugin-1.4.0-py3-none-any.whl", hash = "sha256:630de99fe14d39c26c7915725b39bb7730058c622f547226432eb371cabff33c", size = 39593, upload-time = "2025-09-22T14:18:06.058Z" },
-]
-
-[[package]]
-name = "mkdocs-material"
-version = "9.6.20"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "babel", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "backrefs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "colorama", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs-material-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "paginate", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pymdown-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/ee/6ed7fc739bd7591485c8bec67d5984508d3f2733e708f32714c21593341a/mkdocs_material-9.6.20.tar.gz", hash = "sha256:e1f84d21ec5fb730673c4259b2e0d39f8d32a3fef613e3a8e7094b012d43e790", size = 4037822, upload-time = "2025-09-15T08:48:01.816Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/d8/a31dd52e657bf12b20574706d07df8d767e1ab4340f9bfb9ce73950e5e59/mkdocs_material-9.6.20-py3-none-any.whl", hash = "sha256:b8d8c8b0444c7c06dd984b55ba456ce731f0035c5a1533cc86793618eb1e6c82", size = 9193367, upload-time = "2025-09-15T08:47:58.722Z" },
-]
-
-[[package]]
-name = "mkdocs-material-extensions"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
-]
-
-[[package]]
-name = "mkdocstrings"
-version = "0.30.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "markupsafe", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs-autorefs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pymdown-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/33/2fa3243439f794e685d3e694590d28469a9b8ea733af4b48c250a3ffc9a0/mkdocstrings-0.30.1.tar.gz", hash = "sha256:84a007aae9b707fb0aebfc9da23db4b26fc9ab562eb56e335e9ec480cb19744f", size = 106350, upload-time = "2025-09-19T10:49:26.446Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl", hash = "sha256:41bd71f284ca4d44a668816193e4025c950b002252081e387433656ae9a70a82", size = 36704, upload-time = "2025-09-19T10:49:24.805Z" },
-]
-
-[[package]]
-name = "mkdocstrings-python"
-version = "1.18.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griffe", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocs-autorefs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "mkdocstrings", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/ae/58ab2bfbee2792e92a98b97e872f7c003deb903071f75d8d83aa55db28fa/mkdocstrings_python-1.18.2.tar.gz", hash = "sha256:4ad536920a07b6336f50d4c6d5603316fafb1172c5c882370cbbc954770ad323", size = 207972, upload-time = "2025-08-28T16:11:19.847Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/8f/ce008599d9adebf33ed144e7736914385e8537f5fc686fdb7cceb8c22431/mkdocstrings_python-1.18.2-py3-none-any.whl", hash = "sha256:944fe6deb8f08f33fa936d538233c4036e9f53e840994f6146e8e94eb71b600d", size = 138215, upload-time = "2025-08-28T16:11:18.176Z" },
 ]
 
 [[package]]
@@ -1937,30 +1707,12 @@ wheels = [
 ]
 
 [[package]]
-name = "paginate"
-version = "0.5.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
-]
-
-[[package]]
 name = "parso"
 version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/de/53e0bcf53d13e005bd8c92e7855142494f41171b34c2536b86187474184d/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a", size = 401205, upload-time = "2025-08-23T15:15:28.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/32/f8e3c85d1d5250232a5d3477a2a28cc291968ff175caeadaf3cc19ce0e4a/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887", size = 106668, upload-time = "2025-08-23T15:15:25.663Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
@@ -2215,19 +1967,6 @@ crypto = [
 ]
 
 [[package]]
-name = "pymdown-extensions"
-version = "10.16.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/b3/6d2b3f149bc5413b0a29761c2c5832d8ce904a1d7f621e86616d96f505cc/pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91", size = 853277, upload-time = "2025-07-28T16:19:34.167Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/06/43084e6cbd4b3bc0e80f6be743b2e79fbc6eed8de9ad8c629939fa55d972/pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d", size = 266178, upload-time = "2025-07-28T16:19:31.401Z" },
-]
-
-[[package]]
 name = "pymongo"
 version = "4.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2345,18 +2084,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
     { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
     { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
-]
-
-[[package]]
-name = "pyyaml-env-tag"
-version = "1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -2662,18 +2389,6 @@ wheels = [
 ]
 
 [[package]]
-name = "super-collections"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hjson", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/2c/82f3db1c3a393edaf9e95c64e740bf10044f04d156c04466128f99e65c35/super_collections-0.6.0.tar.gz", hash = "sha256:6c537d9403e27c3626b992805ff2656ece43fc567725e7ccbb4291d6157db99f", size = 30650, upload-time = "2025-09-28T01:50:27.428Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/10/95a07cff55e901359dd049839a4253fca524005072da845aef04180c7492/super_collections-0.6.0-py3-none-any.whl", hash = "sha256:608e5cbf26467a501eac04e9617d3cb1a0729347a27531d38b497603aac51a73", size = 15842, upload-time = "2025-09-28T01:50:26.061Z" },
-]
-
-[[package]]
 name = "temporalio"
 version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2969,24 +2684,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/25/925f35db758a0f9199113aaf61d703de891676b082bd7cf73ea01d6000f7/vulture-2.14.tar.gz", hash = "sha256:cb8277902a1138deeab796ec5bef7076a6e0248ca3607a3f3dee0b6d9e9b8415", size = 58823, upload-time = "2024-12-08T17:39:43.319Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/56/0cc15b8ff2613c1d5c3dc1f3f576ede1c43868c1bc2e5ccaa2d4bcd7974d/vulture-2.14-py2.py3-none-any.whl", hash = "sha256:d9a90dba89607489548a49d557f8bac8112bd25d3cbc8aeef23e860811bd5ed9", size = 28915, upload-time = "2024-12-08T17:39:40.573Z" },
-]
-
-[[package]]
-name = "watchdog"
-version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
-    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
-    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Decouples the documentation build from the backend's workspace `uv.lock` so documenting a newly released SDK API surface no longer forces backend dependency bumps.

## Problem

The mkdocs site documents the published `agentex` SDK via mkdocstrings, which introspects the *installed* `agentex` package. The build installed it from the frozen workspace lock (`uv sync --group docs`), pinning the docs to whatever `agentex-sdk` the backend's lock resolved. Documenting a new path like `agentex.protocol.*` (released in `agentex-sdk` 0.11.5) therefore required bumping `agentex-sdk` in the lock — and because every protocol-supporting SDK floors `openai-agents>=0.14.3` (→ `websockets>=15`) and `temporalio>=1.26`, that cascaded backend-runtime bumps the docs don't need.

## Change

Docs deps now live in `agentex/docs/requirements.txt` and install into an ephemeral environment, independent of the workspace lock:

- **CI** (`ci.yml`, `build-agentex.yml`) and **Makefile** (`serve-docs`, `build-docs`): `uv run --isolated --no-project --with-requirements requirements.txt mkdocs build`
- **Dockerfile** `docs-builder` stage: `uv pip install --system -r docs/requirements.txt` (honors `UV_INDEX_URL` for private-index prod builds)

The workspace lock and backend dependency resolution are untouched — **zero `pyproject.toml` / `uv.lock` changes**. Docs always render against the latest published SDK.

## Verified

- Isolated `mkdocs build` green locally — griffe introspects an ephemeral uv env, not `.venv`.
- `make build-docs` green.

## Notes

- The `docs` dependency-group in `agentex/pyproject.toml` is now unused by the build (left in place; `install-docs` still references it). Removing it + relocking is a trivial follow-up.
- [#254](https://github.com/scaleapi/scale-agentex/pull/254) (canonical `agentex.protocol.acp` doc paths) stacks on this branch and goes green because the isolated build pulls `agentex-sdk>=0.12.0`.

🧑‍💻🤖 — posted via [Claude Code](https://claude.com/claude-code)
<!-- claude-code -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR decouples the MkDocs documentation build from the workspace `uv.lock` by introducing `agentex/docs/requirements.txt` and switching CI, the Makefile, and the Dockerfile `docs-builder` stage to install docs deps in an isolated ephemeral environment. Zero changes to `pyproject.toml` runtime deps or the workspace lock.

- **New `docs/requirements.txt`**: mkdocs toolchain packages are pinned to known-good versions for reproducibility; `agentex-sdk>=0.12.0` stays floating so the rendered docs automatically track new SDK releases without forcing backend dependency bumps.
- **CI & Makefile**: Both workflows and both Makefile targets (`build-docs`, `serve-docs`) now use `uv run --isolated --no-project --with-requirements requirements.txt mkdocs build/serve`.
- **Dockerfile `docs-builder` stage**: Drops the `uv export --frozen --group docs` path in favour of `uv pip install -r docs/requirements.txt`; the `docs` dependency group is removed from both `pyproject.toml` and the workspace lock.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is scoped entirely to the docs build pipeline and leaves the backend runtime deps untouched.

All CI, Makefile, and Dockerfile changes are straightforward substitutions of one install method for another. The workspace lock and backend pyproject.toml runtime dependencies are completely unchanged, so there is no risk to the running service. The only finding is a Docker layer-ordering nit in the docs-builder stage that affects build cache efficiency but not correctness.

The COPY order in the docs-builder stage of agentex/Dockerfile is worth a quick look for the caching optimization, but it does not affect build correctness.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-agentex.yml | Switched docs build from `uv sync --group docs` to `uv run --isolated --no-project --with-requirements requirements.txt mkdocs build`; one-line replacement, straightforward. |
| .github/workflows/ci.yml | Same isolated-env docs build switch as build-agentex.yml; no other changes. |
| agentex/Dockerfile | docs-builder stage now copies the full docs/ dir before running pip install, which breaks Docker layer caching whenever any doc file changes — every .md edit triggers a full dep reinstall. |
| agentex/Makefile | Removed `install-docs` target and updated `serve-docs`/`build-docs` to use isolated uv run; clean change. |
| agentex/docs/requirements.txt | New file with pinned mkdocs toolchain and floating agentex-sdk>=0.12.0; addresses prior review comment about reproducibility. |
| agentex/pyproject.toml | Removed the now-unused `docs` dependency group; clean-up. |
| pyproject.toml | Removed root-level `docs` group that forwarded to `agentex[docs]`; consistent with backend cleanup. |
| uv.lock | Removed all docs-only packages (mkdocs, mkdocs-material, mkdocstrings-python, griffe-pydantic, etc.) from the workspace lock; confirms zero backend-runtime deps were touched. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before
        A[uv sync --group docs] --> B[installs from workspace uv.lock]
        B --> C[mkdocs build]
        B --> D[forces agentex-sdk pin in lock]
    end

    subgraph After
        E[docs/requirements.txt] --> F{build context}
        F -->|CI / Makefile| G["uv run --isolated --no-project\n--with-requirements requirements.txt\nmkdocs build"]
        F -->|Dockerfile docs-builder| H["uv pip install --system\n-r docs/requirements.txt"]
        G --> I[mkdocs build]
        H --> I
        E --> J["agentex-sdk>=0.12.0 floats\ntoolchain pinned for reproducibility"]
    end

    D -. eliminated .-> E
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2FDockerfile%3A68-76%0ADocker%20layer%20caching%20is%20busted%20for%20every%20docs%20content%20change.%20Because%20%60COPY%20%24%7BSOURCE_DIR%7D%2Fdocs%2F%20docs%2F%60%20copies%20all%20Markdown%2C%20images%2C%20and%20config%20files%20before%20the%20%60uv%20pip%20install%60%20step%2C%20any%20edit%20to%20a%20%60.md%60%20file%20or%20%60mkdocs.yml%60%20invalidates%20the%20install%20layer%20and%20forces%20a%20full%20dependency%20reinstall%20on%20every%20docs%20build.%20Copying%20only%20%60requirements.txt%60%20first%20lets%20the%20install%20layer%20stay%20cached%20as%20long%20as%20the%20pins%20don't%20change.%0A%0A%60%60%60suggestion%0ACOPY%20%24%7BSOURCE_DIR%7D%2Fdocs%2Frequirements.txt%20docs%2Frequirements.txt%0A%23%20Docs%20build%20is%20decoupled%20from%20the%20workspace%20lock%3A%20install%20the%20toolchain%20%2B%20latest%0A%23%20SDK%20from%20docs%2Frequirements.txt%20so%20doc%20generation%20tracks%20SDK%20releases.%0ARUN%20if%20%5B%20-n%20%22%24%7BUV_INDEX_URL%7D%22%20%5D%3B%20then%20%5C%0A%20%20%20%20%20%20%20%20uv%20pip%20install%20--system%20--index-url%20%22%24%7BUV_INDEX_URL%7D%22%20-r%20docs%2Frequirements.txt%3B%20%5C%0A%20%20%20%20else%20%5C%0A%20%20%20%20%20%20%20%20uv%20pip%20install%20--system%20-r%20docs%2Frequirements.txt%3B%20%5C%0A%20%20%20%20fi%0ACOPY%20%24%7BSOURCE_DIR%7D%2Fdocs%2F%20docs%2F%0ACOPY%20%24%7BSOURCE_DIR%7D%2Fsrc%2F%20src%2F%0A%60%60%60%0A%0A&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2FDockerfile%3A68-76%0ADocker%20layer%20caching%20is%20busted%20for%20every%20docs%20content%20change.%20Because%20%60COPY%20%24%7BSOURCE_DIR%7D%2Fdocs%2F%20docs%2F%60%20copies%20all%20Markdown%2C%20images%2C%20and%20config%20files%20before%20the%20%60uv%20pip%20install%60%20step%2C%20any%20edit%20to%20a%20%60.md%60%20file%20or%20%60mkdocs.yml%60%20invalidates%20the%20install%20layer%20and%20forces%20a%20full%20dependency%20reinstall%20on%20every%20docs%20build.%20Copying%20only%20%60requirements.txt%60%20first%20lets%20the%20install%20layer%20stay%20cached%20as%20long%20as%20the%20pins%20don't%20change.%0A%0A%60%60%60suggestion%0ACOPY%20%24%7BSOURCE_DIR%7D%2Fdocs%2Frequirements.txt%20docs%2Frequirements.txt%0A%23%20Docs%20build%20is%20decoupled%20from%20the%20workspace%20lock%3A%20install%20the%20toolchain%20%2B%20latest%0A%23%20SDK%20from%20docs%2Frequirements.txt%20so%20doc%20generation%20tracks%20SDK%20releases.%0ARUN%20if%20%5B%20-n%20%22%24%7BUV_INDEX_URL%7D%22%20%5D%3B%20then%20%5C%0A%20%20%20%20%20%20%20%20uv%20pip%20install%20--system%20--index-url%20%22%24%7BUV_INDEX_URL%7D%22%20-r%20docs%2Frequirements.txt%3B%20%5C%0A%20%20%20%20else%20%5C%0A%20%20%20%20%20%20%20%20uv%20pip%20install%20--system%20-r%20docs%2Frequirements.txt%3B%20%5C%0A%20%20%20%20fi%0ACOPY%20%24%7BSOURCE_DIR%7D%2Fdocs%2F%20docs%2F%0ACOPY%20%24%7BSOURCE_DIR%7D%2Fsrc%2F%20src%2F%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22maxparke%2Fagx1-292-docs-build-isolation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22maxparke%2Fagx1-292-docs-build-isolation%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2FDockerfile%3A68-76%0ADocker%20layer%20caching%20is%20busted%20for%20every%20docs%20content%20change.%20Because%20%60COPY%20%24%7BSOURCE_DIR%7D%2Fdocs%2F%20docs%2F%60%20copies%20all%20Markdown%2C%20images%2C%20and%20config%20files%20before%20the%20%60uv%20pip%20install%60%20step%2C%20any%20edit%20to%20a%20%60.md%60%20file%20or%20%60mkdocs.yml%60%20invalidates%20the%20install%20layer%20and%20forces%20a%20full%20dependency%20reinstall%20on%20every%20docs%20build.%20Copying%20only%20%60requirements.txt%60%20first%20lets%20the%20install%20layer%20stay%20cached%20as%20long%20as%20the%20pins%20don't%20change.%0A%0A%60%60%60suggestion%0ACOPY%20%24%7BSOURCE_DIR%7D%2Fdocs%2Frequirements.txt%20docs%2Frequirements.txt%0A%23%20Docs%20build%20is%20decoupled%20from%20the%20workspace%20lock%3A%20install%20the%20toolchain%20%2B%20latest%0A%23%20SDK%20from%20docs%2Frequirements.txt%20so%20doc%20generation%20tracks%20SDK%20releases.%0ARUN%20if%20%5B%20-n%20%22%24%7BUV_INDEX_URL%7D%22%20%5D%3B%20then%20%5C%0A%20%20%20%20%20%20%20%20uv%20pip%20install%20--system%20--index-url%20%22%24%7BUV_INDEX_URL%7D%22%20-r%20docs%2Frequirements.txt%3B%20%5C%0A%20%20%20%20else%20%5C%0A%20%20%20%20%20%20%20%20uv%20pip%20install%20--system%20-r%20docs%2Frequirements.txt%3B%20%5C%0A%20%20%20%20fi%0ACOPY%20%24%7BSOURCE_DIR%7D%2Fdocs%2F%20docs%2F%0ACOPY%20%24%7BSOURCE_DIR%7D%2Fsrc%2F%20src%2F%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex/Dockerfile:68-76
Docker layer caching is busted for every docs content change. Because `COPY ${SOURCE_DIR}/docs/ docs/` copies all Markdown, images, and config files before the `uv pip install` step, any edit to a `.md` file or `mkdocs.yml` invalidates the install layer and forces a full dependency reinstall on every docs build. Copying only `requirements.txt` first lets the install layer stay cached as long as the pins don't change.

```suggestion
COPY ${SOURCE_DIR}/docs/requirements.txt docs/requirements.txt
# Docs build is decoupled from the workspace lock: install the toolchain + latest
# SDK from docs/requirements.txt so doc generation tracks SDK releases.
RUN if [ -n "${UV_INDEX_URL}" ]; then \
        uv pip install --system --index-url "${UV_INDEX_URL}" -r docs/requirements.txt; \
    else \
        uv pip install --system -r docs/requirements.txt; \
    fi
COPY ${SOURCE_DIR}/docs/ docs/
COPY ${SOURCE_DIR}/src/ src/
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into maxparke/agx1-2..."](https://github.com/scaleapi/scale-agentex/commit/07e3759076e1364ca33372a580215d130ab94b77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36304983)</sub>

<!-- /greptile_comment -->