### PR TITLE
fix(otel): Enable Custom OTel metrics to coexist with auto-instrumentation

### DIFF
--- a/agentex/src/utils/otel_metrics.py
+++ b/agentex/src/utils/otel_metrics.py
@@ -1,12 +1,17 @@
 """
 OpenTelemetry metrics configuration for Agentex.
 
-This module sets up the OTel MeterProvider with OTLP export for metrics.
-Metrics are exported to an OTLP-compatible endpoint (e.g., OTel Collector,
-Datadog Agent, or directly to Grafana Cloud/Mimir).
+When auto-instrumentation (e.g. OTel Operator) has already installed a global
+MeterProvider, custom app metrics attach to it instead of replacing it.
+Otherwise this module creates its own provider with OTLP export when an endpoint
+is configured.
 
 Environment Variables:
-    OTEL_EXPORTER_OTLP_ENDPOINT: OTLP endpoint URL (default: http://localhost:4317)
+    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: Metrics OTLP endpoint (falls back to
+        OTEL_EXPORTER_OTLP_ENDPOINT)
+    OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: Metrics export protocol (falls back to
+        OTEL_EXPORTER_OTLP_PROTOCOL; default: grpc)
+    OTEL_EXPORTER_OTLP_ENDPOINT: General OTLP endpoint URL
     OTEL_EXPORTER_OTLP_HEADERS: Optional headers for authentication
     OTEL_SERVICE_NAME: Service name for metrics (default: agentex)
     OTEL_METRICS_EXPORT_INTERVAL_MS: Export interval in ms (default: 30000)
@@ -18,7 +23,12 @@ import os
 from typing import TYPE_CHECKING
 
 from opentelemetry import metrics
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+    OTLPMetricExporter as OTLPGrpcMetricExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter as OTLPHttpMetricExporter,
+)
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
@@ -27,17 +37,51 @@ from src.utils.logging import make_logger
 
 if TYPE_CHECKING:
     from opentelemetry.metrics import Meter
+    from opentelemetry.sdk.metrics.export import MetricExporter
 
 logger = make_logger(__name__)
 
 # Global state
-_meter_provider: MeterProvider | None = None
+_meter_provider: MeterProvider | None = None # Set only when this module creates the provider
 _initialized: bool = False
 
-# Default configuration
-DEFAULT_OTLP_ENDPOINT = "http://localhost:4317"
-DEFAULT_SERVICE_NAME = "agentex"
-DEFAULT_EXPORT_INTERVAL_MS = 30000  # 30 seconds
+
+def _global_meter_provider() -> MeterProvider | None:
+    """Return the global MeterProvider if installed, else None (proxy is ignored)."""
+    provider = metrics.get_meter_provider()
+    return provider if isinstance(provider, MeterProvider) else None
+
+
+def _metrics_endpoint(explicit: str | None = None) -> str | None:
+    if explicit:
+        return explicit
+    return os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT") or os.environ.get(
+        "OTEL_EXPORTER_OTLP_ENDPOINT"
+    )
+
+
+def _metrics_protocol() -> str:
+    return (
+        (
+            os.environ.get("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL")
+            or os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+        )
+        .strip()
+        .lower()
+    )
+
+
+def _create_metric_exporter(endpoint: str, protocol: str) -> MetricExporter:
+    if protocol in {"http/protobuf", "http"}:
+        return OTLPHttpMetricExporter(endpoint=endpoint)
+
+    if protocol != "grpc":
+        logger.warning("Unknown OTEL metrics protocol %r; using grpc", protocol)
+
+    return OTLPGrpcMetricExporter(
+        endpoint=endpoint,
+        insecure=endpoint.startswith("http://"),
+    )
 
 
 def init_otel_metrics(
@@ -48,83 +92,70 @@ def init_otel_metrics(
     export_interval_ms: int | None = None,
 ) -> MeterProvider | None:
     """
-    Initialize OpenTelemetry metrics with OTLP exporter.
+    Initialize OpenTelemetry metrics for custom app instruments.
 
-    This should be called once at application startup. Subsequent calls
-    will return the existing MeterProvider.
+    Call once at application startup. Subsequent calls return the active provider
+    without re-initializing.
 
-    NOTE: Only initializes if OTEL_EXPORTER_OTLP_ENDPOINT is configured.
-    Returns None if OTel is not configured.
+    If auto-instrumentation already installed a MeterProvider, custom metrics
+    attach to it. Otherwise, initializes only when an OTLP endpoint is configured.
 
     Args:
         service_name: Service name for resource attributes
         service_version: Service version for resource attributes
         environment: Deployment environment (e.g., "development", "production")
-        otlp_endpoint: OTLP gRPC endpoint URL
+        otlp_endpoint: OTLP endpoint URL
         export_interval_ms: Metric export interval in milliseconds
 
     Returns:
-        The configured MeterProvider, or None if not configured
+        The active MeterProvider, or None when metrics are disabled
     """
     global _meter_provider, _initialized
 
     if _initialized:
-        return _meter_provider
-
-    # Check if OTLP endpoint is configured
-    otlp_endpoint = otlp_endpoint or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
-    if not otlp_endpoint:
-        logger.info(
-            "OpenTelemetry metrics disabled: OTEL_EXPORTER_OTLP_ENDPOINT not configured"
-        )
-        _initialized = True
-        return None
-
-    # Resolve configuration from environment or defaults
-    service_name = (
-        service_name or os.environ.get("OTEL_SERVICE_NAME") or DEFAULT_SERVICE_NAME
-    )
-    service_version = service_version or os.environ.get("SERVICE_VERSION", "0.1.0")
-    environment = environment or os.environ.get("ENVIRONMENT", "development")
-    export_interval_ms = export_interval_ms or int(
-        os.environ.get("OTEL_METRICS_EXPORT_INTERVAL_MS", DEFAULT_EXPORT_INTERVAL_MS)
-    )
-
-    # Create resource with service information
-    resource = Resource.create(
-        {
-            SERVICE_NAME: service_name,
-            SERVICE_VERSION: service_version,
-            "deployment.environment": environment,
-        }
-    )
-
-    # Create OTLP exporter
-    # The exporter will use OTEL_EXPORTER_OTLP_HEADERS env var for auth if set
-    exporter = OTLPMetricExporter(
-        endpoint=otlp_endpoint,
-        insecure=otlp_endpoint.startswith("http://"),  # Use insecure for non-TLS
-    )
-
-    # Create periodic reader that exports at the specified interval
-    reader = PeriodicExportingMetricReader(
-        exporter=exporter,
-        export_interval_millis=export_interval_ms,
-    )
-
-    # Create and set the meter provider
-    _meter_provider = MeterProvider(
-        resource=resource,
-        metric_readers=[reader],
-    )
-    metrics.set_meter_provider(_meter_provider)
+        return _meter_provider or _global_meter_provider()
 
     _initialized = True
-    logger.info(
-        f"OpenTelemetry metrics initialized: endpoint={otlp_endpoint}, "
-        f"service={service_name}, interval={export_interval_ms}ms"
+
+    if existing := _global_meter_provider():
+        logger.info("OpenTelemetry metrics using existing MeterProvider")
+        return existing
+
+    endpoint = _metrics_endpoint(otlp_endpoint)
+    if not endpoint:
+        logger.info("OpenTelemetry metrics disabled: no OTLP endpoint configured")
+        return None
+
+    protocol = _metrics_protocol()
+    resolved_service_name = service_name or os.environ.get(
+        "OTEL_SERVICE_NAME", "agentex"
+    )
+    resolved_export_interval_ms = (
+        export_interval_ms
+        if export_interval_ms is not None
+        else int(os.environ.get("OTEL_METRICS_EXPORT_INTERVAL_MS", 30000))
+    )
+    resource = Resource.create(
+        {
+            SERVICE_NAME: resolved_service_name,
+            SERVICE_VERSION: service_version
+            or os.environ.get("SERVICE_VERSION", "0.1.0"),
+            "deployment.environment": environment
+            or os.environ.get("ENVIRONMENT", "development"),
+        }
+    )
+    reader = PeriodicExportingMetricReader(
+        exporter=_create_metric_exporter(endpoint, protocol),
+        export_interval_millis=resolved_export_interval_ms,
     )
 
+    _meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(_meter_provider)
+    logger.info(
+        f"OpenTelemetry metrics initialized: endpoint={endpoint}, "
+        f"protocol={protocol}, service={resolved_service_name}, "
+        f"interval={resolved_export_interval_ms}ms"
+    )
     return _meter_provider
 
 
@@ -139,16 +170,10 @@ def get_meter(name: str, version: str = "0.1.0") -> Meter | None:
     Returns:
         An OpenTelemetry Meter instance, or None if OTel is not configured
     """
-    global _initialized, _meter_provider
-
     if not _initialized:
-        # Auto-initialize with defaults if not already initialized
         init_otel_metrics()
-
-    # Return None if OTel is not configured
-    if _meter_provider is None:
+    if _meter_provider is None and _global_meter_provider() is None:
         return None
-
     return metrics.get_meter(name, version)
 
 
@@ -156,17 +181,20 @@ def shutdown_otel_metrics() -> None:
     """
     Shutdown the meter provider, flushing any remaining metrics.
 
-    Should be called during application shutdown.
+    Should be called during application shutdown. Only shuts down a provider
+    this module created; a provider installed by auto-instrumentation is left
+    running.
     """
     global _meter_provider, _initialized
 
     if _meter_provider is not None:
         _meter_provider.shutdown()
         logger.info("OpenTelemetry metrics shut down")
-        _meter_provider = None
-        _initialized = False
+
+    _meter_provider = None
+    _initialized = False
 
 
 def is_otel_configured() -> bool:
-    """Check if an OTLP endpoint is configured via environment."""
-    return bool(os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"))
+    """Check if metrics export is configured via environment."""
+    return bool(_metrics_endpoint())

--- a/agentex/src/utils/otel_metrics.py
+++ b/agentex/src/utils/otel_metrics.py
@@ -159,7 +159,11 @@ def init_otel_metrics(
     )
 
     provider = MeterProvider(resource=resource, metric_readers=[reader])
-    metrics.set_meter_provider(provider)
+    try:
+        metrics.set_meter_provider(provider)
+    except Exception:
+        provider.shutdown()
+        raise
     _meter_provider = provider
     _initialized = True
     logger.info(

--- a/agentex/src/utils/otel_metrics.py
+++ b/agentex/src/utils/otel_metrics.py
@@ -119,14 +119,14 @@ def init_otel_metrics(
     if _initialized:
         return _meter_provider or _global_meter_provider()
 
-    _initialized = True
-
     if existing := _global_meter_provider():
+        _initialized = True
         logger.info("OpenTelemetry metrics using existing MeterProvider")
         return existing
 
     endpoint = _metrics_endpoint(otlp_endpoint)
     if not endpoint:
+        _initialized = True
         logger.info("OpenTelemetry metrics disabled: no OTLP endpoint configured")
         return None
 
@@ -159,6 +159,7 @@ def init_otel_metrics(
 
     _meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
     metrics.set_meter_provider(_meter_provider)
+    _initialized = True
     logger.info(
         f"OpenTelemetry metrics initialized: endpoint={endpoint}, "
         f"protocol={protocol}, service={resolved_service_name}, "

--- a/agentex/src/utils/otel_metrics.py
+++ b/agentex/src/utils/otel_metrics.py
@@ -23,6 +23,7 @@ import os
 from typing import TYPE_CHECKING
 
 from opentelemetry import metrics
+from opentelemetry.metrics import NoOpMeterProvider
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
     OTLPMetricExporter as OTLPGrpcMetricExporter,
 )
@@ -199,6 +200,7 @@ def shutdown_otel_metrics() -> None:
 
     if _meter_provider is not None:
         _meter_provider.shutdown()
+        metrics.set_meter_provider(NoOpMeterProvider())
         logger.info("OpenTelemetry metrics shut down")
 
     _meter_provider = None

--- a/agentex/src/utils/otel_metrics.py
+++ b/agentex/src/utils/otel_metrics.py
@@ -157,8 +157,9 @@ def init_otel_metrics(
         export_interval_millis=resolved_export_interval_ms,
     )
 
-    _meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
-    metrics.set_meter_provider(_meter_provider)
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+    _meter_provider = provider
     _initialized = True
     logger.info(
         f"OpenTelemetry metrics initialized: endpoint={endpoint}, "

--- a/agentex/src/utils/otel_metrics.py
+++ b/agentex/src/utils/otel_metrics.py
@@ -45,6 +45,10 @@ logger = make_logger(__name__)
 _meter_provider: MeterProvider | None = None # Set only when this module creates the provider
 _initialized: bool = False
 
+# Default configuration
+DEFAULT_SERVICE_NAME = "agentex"
+DEFAULT_EXPORT_INTERVAL_MS = 30000  # 30 seconds
+
 
 def _global_meter_provider() -> MeterProvider | None:
     """Return the global MeterProvider if installed, else None (proxy is ignored)."""
@@ -128,12 +132,16 @@ def init_otel_metrics(
 
     protocol = _metrics_protocol()
     resolved_service_name = service_name or os.environ.get(
-        "OTEL_SERVICE_NAME", "agentex"
+        "OTEL_SERVICE_NAME", DEFAULT_SERVICE_NAME
     )
     resolved_export_interval_ms = (
         export_interval_ms
         if export_interval_ms is not None
-        else int(os.environ.get("OTEL_METRICS_EXPORT_INTERVAL_MS", 30000))
+        else int(
+            os.environ.get(
+                "OTEL_METRICS_EXPORT_INTERVAL_MS", DEFAULT_EXPORT_INTERVAL_MS
+            )
+        )
     )
     resource = Resource.create(
         {

--- a/agentex/src/utils/otel_metrics.py
+++ b/agentex/src/utils/otel_metrics.py
@@ -198,13 +198,20 @@ def shutdown_otel_metrics() -> None:
     """
     global _meter_provider, _initialized
 
-    if _meter_provider is not None:
-        _meter_provider.shutdown()
-        metrics.set_meter_provider(NoOpMeterProvider())
-        logger.info("OpenTelemetry metrics shut down")
-
-    _meter_provider = None
-    _initialized = False
+    try:
+        if _meter_provider is not None:
+            _meter_provider.shutdown()
+            logger.info("OpenTelemetry metrics shut down")
+    except Exception:
+        logger.exception("OpenTelemetry metrics shutdown failed")
+    finally:
+        if _meter_provider is not None:
+            try:
+                metrics.set_meter_provider(NoOpMeterProvider())
+            except Exception:
+                logger.exception("Failed to reset global MeterProvider after shutdown")
+        _meter_provider = None
+        _initialized = False
 
 
 def is_otel_configured() -> bool:

--- a/agentex/tests/unit/utils/test_otel_metrics.py
+++ b/agentex/tests/unit/utils/test_otel_metrics.py
@@ -17,23 +17,36 @@ from opentelemetry.sdk.resources import Resource
 from src.utils import otel_metrics
 
 
+def _set_global_meter_provider(provider: object | None = None) -> None:
+    """Test-only access to the global MeterProvider slot.
+
+    Skips with a clear message if OTel SDK internals move. Pass ``None`` to
+    install the no-op proxy (unset state).
+    """
+    try:
+        if provider is None:
+            provider = metrics._internal._ProxyMeterProvider()
+        metrics._internal._METER_PROVIDER = provider
+    except AttributeError as exc:
+        pytest.skip(f"OpenTelemetry SDK internals changed: {exc}")
+
+
 @pytest.fixture(autouse=True)
 def reset_otel_metrics_state():
     """Reset module and global OTel state between tests."""
     saved_provider = metrics.get_meter_provider()
     otel_metrics.shutdown_otel_metrics()
-    metrics._internal._METER_PROVIDER = metrics._internal._ProxyMeterProvider()
+    _set_global_meter_provider()
 
     yield
 
     otel_metrics.shutdown_otel_metrics()
-    metrics._internal._METER_PROVIDER = saved_provider
+    _set_global_meter_provider(saved_provider)
 
 
 def _set_operator_provider() -> MeterProvider:
-    """Install a stand-in operator provider, bypassing ddtrace's set-once guard."""
     provider = MeterProvider(resource=Resource.create({}))
-    metrics._internal._METER_PROVIDER = provider
+    _set_global_meter_provider(provider)
     return provider
 
 
@@ -92,7 +105,6 @@ def test_init_creates_meter_provider_when_none_configured(monkeypatch):
     assert isinstance(result, MeterProvider)
     assert otel_metrics._meter_provider is result
     assert otel_metrics._initialized is True
-    assert metrics.get_meter_provider() is result
     assert otel_metrics.get_meter("agentex.test") is not None
 
 

--- a/agentex/tests/unit/utils/test_otel_metrics.py
+++ b/agentex/tests/unit/utils/test_otel_metrics.py
@@ -80,10 +80,10 @@ def test_init_does_not_shutdown_operator_provider():
 
     otel_metrics.shutdown_otel_metrics()
 
-    assert not operator_provider._shutdown
     assert metrics.get_meter_provider() is operator_provider
     assert otel_metrics._initialized is False
     assert otel_metrics._meter_provider is None
+    assert otel_metrics.get_meter("agentex.test") is not None
 
 
 @pytest.mark.unit
@@ -181,6 +181,20 @@ def test_metrics_endpoint_takes_precedence_over_general_endpoint(monkeypatch):
         otel_metrics.init_otel_metrics()
 
     mock_create.assert_called_once_with("http://metrics:4318", "grpc")
+
+
+@pytest.mark.unit
+def test_init_after_shutdown_in_standalone_mode(monkeypatch):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    first = otel_metrics.init_otel_metrics()
+    assert first is not None
+    otel_metrics.shutdown_otel_metrics()
+
+    second = otel_metrics.init_otel_metrics()
+    assert second is not None
+    assert second is not first
+    assert otel_metrics.get_meter("agentex.test") is not None
 
 
 @pytest.mark.unit

--- a/agentex/tests/unit/utils/test_otel_metrics.py
+++ b/agentex/tests/unit/utils/test_otel_metrics.py
@@ -1,0 +1,166 @@
+"""Unit tests for OpenTelemetry metrics initialization and coexistence."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from opentelemetry import metrics
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+    OTLPMetricExporter as OTLPGrpcMetricExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter as OTLPHttpMetricExporter,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.resources import Resource
+from src.utils import otel_metrics
+
+
+@pytest.fixture(autouse=True)
+def reset_otel_metrics_state():
+    """Reset module and global OTel state between tests."""
+    saved_provider = metrics.get_meter_provider()
+    otel_metrics.shutdown_otel_metrics()
+    metrics._internal._METER_PROVIDER = metrics._internal._ProxyMeterProvider()
+
+    yield
+
+    otel_metrics.shutdown_otel_metrics()
+    metrics._internal._METER_PROVIDER = saved_provider
+
+
+def _set_operator_provider() -> MeterProvider:
+    """Install a stand-in operator provider, bypassing ddtrace's set-once guard."""
+    provider = MeterProvider(resource=Resource.create({}))
+    metrics._internal._METER_PROVIDER = provider
+    return provider
+
+
+@pytest.mark.unit
+def test_init_coexists_with_existing_meter_provider():
+    operator_provider = _set_operator_provider()
+
+    result = otel_metrics.init_otel_metrics()
+
+    assert result is operator_provider
+    assert metrics.get_meter_provider() is operator_provider
+    assert otel_metrics._initialized is True
+    assert otel_metrics._meter_provider is None
+
+    meter = otel_metrics.get_meter("agentex.test")
+    assert meter is not None
+
+
+@pytest.mark.unit
+def test_init_is_idempotent_in_shared_mode():
+    operator_provider = _set_operator_provider()
+
+    assert otel_metrics.init_otel_metrics() is operator_provider
+    assert otel_metrics.init_otel_metrics() is operator_provider
+
+
+@pytest.mark.unit
+def test_init_does_not_shutdown_operator_provider():
+    operator_provider = _set_operator_provider()
+    otel_metrics.init_otel_metrics()
+
+    otel_metrics.shutdown_otel_metrics()
+
+    assert not operator_provider._shutdown
+    assert metrics.get_meter_provider() is operator_provider
+    assert otel_metrics._initialized is False
+    assert otel_metrics._meter_provider is None
+
+
+@pytest.mark.unit
+def test_init_after_shutdown_in_shared_mode():
+    operator_provider = _set_operator_provider()
+
+    otel_metrics.init_otel_metrics()
+    otel_metrics.shutdown_otel_metrics()
+
+    assert otel_metrics.init_otel_metrics() is operator_provider
+
+
+@pytest.mark.unit
+def test_init_creates_meter_provider_when_none_configured(monkeypatch):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    result = otel_metrics.init_otel_metrics()
+
+    assert isinstance(result, MeterProvider)
+    assert otel_metrics._meter_provider is result
+    assert otel_metrics._initialized is True
+    assert metrics.get_meter_provider() is result
+    assert otel_metrics.get_meter("agentex.test") is not None
+
+
+@pytest.mark.unit
+def test_init_disabled_without_endpoint(monkeypatch):
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+
+    result = otel_metrics.init_otel_metrics()
+
+    assert result is None
+    assert otel_metrics.get_meter("agentex.test") is None
+
+
+@pytest.mark.unit
+def test_shutdown_resets_state_when_disabled(monkeypatch):
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+
+    otel_metrics.init_otel_metrics()
+    otel_metrics.shutdown_otel_metrics()
+
+    assert otel_metrics._initialized is False
+    assert otel_metrics._meter_provider is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("protocol_env", "expected_exporter"),
+    [
+        ("grpc", OTLPGrpcMetricExporter),
+        ("http/protobuf", OTLPHttpMetricExporter),
+    ],
+)
+def test_protocol_selection_from_env(
+    monkeypatch, protocol_env: str, expected_exporter: type
+):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", protocol_env)
+
+    with patch.object(otel_metrics, "_create_metric_exporter") as mock_create:
+        mock_create.return_value = expected_exporter(endpoint="http://localhost:4318")
+        otel_metrics.init_otel_metrics()
+
+    mock_create.assert_called_once_with("http://localhost:4318", protocol_env)
+
+
+@pytest.mark.unit
+def test_metrics_endpoint_takes_precedence_over_general_endpoint(monkeypatch):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://general:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics:4318")
+
+    with patch.object(otel_metrics, "_create_metric_exporter") as mock_create:
+        mock_create.return_value = OTLPGrpcMetricExporter(
+            endpoint="http://metrics:4318"
+        )
+        otel_metrics.init_otel_metrics()
+
+    mock_create.assert_called_once_with("http://metrics:4318", "grpc")
+
+
+@pytest.mark.unit
+def test_shutdown_only_own_provider(monkeypatch):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    provider = otel_metrics.init_otel_metrics()
+    assert provider is not None
+
+    otel_metrics.shutdown_otel_metrics()
+
+    assert otel_metrics._initialized is False
+    assert otel_metrics._meter_provider is None

--- a/agentex/tests/unit/utils/test_otel_metrics.py
+++ b/agentex/tests/unit/utils/test_otel_metrics.py
@@ -109,6 +109,23 @@ def test_init_creates_meter_provider_when_none_configured(monkeypatch):
 
 
 @pytest.mark.unit
+def test_init_retries_after_provider_creation_failure(monkeypatch):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    with patch.object(
+        metrics, "set_meter_provider", side_effect=RuntimeError("blocked")
+    ):
+        with pytest.raises(RuntimeError):
+            otel_metrics.init_otel_metrics()
+        assert otel_metrics._initialized is False
+
+    result = otel_metrics.init_otel_metrics()
+
+    assert isinstance(result, MeterProvider)
+    assert otel_metrics._initialized is True
+
+
+@pytest.mark.unit
 def test_init_disabled_without_endpoint(monkeypatch):
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)

--- a/agentex/tests/unit/utils/test_otel_metrics.py
+++ b/agentex/tests/unit/utils/test_otel_metrics.py
@@ -114,12 +114,16 @@ def test_init_creates_meter_provider_when_none_configured(monkeypatch):
 def test_init_retries_after_provider_creation_failure(monkeypatch):
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 
-    with patch.object(
-        metrics, "set_meter_provider", side_effect=RuntimeError("blocked")
+    with (
+        patch.object(
+            metrics, "set_meter_provider", side_effect=RuntimeError("blocked")
+        ),
+        patch.object(MeterProvider, "shutdown") as mock_shutdown,
     ):
         with pytest.raises(RuntimeError):
             otel_metrics.init_otel_metrics()
         assert otel_metrics._initialized is False
+        mock_shutdown.assert_called_once()
 
     result = otel_metrics.init_otel_metrics()
 

--- a/agentex/tests/unit/utils/test_otel_metrics.py
+++ b/agentex/tests/unit/utils/test_otel_metrics.py
@@ -13,8 +13,10 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
     OTLPMetricExporter as OTLPHttpMetricExporter,
 )
 from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.resources import Resource
 from src.utils import otel_metrics
+from src.utils import cache_metrics
 
 
 def _set_global_meter_provider(provider: object | None = None) -> None:
@@ -184,6 +186,49 @@ def test_metrics_endpoint_takes_precedence_over_general_endpoint(monkeypatch):
 
 
 @pytest.mark.unit
+def test_custom_metrics_preserve_instrument_attributes_in_shared_mode():
+    """Instrument names and point attributes must not change when attaching to operator provider."""
+    cache_metrics._instruments_initialized = False
+    cache_metrics._access_counter = None
+    cache_metrics._eviction_counter = None
+
+    reader = InMemoryMetricReader()
+    operator_provider = MeterProvider(
+        resource=Resource.create({"service.name": "operator-svc"}),
+        metric_readers=[reader],
+    )
+    _set_global_meter_provider(operator_provider)
+
+    otel_metrics.init_otel_metrics()
+    cache_metrics.record_cache_access("auth_gateway", "hit")
+    cache_metrics.record_cache_eviction("agent_api_key")
+
+    data = reader.get_metrics_data()
+    assert data is not None
+    points = [
+        (
+            metric.name,
+            scope.scope.name,
+            dict(data_point.attributes),
+        )
+        for resource_metrics in data.resource_metrics
+        for scope in resource_metrics.scope_metrics
+        for metric in scope.metrics
+        for data_point in metric.data.data_points
+    ]
+    assert (
+        "auth_cache.access",
+        "agentex.auth_cache",
+        {"cache": "auth_gateway", "result": "hit"},
+    ) in points
+    assert (
+        "auth_cache.eviction",
+        "agentex.auth_cache",
+        {"cache": "agent_api_key"},
+    ) in points
+
+
+@pytest.mark.unit
 def test_init_after_shutdown_in_standalone_mode(monkeypatch):
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 
@@ -195,6 +240,20 @@ def test_init_after_shutdown_in_standalone_mode(monkeypatch):
     assert second is not None
     assert second is not first
     assert otel_metrics.get_meter("agentex.test") is not None
+
+
+@pytest.mark.unit
+def test_shutdown_resets_state_when_provider_shutdown_raises(monkeypatch):
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    provider = otel_metrics.init_otel_metrics()
+    assert provider is not None
+
+    with patch.object(provider, "shutdown", side_effect=RuntimeError("export failed")):
+        otel_metrics.shutdown_otel_metrics()
+
+    assert otel_metrics._initialized is False
+    assert otel_metrics._meter_provider is None
+    assert otel_metrics.init_otel_metrics() is not None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Fixes custom app metrics (`auth_cache.*`, `db.client.*`) coexisting with OTel Operator Python auto-instrumentation instead of replacing its global `MeterProvider`.
- When a real SDK `MeterProvider` is already installed (operator), `init_otel_metrics()` attaches custom instruments to it and does not call `set_meter_provider()` or shut it down on exit.
- In standalone mode (local dev, no operator), the module still creates its own provider when an OTLP endpoint is configured, with protocol-aware export (`grpc` vs `http/protobuf`) via `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` / `OTEL_EXPORTER_OTLP_PROTOCOL`.
- Relates to: https://linear.app/scale-epd/issue/SGPINF-1718/execute-rocket-load-test-and-generate-report-for-10x-traffic
## Problem

The previous implementation always called `metrics.set_meter_provider()` with a gRPC exporter, which replaced the operator's HTTP/protobuf provider and dropped auto-instrumentation HTTP metrics (`http_server_request_duration_seconds`, etc.). `get_meter()` also returned `None` under operator injection because it only checked a module-local provider.

## Solution

- Detect an existing real `MeterProvider` via `_global_meter_provider()` and use it in shared mode.
- Track `_meter_provider` only when this module creates the provider (for shutdown).
- `get_meter()` works when either we created a provider or a global one is already installed.
- `shutdown_otel_metrics()` only shuts down a provider this module created.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the conflict between custom app metrics (`auth_cache.*`, `db.client.*`) and the OTel Operator's Python auto-instrumentation by detecting an already-installed SDK `MeterProvider` and attaching to it rather than replacing it. In standalone mode the module still creates its own provider with protocol-aware export (`grpc` or `http/protobuf`), now with proper exception handling that prevents `PeriodicExportingMetricReader` thread leaks and ensures a `NoOpMeterProvider` is installed on shutdown to prevent a stale dead provider from being mistaken for a live operator provider on re-init.

- **Shared mode**: `_global_meter_provider()` detects the operator's provider; `init_otel_metrics()` attaches to it with no `set_meter_provider()` call, and `shutdown_otel_metrics()` leaves it running.
- **Standalone mode**: `set_meter_provider()` is wrapped in `try/except` that shuts down the newly-created provider on failure, and the `finally` block installs `NoOpMeterProvider()` to clear the global slot so re-init works correctly.
- **Tests**: 11 new unit tests cover both modes, protocol selection, failure/retry paths, and cache-instrument attribute preservation, with private-SDK state injection wrapped in `pytest.skip` on `AttributeError`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the coexistence logic is correct, previously identified flag-ordering and thread-leak bugs are fixed, and the shutdown path now clears the global OTel slot to prevent stale-provider misdetection on re-init.

The state-machine transitions across shared/standalone/disabled modes are all covered by tests, the try/finally exception handling in both init_otel_metrics and shutdown_otel_metrics is correct, and the invariant that _meter_provider is only set when this module owns the global slot is maintained throughout.

No files require special attention. The one test isolation gap (cache_metrics state not restored in teardown) is latent and has no impact on the current test suite.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/utils/otel_metrics.py | Core fix: detects existing SDK MeterProvider via _global_meter_provider(), attaches in shared mode without calling set_meter_provider(), adds try/except around set_meter_provider() to shut down leaked PeriodicExportingMetricReader threads, and installs NoOpMeterProvider in finally-block to clear the global slot on standalone shutdown. Previously flagged ordering bugs are corrected. |
| agentex/tests/unit/utils/test_otel_metrics.py | New test file with 11 unit tests covering shared mode coexistence, standalone mode lifecycle, protocol selection, retry-after-failure, and cache instrument attribute preservation. The test_custom_metrics_preserve_instrument_attributes_in_shared_mode test mutates cache_metrics module state at setup but has no corresponding teardown, leaving _instruments_initialized=True and counters bound to the test provider after the test completes. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Ftests%2Funit%2Futils%2Ftest_otel_metrics.py%3A192-197%0AThe%20test%20resets%20%60cache_metrics%60%20module%20state%20before%20the%20test%20body%20but%20leaves%20%60_instruments_initialized%3DTrue%60%20and%20the%20counters%20bound%20to%20the%20test-local%20%60operator_provider%60%20after%20the%20test%20completes.%20The%20autouse%20fixture%20restores%20the%20OTel%20global%20slot%20but%20does%20not%20touch%20%60cache_metrics%60.%20Any%20future%20test%20that%20calls%20%60record_cache_access%60%2F%60record_cache_eviction%60%20after%20this%20test%20will%20find%20%60_instruments_initialized%3DTrue%60%2C%20skip%20re-initialization%2C%20and%20silently%20emit%20to%20the%20stale%20instruments.%20Restoring%20the%20three%20fields%20in%20teardown%20keeps%20isolation%20complete.%0A%0A&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Ftests%2Funit%2Futils%2Ftest_otel_metrics.py%3A192-197%0AThe%20test%20resets%20%60cache_metrics%60%20module%20state%20before%20the%20test%20body%20but%20leaves%20%60_instruments_initialized%3DTrue%60%20and%20the%20counters%20bound%20to%20the%20test-local%20%60operator_provider%60%20after%20the%20test%20completes.%20The%20autouse%20fixture%20restores%20the%20OTel%20global%20slot%20but%20does%20not%20touch%20%60cache_metrics%60.%20Any%20future%20test%20that%20calls%20%60record_cache_access%60%2F%60record_cache_eviction%60%20after%20this%20test%20will%20find%20%60_instruments_initialized%3DTrue%60%2C%20skip%20re-initialization%2C%20and%20silently%20emit%20to%20the%20stale%20instruments.%20Restoring%20the%20three%20fields%20in%20teardown%20keeps%20isolation%20complete.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22jamesc-fix-otel-shared-meterprovider%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jamesc-fix-otel-shared-meterprovider%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Ftests%2Funit%2Futils%2Ftest_otel_metrics.py%3A192-197%0AThe%20test%20resets%20%60cache_metrics%60%20module%20state%20before%20the%20test%20body%20but%20leaves%20%60_instruments_initialized%3DTrue%60%20and%20the%20counters%20bound%20to%20the%20test-local%20%60operator_provider%60%20after%20the%20test%20completes.%20The%20autouse%20fixture%20restores%20the%20OTel%20global%20slot%20but%20does%20not%20touch%20%60cache_metrics%60.%20Any%20future%20test%20that%20calls%20%60record_cache_access%60%2F%60record_cache_eviction%60%20after%20this%20test%20will%20find%20%60_instruments_initialized%3DTrue%60%2C%20skip%20re-initialization%2C%20and%20silently%20emit%20to%20the%20stale%20instruments.%20Restoring%20the%20three%20fields%20in%20teardown%20keeps%20isolation%20complete.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex/tests/unit/utils/test_otel_metrics.py:192-197
The test resets `cache_metrics` module state before the test body but leaves `_instruments_initialized=True` and the counters bound to the test-local `operator_provider` after the test completes. The autouse fixture restores the OTel global slot but does not touch `cache_metrics`. Any future test that calls `record_cache_access`/`record_cache_eviction` after this test will find `_instruments_initialized=True`, skip re-initialization, and silently emit to the stale instruments. Restoring the three fields in teardown keeps isolation complete.

`````

</details>

<sub>Reviews (8): Last reviewed commit: ["Merge branch &#39;main&#39; into jamesc-fix-otel..."](https://github.com/scaleapi/scale-agentex/commit/51a270e04239a734f9f98d015477a8624c444c29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36313424)</sub>

<!-- /greptile_comment -->