### PR TITLE
fix(auth): skip caching api key principals

### DIFF
--- a/agentex/src/api/authentication_cache.py
+++ b/agentex/src/api/authentication_cache.py
@@ -240,9 +240,20 @@ class AuthenticationCache:
         self, headers: dict[str, str], principal_context: Any
     ) -> None:
         """Cache auth gateway response."""
+        if self._contains_api_key(principal_context):
+            logger.debug("Skipping auth gateway cache for API key principal")
+            return
         cache_key = self._create_headers_cache_key(headers)
         await self.auth_gateway_cache.set(f"gateway:{cache_key}", principal_context)
         logger.debug("Cached auth gateway response")
+
+    @staticmethod
+    def _contains_api_key(principal_context: Any) -> bool:
+        if principal_context is None:
+            return False
+        if isinstance(principal_context, dict):
+            return bool(principal_context.get("api_key"))
+        return bool(getattr(principal_context, "api_key", None))
 
     # Authorization Check Cache Methods (Async)
 

--- a/agentex/tests/unit/api/test_authentication_cache_metrics.py
+++ b/agentex/tests/unit/api/test_authentication_cache_metrics.py
@@ -90,3 +90,15 @@ def test_authentication_cache_assigns_distinct_names():
     assert cache.agent_api_key_cache.name == "agent_api_key"
     assert cache.auth_gateway_cache.name == "auth_gateway"
     assert cache.authorization_check_cache.name == "authorization_check"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_auth_gateway_response_with_api_key_principal_is_not_cached():
+    cache = AuthenticationCache()
+    headers = {"x-api-key": "secret-key", "x-selected-account-id": "acct-1"}
+    principal = {"user_id": "user-1", "account_id": "acct-1", "api_key": "secret-key"}
+
+    await cache.set_auth_gateway_response(headers, principal)
+
+    assert await cache.get_auth_gateway_response(headers) is None


### PR DESCRIPTION
## What changed

Skip auth gateway response caching when the principal context contains an API key. Added coverage that API-key-backed principals are not stored in the auth gateway cache.

## Why

Passing `principal.api_key` is needed for Spark feature flag routing, but raw API keys should not be retained in the auth gateway cache. This keeps direct SDK requests functional while avoiding cached raw credentials.

## Impact

API-key-backed Agentex SDK requests will re-authenticate through the gateway instead of using a cached principal context. Other auth gateway responses continue to use the existing cache behavior.

## Validation

- `uv run pytest tests/unit/api/test_authentication_cache_metrics.py`
- `uv run ruff check src/api/authentication_cache.py tests/unit/api/test_authentication_cache_metrics.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a guard in `set_auth_gateway_response` that skips writing to the auth gateway cache when the principal context carries a raw `api_key` field, preventing plaintext credentials from being retained in memory.

- `_contains_api_key` is a new static helper that handles both dict-style (`principal.get(\"api_key\")`) and object-style (`getattr(principal, \"api_key\", None)`) principals, making the guard robust to different caller shapes.
- One new test verifies the skip behaviour for a dict-based principal; the object-based branch and the positive caching path (principal without `api_key` continues to be cached) are not yet covered.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the production path correctly skips caching API-key principals and does not affect other auth flows.

The implementation is correct and the security intent is clear. The only gap is in test coverage: the getattr-based branch of _contains_api_key is untested, and there is no test confirming that principals without an API key are still cached normally.

agentex/tests/unit/api/test_authentication_cache_metrics.py — the new test only covers the dict-based principal shape; adding tests for object-based principals and the non-skip (caching) path would complete coverage.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/api/authentication_cache.py | Adds _contains_api_key guard in set_auth_gateway_response to skip caching when the principal carries a raw API key; implementation correctly handles both dict and object-style principals. |
| agentex/tests/unit/api/test_authentication_cache_metrics.py | Adds one new test covering the API-key-skip path (dict form only); missing tests for the object-based principal branch and the positive caching path for non-API-key principals. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant set_auth_gateway_response
    participant _contains_api_key
    participant AsyncTTLCache

    Caller->>set_auth_gateway_response: headers, principal_context
    set_auth_gateway_response->>_contains_api_key: principal_context
    alt principal has truthy api_key
        _contains_api_key-->>set_auth_gateway_response: True
        set_auth_gateway_response-->>Caller: return (no cache write)
    else no api_key present
        _contains_api_key-->>set_auth_gateway_response: False
        set_auth_gateway_response->>set_auth_gateway_response: _create_headers_cache_key(headers)
        set_auth_gateway_response->>AsyncTTLCache: "set(gateway:{key}, principal_context)"
        AsyncTTLCache-->>set_auth_gateway_response: stored
        set_auth_gateway_response-->>Caller: return
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Ftests%2Funit%2Fapi%2Ftest_authentication_cache_metrics.py%3A95-104%0A**Object-based%20principal%20path%20not%20covered**%0A%0A%60_contains_api_key%60%20has%20two%20distinct%20branches%3A%20dict%20lookup%20%28%60.get%28%22api_key%22%29%60%29%20and%20attribute%20access%20%28%60getattr%28...%2C%20%22api_key%22%2C%20None%29%60%29.%20The%20new%20test%20only%20exercises%20the%20dict%20branch.%20If%20a%20caller%20passes%20an%20object-style%20principal%20%28e.g.%20a%20Pydantic%20model%20or%20dataclass%29%2C%20the%20%60getattr%60%20branch%20is%20exercised%20but%20never%20tested%2C%20so%20a%20regression%20there%20would%20be%20silently%20missed.%20A%20companion%20test%20with%20a%20simple%20namespace%2Fobject%20principal%20would%20close%20this%20gap.%0A%0AAdditionally%2C%20there%20is%20no%20positive-case%20test%20confirming%20that%20a%20principal%20*without*%20%60api_key%60%20is%20still%20cached%20normally.%20Without%20it%2C%20a%20future%20change%20that%20accidentally%20skips%20all%20caching%20would%20not%20be%20caught%20by%20this%20suite.%0A%0A&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Ftests%2Funit%2Fapi%2Ftest_authentication_cache_metrics.py%3A95-104%0A**Object-based%20principal%20path%20not%20covered**%0A%0A%60_contains_api_key%60%20has%20two%20distinct%20branches%3A%20dict%20lookup%20%28%60.get%28%22api_key%22%29%60%29%20and%20attribute%20access%20%28%60getattr%28...%2C%20%22api_key%22%2C%20None%29%60%29.%20The%20new%20test%20only%20exercises%20the%20dict%20branch.%20If%20a%20caller%20passes%20an%20object-style%20principal%20%28e.g.%20a%20Pydantic%20model%20or%20dataclass%29%2C%20the%20%60getattr%60%20branch%20is%20exercised%20but%20never%20tested%2C%20so%20a%20regression%20there%20would%20be%20silently%20missed.%20A%20companion%20test%20with%20a%20simple%20namespace%2Fobject%20principal%20would%20close%20this%20gap.%0A%0AAdditionally%2C%20there%20is%20no%20positive-case%20test%20confirming%20that%20a%20principal%20*without*%20%60api_key%60%20is%20still%20cached%20normally.%20Without%20it%2C%20a%20future%20change%20that%20accidentally%20skips%20all%20caching%20would%20not%20be%20caught%20by%20this%20suite.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22codex%2Fskip-api-key-auth-gateway-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fskip-api-key-auth-gateway-cache%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Ftests%2Funit%2Fapi%2Ftest_authentication_cache_metrics.py%3A95-104%0A**Object-based%20principal%20path%20not%20covered**%0A%0A%60_contains_api_key%60%20has%20two%20distinct%20branches%3A%20dict%20lookup%20%28%60.get%28%22api_key%22%29%60%29%20and%20attribute%20access%20%28%60getattr%28...%2C%20%22api_key%22%2C%20None%29%60%29.%20The%20new%20test%20only%20exercises%20the%20dict%20branch.%20If%20a%20caller%20passes%20an%20object-style%20principal%20%28e.g.%20a%20Pydantic%20model%20or%20dataclass%29%2C%20the%20%60getattr%60%20branch%20is%20exercised%20but%20never%20tested%2C%20so%20a%20regression%20there%20would%20be%20silently%20missed.%20A%20companion%20test%20with%20a%20simple%20namespace%2Fobject%20principal%20would%20close%20this%20gap.%0A%0AAdditionally%2C%20there%20is%20no%20positive-case%20test%20confirming%20that%20a%20principal%20*without*%20%60api_key%60%20is%20still%20cached%20normally.%20Without%20it%2C%20a%20future%20change%20that%20accidentally%20skips%20all%20caching%20would%20not%20be%20caught%20by%20this%20suite.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex/tests/unit/api/test_authentication_cache_metrics.py:95-104
**Object-based principal path not covered**

`_contains_api_key` has two distinct branches: dict lookup (`.get("api_key")`) and attribute access (`getattr(..., "api_key", None)`). The new test only exercises the dict branch. If a caller passes an object-style principal (e.g. a Pydantic model or dataclass), the `getattr` branch is exercised but never tested, so a regression there would be silently missed. A companion test with a simple namespace/object principal would close this gap.

Additionally, there is no positive-case test confirming that a principal *without* `api_key` is still cached normally. Without it, a future change that accidentally skips all caching would not be caught by this suite.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): skip caching api key principa..."](https://github.com/scaleapi/scale-agentex/commit/f25b8604e240a3ea9c0caef0055b8f87c0e98207) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36324252)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->