### PR TITLE
fix(agentex): robustly parse inbound Cookie header for delegation

### DIFF
--- a/agentex/src/domain/delegation_headers.py
+++ b/agentex/src/domain/delegation_headers.py
@@ -10,7 +10,6 @@ Default name is _identityJwt. Override with AGENTEX_DELEGATION_SESSION_COOKIE_NA
 """
 
 import os
-from http.cookies import CookieError, SimpleCookie
 from typing import Any
 
 HEADER_ACTING_USER_API_KEY = "x-acting-user-api-key"
@@ -41,21 +40,30 @@ def session_cookie_names_to_forward() -> tuple[str, ...]:
 
 
 def _minimal_session_cookie(cookie_header: str, names: tuple[str, ...]) -> str | None:
+    """Extract only the allowlisted session cookies from an inbound Cookie header.
+
+    We parse the header by hand rather than via ``http.cookies.SimpleCookie``.
+    Real browsers send a long, messy Cookie header full of third-party/analytics
+    morsels that ``SimpleCookie`` cannot parse — e.g. ``__utmzz`` values containing
+    spaces and parentheses (``(not set)``), ``fs_uid`` containing ``#``, or base64
+    values ending in ``==``. When ``SimpleCookie.load()`` hits one of those it stops
+    and silently drops the remaining morsels, so a perfectly valid ``_identityJwt``
+    sitting later in the header is lost and cookie delegation breaks entirely (the
+    agent pod then gets no acting credential). Since we only ever forward exact
+    ``name=value`` pairs for a small allowlist, splitting on ``;`` is both more robust
+    and sufficient — and it never trusts/decodes the non-allowlisted cookies.
+    """
     if not names:
         return None
 
-    jar = SimpleCookie()
-    try:
-        jar.load(cookie_header)
-    except CookieError:
-        return None
+    jar: dict[str, str] = {}
+    for part in cookie_header.split(";"):
+        name, sep, value = part.strip().partition("=")
+        if sep:
+            # First occurrence wins, matching prior SimpleCookie behavior.
+            jar.setdefault(name.strip(), value.strip())
 
-    pairs: list[str] = []
-    for name in names:
-        morsel = jar.get(name)
-        if morsel is not None:
-            pairs.append(f"{name}={morsel.value}")
-
+    pairs = [f"{name}={jar[name]}" for name in names if name in jar]
     return "; ".join(pairs) if pairs else None
 
 

--- a/agentex/tests/unit/domain/test_delegation_headers.py
+++ b/agentex/tests/unit/domain/test_delegation_headers.py
@@ -53,6 +53,31 @@ class TestBuildDelegationHeaders:
             "x-selected-account-id": "acct-2",
         }
 
+    def test_cookie_delegation_survives_messy_browser_header(self):
+        """Real browsers send long Cookie headers full of morsels that
+        http.cookies.SimpleCookie cannot parse (analytics cookies with spaces and
+        parentheses, '#' chars, base64 '=='). The parser must still extract the
+        allowlisted _identityJwt sitting among them — otherwise cookie delegation
+        silently drops to {} and agent pods get no acting credential (regression:
+        SimpleCookie.load() aborted on the first bad morsel and lost the rest)."""
+        cookie = (
+            "_fbp=fb.1.1757359049951.112906694371483372; "
+            "__utmzz=utmcsr=google|utmcmd=organic|utmccn=(not set)|utmctr=(not provided); "
+            "fs_uid=#25WP4#678b3617:a3955fc3::1#96c136b6##/1809111214; "
+            "_identityJwt=eyJhbGciOiJFUzI1NiJ9.payload.sig; "
+            "__q_state_bbwZsKT3=eyJ1dWlkIjoiZDc1NDhjMDQ9PQ==; "
+            "OptanonConsent=isGpcEnabled=0&groups=C0001%3A1%2CC0002%3A1&geolocation=US%3BOR; "
+            "_jwt=eyJhbGciOiJFUzI1NiJ9.payload2.sig2"
+        )
+        headers = build_delegation_headers(
+            _user_principal(),
+            {"Cookie": cookie, "x-selected-account-id": "acct-9"},
+        )
+        assert headers == {
+            HEADER_ACTING_USER_COOKIE: "_identityJwt=eyJhbGciOiJFUzI1NiJ9.payload.sig",
+            "x-selected-account-id": "acct-9",
+        }
+
     def test_cookie_delegation_respects_custom_names(
         self, monkeypatch: pytest.MonkeyPatch
     ):


### PR DESCRIPTION
## Summary

Cookie-based runtime delegation forwards the user's session cookie to agent pods as `x-acting-user-cookie` so they can call downstream services as the user. It extracted the allowlisted session cookie from the inbound `Cookie` header using `http.cookies.SimpleCookie`.

Real browsers send a long `Cookie` header containing third-party/analytics morsels that `SimpleCookie` cannot parse — values with spaces and parentheses (e.g. `__utmzz=...(not set)...`), values containing `#`, base64 values ending in `==`, etc. `SimpleCookie.load()` aborts on the first such morsel and silently drops the remaining cookies. When the session cookie sits after one of these, it's lost and `build_delegation_headers` collapses to `{}` — the agent pod receives **no** acting-user credential and user-scoped downstream calls fail, even though the cookie was present in the request.

## Fix

Parse the inbound `Cookie` header by hand: split on `;` and extract only the exact `name=value` pairs for the configured allowlist. This avoids the wholesale drop when an unrelated third-party cookie is unparseable, and it never trusts or decodes the non-allowlisted cookies. Behavior is otherwise unchanged — first occurrence wins, only allowlisted names are forwarded, API-key delegation and the empty/disabled cases are untouched.

## Test plan

- New regression test `test_cookie_delegation_survives_messy_browser_header` with a representative real-world `Cookie` header (analytics cookies with spaces/parens, `#`, base64 `==`) asserts `_identityJwt` is still extracted and forwarded.
- All existing delegation tests still pass (`tests/unit/domain/test_delegation_headers.py`, 13 passed).
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent delegation failure caused by `http.cookies.SimpleCookie` aborting on unparseable real-world analytics cookies (spaces, parentheses, `#`, base64 `==`) and dropping all subsequent cookies including the allowlisted session cookie. The fix replaces `SimpleCookie` with a hand-rolled `;`-split parser that uses `str.partition("=")` to extract only the exact allowlisted `name=value` pairs.

- **`delegation_headers.py`**: `_minimal_session_cookie` now splits the `Cookie` header on `;`, extracts name/value via `partition("=")` (preserving embedded `=` in base64 values), and strips surrounding whitespace. Non-allowlisted cookies are never decoded or stored.
- **`test_delegation_headers.py`**: A regression test `test_cookie_delegation_survives_messy_browser_header` validates that `_identityJwt` is still extracted from a representative messy real-world cookie header containing analytics morsels that previously broke `SimpleCookie`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, well-scoped fix that only affects one private helper function with no side-effects on other code paths.

The manual cookie parser is correct: `partition("=")` handles embedded `=` in base64 values, `setdefault` preserves first-occurrence semantics, and whitespace stripping is harmless for JWT/session tokens. All pre-existing tests pass and a new regression test directly covers the reported failure mode. API-key delegation, the empty/disabled case, and the `build_delegation_headers` contract are completely unchanged.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/delegation_headers.py | Replaces `SimpleCookie` with a robust manual `;`-split parser; logic is correct, `partition("=")` preserves embedded `=` in values, `setdefault` preserves first-occurrence semantics, and whitespace stripping is safe for JWT/session cookie values. |
| agentex/tests/unit/domain/test_delegation_headers.py | Adds a focused regression test with a representative messy browser `Cookie` header; covers analytics cookies with spaces/parentheses, `#`, and base64 `==`, and asserts the allowlisted cookie is still extracted correctly. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["build_delegation_headers(principal, inbound_headers)"] --> B{principal is None\nor agent_identity set?}
    B -->|Yes| C["return {}"]
    B -->|No| D["normalize_headers → lowercase keys"]
    D --> E{x-api-key present?}
    E -->|Yes| F["result[x-acting-user-api-key] = api_key"]
    E -->|No| G{cookie header present?}
    G -->|No| H["return {}"]
    G -->|Yes| I["_minimal_session_cookie(cookie_header, names)"]
    I --> J["split on ';'"]
    J --> K["for each part: strip → partition on first '='"]
    K --> L["setdefault(name.strip(), value.strip())\nfirst occurrence wins"]
    L --> M["build pairs for allowlisted names only"]
    M --> N{any matching\ncookies found?}
    N -->|No| O["return {}"]
    N -->|Yes| P["result[x-acting-user-cookie] = joined pairs"]
    F --> Q{x-selected-account-id\npresent?}
    P --> Q
    Q -->|Yes| R["result[x-selected-account-id] = account_id"]
    Q -->|No| S["return result"]
    R --> S
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agentex): robustly parse inbound Coo..."](https://github.com/scaleapi/scale-agentex/commit/7369f9fad1f521ce1ebe971297752344c8d777e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36354483)</sub>

<!-- /greptile_comment -->