### PR TITLE
fix(authz): mint agentex resource ownership on create under FGAC

### DIFF
--- a/agentex/src/api/middleware_utils.py
+++ b/agentex/src/api/middleware_utils.py
@@ -43,8 +43,12 @@ def is_whitelisted_route(
     path: str, whitelisted_routes: set[str] = WHITELISTED_ROUTES
 ) -> bool:
     """Check if a route path is whitelisted (bypasses authentication)."""
+    # Boundary-aware prefix match: a whitelisted route only matches the route
+    # itself or a sub-path under it (route + "/..."). Plain startswith() would
+    # let "/agents/register" whitelist "/agents/register-build" too, which must
+    # stay authenticated so it can carry the caller's principal (owner grant).
     return path in whitelisted_routes or any(
-        path.startswith(route) for route in whitelisted_routes
+        path == route or path.startswith(route + "/") for route in whitelisted_routes
     )
 
 

--- a/agentex/src/domain/services/schedule_service.py
+++ b/agentex/src/domain/services/schedule_service.py
@@ -132,8 +132,14 @@ class ScheduleService:
         identity is resolvable and registration is skipped.
         """
         principal_context = self.authorization_service.principal_context
-        user_id = getattr(principal_context, "user_id", None)
-        service_account_id = getattr(principal_context, "service_account_id", None)
+        # principal_context is `Any` (a dict from /v1/authn), not a typed model,
+        # so getattr always yields None and silently skips the Spark register.
+        if isinstance(principal_context, dict):
+            user_id = principal_context.get("user_id")
+            service_account_id = principal_context.get("service_account_id")
+        else:
+            user_id = getattr(principal_context, "user_id", None)
+            service_account_id = getattr(principal_context, "service_account_id", None)
         if user_id is None and service_account_id is None:
             logger.warning(
                 "Skipping auth registration for schedule: no creator resolvable",

--- a/agentex/src/domain/use_cases/agent_api_keys_use_case.py
+++ b/agentex/src/domain/use_cases/agent_api_keys_use_case.py
@@ -120,8 +120,14 @@ class AgentAPIKeysUseCase:
         persisted api key that cannot be authorized.
         """
         principal_context = self.authorization_service.principal_context
-        user_id = getattr(principal_context, "user_id", None)
-        service_account_id = getattr(principal_context, "service_account_id", None)
+        # principal_context is `Any` (a dict from /v1/authn), not a typed model,
+        # so getattr always yields None and silently skips the Spark register.
+        if isinstance(principal_context, dict):
+            user_id = principal_context.get("user_id")
+            service_account_id = principal_context.get("service_account_id")
+        else:
+            user_id = getattr(principal_context, "user_id", None)
+            service_account_id = getattr(principal_context, "service_account_id", None)
         if user_id is None and service_account_id is None:
             logger.warning(
                 "Skipping auth registration for api_key: no creator resolvable",

--- a/agentex/src/domain/use_cases/agents_use_case.py
+++ b/agentex/src/domain/use_cases/agents_use_case.py
@@ -68,8 +68,16 @@ class AgentsUseCase:
         a resource it never registered.
         """
         principal_context = self.authorization_service.principal_context
-        user_id = getattr(principal_context, "user_id", None)
-        service_account_id = getattr(principal_context, "service_account_id", None)
+        # principal_context is `Any` (a dict from /v1/authn), not a typed model,
+        # so attribute access via getattr always yields None and silently skips
+        # the Spark resource registration. Read from the dict (fall back to attr
+        # access for any object-shaped principal).
+        if isinstance(principal_context, dict):
+            user_id = principal_context.get("user_id")
+            service_account_id = principal_context.get("service_account_id")
+        else:
+            user_id = getattr(principal_context, "user_id", None)
+            service_account_id = getattr(principal_context, "service_account_id", None)
         if user_id is None and service_account_id is None:
             logger.warning(
                 "Skipping authorization registration for agent: no creator resolvable",

--- a/agentex/tests/integration/api/events/test_events_authz_api.py
+++ b/agentex/tests/integration/api/events/test_events_authz_api.py
@@ -248,7 +248,7 @@ class TestEventsAuthzAPIIntegration:
         "src.domain.services.authorization_service.AuthorizationService.is_enabled",
         return_value=True,
     )
-    async def test_list_events_unauthorized_agent_returns_403(
+    async def test_list_events_unauthorized_agent_returns_404(
         self,
         is_enabled_authorization_mock,
         is_enabled_mock,
@@ -257,7 +257,7 @@ class TestEventsAuthzAPIIntegration:
         test_agent,
         test_task,
     ):
-        """Direct-resource denials surface as 403 (convention from #249/#255)."""
+        """Denied agent-route access collapses to 404 (convention from #271)."""
         with patch(
             "src.utils.http_request_handler.HttpRequestHandler.post_with_error_handling",
             side_effect=_mock_post_factory(deny_agent_ids={test_agent.id}),
@@ -265,4 +265,4 @@ class TestEventsAuthzAPIIntegration:
             response = await isolated_client.get(
                 f"/events?task_id={test_task.id}&agent_id={test_agent.id}"
             )
-        assert response.status_code == 403
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
Resource ownership was not being recorded on agentex resource creation when fine-grained access control is enforced. Two independent issues:

### 1. `register-build` bypassed authentication
`is_whitelisted_route` matched whitelisted entries with a plain `startswith`, so the `/agents/register` entry also matched `/agents/register-build`. The build-time registration endpoint therefore skipped authentication and ran with no principal context — its ownership grant/register executed with a null principal, and the create check failed (HTTP 422) under enforcement.

**Fix:** boundary-aware match — a route matches only itself or a true sub-path (`route + "/"`). `/agents/register` stays whitelisted (deployed pods self-register without a user principal); `/agents/register-build` now authenticates and carries the caller principal that becomes the owner.

### 2. Creator never resolved from the principal context
`_register_in_auth` / `_register_api_key_in_auth` / `_register_schedule_in_auth` read the creator via `getattr(principal_context, "user_id" / "service_account_id")`, but the principal context is an untyped dict, so both were always `None`. Registration was skipped with "no creator resolvable", so the resource (and its children) were never written to the authorization graph.

**Fix:** read the fields from the dict (with an attribute-access fallback), so `register_resource` fires for agent, agent_api_key, and schedule (covers both user and service-account creators).

## Testing
Verified end-to-end against a live authorization backend: the owner can see/read created resources, while a different user in the same account is correctly isolated when enforcement is on and falls back to account-level access when enforcement is off. The boundary-whitelist behavior was unit-checked across exact / sub-path / prefix-sibling cases.

## Follow-up (not in this PR)
The root cause of #2 is that the principal context type is effectively untyped (`Any`), so attribute access silently no-ops. A cleaner long-term fix is to make it a typed model so attribute access works everywhere (and the auth-middleware success log stops reporting `user_id=None`). This PR keeps the change minimal and localized.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent authorization bugs that prevented resource ownership from being recorded on creation under FGAC: a whitelist boundary check that accidentally exempted `/agents/register-build` from authentication, and a principal-context field-access bug (dict vs typed model) that caused every creator lookup to silently return `None`.

- **Boundary-aware whitelist** (`middleware_utils.py`): replaces bare `startswith` with `path == route or path.startswith(route + "/")` so `/agents/register` no longer accidentally covers `/agents/register-build`.
- **Dict-safe creator lookup** (`agents_use_case.py`, `agent_api_keys_use_case.py`, `schedule_service.py`): reads `user_id`/`service_account_id` via `.get()` when `principal_context` is a dict, falling back to `getattr` for any future typed model.
- **Test alignment** (`test_events_authz_api.py`): updates the expected response code for a denied-agent list request from 403 → 404, consistent with the convention established in #271.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the two targeted fixes are correct, the whitelist logic is well-reasoned, and the dict-safe principal extraction pattern is applied consistently across all three registration sites.

The whitelist boundary fix correctly narrows what was an accidental over-match. The dict-safe lookup change is a straightforward type-check guard that matches how the principal context is actually structured. The test update is internally consistent with the 404-on-denial convention already present in the same file. No regressions are introduced.

No files require special attention beyond the minor dead-code redundancy in middleware_utils.py.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| agentex/src/api/middleware_utils.py | Boundary-aware whitelist fix; path == route inside any() is redundant dead code (set lookup already handles exact matches), but the core logic is correct. |
| agentex/src/domain/use_cases/agents_use_case.py | Dict-safe principal_context field extraction; isinstance guard correctly handles the actual dict shape from /v1/authn. |
| agentex/src/domain/use_cases/agent_api_keys_use_case.py | Same dict-safe fix as agents_use_case.py; consistent pattern applied correctly. |
| agentex/src/domain/services/schedule_service.py | Same dict-safe fix as the use-case files; schedule registration now correctly resolves the creator identity. |
| agentex/tests/integration/api/events/test_events_authz_api.py | Test updated to expect 404 instead of 403 on denied agent-list access, consistent with the established convention in #271. |

</details>



<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as AuthMiddleware
    participant WL as is_whitelisted_route
    participant AuthGW as AuthGateway (/v1/authn)
    participant UseCase as AgentsUseCase._register_in_auth
    participant AuthSvc as AuthorizationService (Spark)

    Client->>Middleware: POST /agents/register-build
    Middleware->>WL: is_whitelisted_route("/agents/register-build")
    Note over WL: OLD: startswith("/agents/register") → True (bypassed auth!)<br/>NEW: startswith(route+"/") → False
    WL-->>Middleware: False (not whitelisted)
    Middleware->>AuthGW: verify headers
    AuthGW-->>Middleware: "principal_context {user_id, account_id}"
    Middleware->>UseCase: register_agent(...)
    UseCase->>UseCase: "isinstance(principal_context, dict)?<br/>OLD: getattr → None, skipped<br/>NEW: dict.get() → user-123"
    UseCase->>AuthSvc: "register_resource(agent, owner=user-123)"
    AuthSvc-->>UseCase: OK
    UseCase-->>Client: 200 agent created with ownership
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `agentex/src/api/middleware_utils.py`, line 152-155 ([link](https://github.com/scaleapi/scale-agentex/blob/cc50f6541bdd2ed11f2c9b392363016fad6ec820/agentex/src/api/middleware_utils.py#L152-L155)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Authentication success log still reports `user_id=None`**

   `verify_auth_gateway` logs `user_id` and `account_id` via `getattr(principal_context, …, None)` (lines 153–154), but `principal_context` is a dict, so `getattr` always yields `None`. Every authenticated request will log `user_id=None, account_id=None`, making the success log useless for debugging and correlation. The PR description mentions this as a follow-up, but it is worth flagging since it degrades observability immediately after this fix lands.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: agentex/src/api/middleware_utils.py
   Line: 152-155

   Comment:
   **Authentication success log still reports `user_id=None`**

   `verify_auth_gateway` logs `user_id` and `account_id` via `getattr(principal_context, …, None)` (lines 153–154), but `principal_context` is a dict, so `getattr` always yields `None`. Every authenticated request will log `user_id=None, account_id=None`, making the success log useless for debugging and correlation. The PR description mentions this as a follow-up, but it is worth flagging since it degrades observability immediately after this fix lands.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fsrc%2Fapi%2Fmiddleware_utils.py%0ALine%3A%20152-155%0A%0AComment%3A%0A**Authentication%20success%20log%20still%20reports%20%60user_id%3DNone%60**%0A%0A%60verify_auth_gateway%60%20logs%20%60user_id%60%20and%20%60account_id%60%20via%20%60getattr%28principal_context%2C%20%E2%80%A6%2C%20None%29%60%20%28lines%20153%E2%80%93154%29%2C%20but%20%60principal_context%60%20is%20a%20dict%2C%20so%20%60getattr%60%20always%20yields%20%60None%60.%20Every%20authenticated%20request%20will%20log%20%60user_id%3DNone%2C%20account_id%3DNone%60%2C%20making%20the%20success%20log%20useless%20for%20debugging%20and%20correlation.%20The%20PR%20description%20mentions%20this%20as%20a%20follow-up%2C%20but%20it%20is%20worth%20flagging%20since%20it%20degrades%20observability%20immediately%20after%20this%20fix%20lands.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fsrc%2Fapi%2Fmiddleware_utils.py%0ALine%3A%20152-155%0A%0AComment%3A%0A**Authentication%20success%20log%20still%20reports%20%60user_id%3DNone%60**%0A%0A%60verify_auth_gateway%60%20logs%20%60user_id%60%20and%20%60account_id%60%20via%20%60getattr%28principal_context%2C%20%E2%80%A6%2C%20None%29%60%20%28lines%20153%E2%80%93154%29%2C%20but%20%60principal_context%60%20is%20a%20dict%2C%20so%20%60getattr%60%20always%20yields%20%60None%60.%20Every%20authenticated%20request%20will%20log%20%60user_id%3DNone%2C%20account_id%3DNone%60%2C%20making%20the%20success%20log%20useless%20for%20debugging%20and%20correlation.%20The%20PR%20description%20mentions%20this%20as%20a%20follow-up%2C%20but%20it%20is%20worth%20flagging%20since%20it%20degrades%20observability%20immediately%20after%20this%20fix%20lands.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22harvhan%2Ffgac-register-ownership%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harvhan%2Ffgac-register-ownership%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fsrc%2Fapi%2Fmiddleware_utils.py%0ALine%3A%20152-155%0A%0AComment%3A%0A**Authentication%20success%20log%20still%20reports%20%60user_id%3DNone%60**%0A%0A%60verify_auth_gateway%60%20logs%20%60user_id%60%20and%20%60account_id%60%20via%20%60getattr%28principal_context%2C%20%E2%80%A6%2C%20None%29%60%20%28lines%20153%E2%80%93154%29%2C%20but%20%60principal_context%60%20is%20a%20dict%2C%20so%20%60getattr%60%20always%20yields%20%60None%60.%20Every%20authenticated%20request%20will%20log%20%60user_id%3DNone%2C%20account_id%3DNone%60%2C%20making%20the%20success%20log%20useless%20for%20debugging%20and%20correlation.%20The%20PR%20description%20mentions%20this%20as%20a%20follow-up%2C%20but%20it%20is%20worth%20flagging%20since%20it%20degrades%20observability%20immediately%20after%20this%20fix%20lands.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Fapi%2Fmiddleware_utils.py%3A50-52%0AThe%20%60path%20%3D%3D%20route%60%20branch%20inside%20the%20%60any%28%29%60%20generator%20is%20dead%20code.%20Because%20%60path%20in%20whitelisted_routes%60%20is%20evaluated%20first%20%28O%281%29%20set%20lookup%29%2C%20control%20only%20reaches%20the%20%60any%28%29%60%20when%20%60path%60%20is%20not%20in%20the%20set%20%E2%80%94%20which%20means%20%60path%20%3D%3D%20route%60%20will%20be%20%60False%60%20for%20every%20element%20in%20%60whitelisted_routes%60.%20The%20%60path%20%3D%3D%20route%60%20arm%20can%20never%20contribute%20a%20%60True%60%20that%20wasn't%20already%20caught%20above.%20Removing%20it%20makes%20the%20intent%20clearer%20and%20slightly%20faster.%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20path%20in%20whitelisted_routes%20or%20any%28%0A%20%20%20%20%20%20%20%20path.startswith%28route%20%2B%20%22%2F%22%29%20for%20route%20in%20whitelisted_routes%0A%20%20%20%20%29%0A%60%60%60%0A%0A&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Fapi%2Fmiddleware_utils.py%3A50-52%0AThe%20%60path%20%3D%3D%20route%60%20branch%20inside%20the%20%60any%28%29%60%20generator%20is%20dead%20code.%20Because%20%60path%20in%20whitelisted_routes%60%20is%20evaluated%20first%20%28O%281%29%20set%20lookup%29%2C%20control%20only%20reaches%20the%20%60any%28%29%60%20when%20%60path%60%20is%20not%20in%20the%20set%20%E2%80%94%20which%20means%20%60path%20%3D%3D%20route%60%20will%20be%20%60False%60%20for%20every%20element%20in%20%60whitelisted_routes%60.%20The%20%60path%20%3D%3D%20route%60%20arm%20can%20never%20contribute%20a%20%60True%60%20that%20wasn't%20already%20caught%20above.%20Removing%20it%20makes%20the%20intent%20clearer%20and%20slightly%20faster.%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20path%20in%20whitelisted_routes%20or%20any%28%0A%20%20%20%20%20%20%20%20path.startswith%28route%20%2B%20%22%2F%22%29%20for%20route%20in%20whitelisted_routes%0A%20%20%20%20%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22harvhan%2Ffgac-register-ownership%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22harvhan%2Ffgac-register-ownership%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Fapi%2Fmiddleware_utils.py%3A50-52%0AThe%20%60path%20%3D%3D%20route%60%20branch%20inside%20the%20%60any%28%29%60%20generator%20is%20dead%20code.%20Because%20%60path%20in%20whitelisted_routes%60%20is%20evaluated%20first%20%28O%281%29%20set%20lookup%29%2C%20control%20only%20reaches%20the%20%60any%28%29%60%20when%20%60path%60%20is%20not%20in%20the%20set%20%E2%80%94%20which%20means%20%60path%20%3D%3D%20route%60%20will%20be%20%60False%60%20for%20every%20element%20in%20%60whitelisted_routes%60.%20The%20%60path%20%3D%3D%20route%60%20arm%20can%20never%20contribute%20a%20%60True%60%20that%20wasn't%20already%20caught%20above.%20Removing%20it%20makes%20the%20intent%20clearer%20and%20slightly%20faster.%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20path%20in%20whitelisted_routes%20or%20any%28%0A%20%20%20%20%20%20%20%20path.startswith%28route%20%2B%20%22%2F%22%29%20for%20route%20in%20whitelisted_routes%0A%20%20%20%20%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=291&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex/src/api/middleware_utils.py:50-52
The `path == route` branch inside the `any()` generator is dead code. Because `path in whitelisted_routes` is evaluated first (O(1) set lookup), control only reaches the `any()` when `path` is not in the set — which means `path == route` will be `False` for every element in `whitelisted_routes`. The `path == route` arm can never contribute a `True` that wasn't already caught above. Removing it makes the intent clearer and slightly faster.

```suggestion
    return path in whitelisted_routes or any(
        path.startswith(route + "/") for route in whitelisted_routes
    )
```


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into harvhan/fgac-re..."](https://github.com/scaleapi/scale-agentex/commit/0a0c4a4ba57dc270c55ba3c1c381fcd69b08c09b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36396840)</sub>

<!-- /greptile_comment -->