### PR TITLE
fix(events): collapse unauthorized-agent list to 404

### DIFF
--- a/agentex/tests/integration/api/events/test_events_authz_api.py
+++ b/agentex/tests/integration/api/events/test_events_authz_api.py
@@ -248,7 +248,7 @@ class TestEventsAuthzAPIIntegration:
         "src.domain.services.authorization_service.AuthorizationService.is_enabled",
         return_value=True,
     )
-    async def test_list_events_unauthorized_agent_returns_403(
+    async def test_list_events_unauthorized_agent_returns_404(
         self,
         is_enabled_authorization_mock,
         is_enabled_mock,
@@ -257,7 +257,6 @@ class TestEventsAuthzAPIIntegration:
         test_agent,
         test_task,
     ):
-        """Direct-resource denials surface as 403 (convention from #249/#255)."""
         with patch(
             "src.utils.http_request_handler.HttpRequestHandler.post_with_error_handling",
             side_effect=_mock_post_factory(deny_agent_ids={test_agent.id}),
@@ -265,4 +264,6 @@ class TestEventsAuthzAPIIntegration:
             response = await isolated_client.get(
                 f"/events?task_id={test_task.id}&agent_id={test_agent.id}"
             )
-        assert response.status_code == 403
+        # Agent denial collapses to 404 so the filter can't reveal cross-tenant
+        # agent existence.
+        assert response.status_code == 404


### PR DESCRIPTION
## What

`GET /events` gates on the parent agent via `DAuthorizedQuery`, which collapses a denied agent check to 404 — consistent with the other agent-gated routes — so the events filter can't be used to probe cross-tenant agent existence. The integration test still asserted 403; this aligns it with that behavior.

## Test

`tests/integration/api/events/test_events_authz_api.py::TestEventsAuthzAPIIntegration::test_list_events_unauthorized_agent_returns_404` (renamed from `_returns_403`) — passes locally alongside the rest of the events authz suite.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a stale integration test that was asserting a 403 response for an unauthorized-agent query on `GET /events`, when the production code already collapses that denial to 404 via `DAuthorizedQuery` → `_check_agent_or_collapse_to_404`.

- Renames `test_list_events_unauthorized_agent_returns_403` → `_returns_404` and updates the `assert response.status_code` from `403` to `404`.
- Removes the now-incorrect docstring that cited the "403 convention" and replaces it with an inline comment explaining the cross-tenant probe-prevention rationale.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the single changed test now correctly reflects the 404 behavior already enforced by the production authorization helper.

The fix is confined to one test assertion. The production path through DAuthorizedQuery → _check_agent_or_collapse_to_404 has been returning 404 for denied agents, so updating the test to match closes a gap where the test was silently not exercising the real behavior.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/tests/integration/api/events/test_events_authz_api.py | Single test corrected: assertion updated from 403 → 404 to match the actual behavior of DAuthorizedQuery for agent resources, and docstring referencing the old convention removed. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant EventsRouter as GET /events
    participant DAuthorizedQuery
    participant CheckAgent as _check_agent_or_collapse_to_404
    participant AuthService as AuthorizationService
    participant Exception as ItemDoesNotExist (404)

    Client->>EventsRouter: "GET /events?task_id=X&agent_id=Y"
    EventsRouter->>DAuthorizedQuery: resolve agent_id dependency
    DAuthorizedQuery->>CheckAgent: check agent Y (read)
    CheckAgent->>AuthService: authorization.check(agent Y, read)
    AuthService-->>CheckAgent: AuthorizationError (denied)
    CheckAgent->>Exception: raise ItemDoesNotExist
    Exception-->>Client: HTTP 404
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(events): collapse unauthorized-agent..."](https://github.com/scaleapi/scale-agentex/commit/c2560483665b53fb7602825c26f96d8a311e1848) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36366938)</sub>

<!-- /greptile_comment -->