### PR TITLE
fix(authz): skip create-check/grant on unauthenticated agent self-register

### DIFF
--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -50,6 +50,28 @@ logger = make_logger(__name__)
 router = APIRouter(prefix="/agents", tags=["Agents"])
 
 
+def _has_resolvable_creator(principal_context) -> bool:
+    """Whether a creator identity (user or service account) is present.
+
+    ``/agents/register`` is whitelisted, so deployed pods self-register on
+    startup with no principal context (``None``). The agent already exists and
+    is owned from build time (``register-build`` runs before deploy-time
+    register), so the create authorization check and ownership grant don't
+    apply on that path -- and forwarding a ``None`` principal to agentex-auth
+    raises 422, crash-looping the pod. Skip the check/grant when no creator is
+    resolvable; enforce normally for an authenticated caller.
+    """
+    if isinstance(principal_context, dict):
+        return bool(
+            principal_context.get("user_id")
+            or principal_context.get("service_account_id")
+        )
+    return bool(
+        getattr(principal_context, "user_id", None)
+        or getattr(principal_context, "service_account_id", None)
+    )
+
+
 @router.get(
     "/{agent_id}",
     summary="Get Agent by ID",
@@ -173,10 +195,14 @@ async def register_agent(
     If agent_id is not provided, the system will look for an existing agent by name and update it,
     or create a new one if it doesn't exist.
     """
-    await authorization_service.check(
-        AgentexResource.agent("*"),
-        AuthorizedOperationType.create,
+    enforce_ownership = _has_resolvable_creator(
+        authorization_service.principal_context
     )
+    if enforce_ownership:
+        await authorization_service.check(
+            AgentexResource.agent("*"),
+            AuthorizedOperationType.create,
+        )
     logger.info(f"Registering agent: {request}")
     try:
         agent_entity = await agents_use_case.register_agent(
@@ -188,9 +214,10 @@ async def register_agent(
             registration_metadata=request.registration_metadata,
             agent_input_type=request.agent_input_type,
         )
-        await authorization_service.grant(
-            AgentexResource.agent(agent_entity.id),
-        )
+        if enforce_ownership:
+            await authorization_service.grant(
+                AgentexResource.agent(agent_entity.id),
+            )
         response_fields = agent_entity.model_dump()
         existing_key = await api_keys_use_case.get_internal_api_key_by_agent_id(
             agent_id=agent_entity.id

--- a/agentex/tests/integration/api/agents/test_agents_auth_api.py
+++ b/agentex/tests/integration/api/agents/test_agents_auth_api.py
@@ -188,7 +188,7 @@ class TestAgentsAuthAPIIntegration:
         "src.utils.http_request_handler.HttpRequestHandler.post_with_error_handling",
         side_effect=_mock_post_with_error_handling,
     )
-    async def test_agent_create_and_delete_gate_and_write_legacy_authz(
+    async def test_agent_register_skips_authz_and_delete_gates_legacy_authz(
         self,
         post_with_error_handling_mock,
         is_enabled_mock,
@@ -214,20 +214,13 @@ class TestAgentsAuthAPIIntegration:
         assert response.status_code == 200
         agent = response.json()
 
-        create_checks = _payloads("/v1/authz/check")
-        assert len(create_checks) == 1
-        assert create_checks[0]["resource"]["type"] == AgentexResourceType.agent.value
-        assert create_checks[0]["resource"]["selector"] == "*"
-        assert create_checks[0]["operation"] == "create"
-
-        agent_grants = [
-            payload
-            for payload in _payloads("/v1/authz/grant")
-            if payload["resource"]["type"] == AgentexResourceType.agent.value
-        ]
-        assert len(agent_grants) == 1
-        assert agent_grants[0]["resource"]["selector"] == agent["id"]
-        assert agent_grants[0]["operation"] == "create"
+        # /agents/register is whitelisted: deployed pods self-register on
+        # startup without a principal, so register does not gate on `create`
+        # or write an ownership grant -- the agent is already owned from build
+        # time (register-build runs first). Forwarding a None principal here
+        # previously 422'd and crash-looped the pod.
+        assert _payloads("/v1/authz/check") == []
+        assert _payloads("/v1/authz/grant") == []
 
         post_with_error_handling_mock.reset_mock()
         response = await isolated_client.delete("/agents/name/test-agent")

--- a/agentex/tests/unit/api/test_agents_authz.py
+++ b/agentex/tests/unit/api/test_agents_authz.py
@@ -7,6 +7,7 @@ forwards the authorized-id set to the use case.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -17,6 +18,9 @@ from src.api.schemas.authorization_types import (
     AgentexResourceType,
     AuthorizedOperationType,
 )
+from src.api.routes.agents import register_agent
+from src.api.schemas.agents import RegisterAgentRequest
+from src.domain.entities.agents import ACPType, AgentEntity, AgentStatus
 from src.utils.authorization_shortcuts import (
     DAuthorizedId,
     DAuthorizedName,
@@ -261,3 +265,70 @@ class TestListFiltering:
             order_by=None,
             order_direction="desc",
         )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestRegisterAgentOwnershipEnforcement:
+    """``/agents/register`` is whitelisted, so deployed pods self-register with
+    no principal. The create check / ownership grant must be skipped on that
+    path (the agent is already owned from build time), so a ``None`` principal
+    does not 422 and crash-loop the pod. An authenticated caller is enforced."""
+
+    @staticmethod
+    def _mocks(principal_context):
+        authorization = MagicMock()
+        authorization.principal_context = principal_context
+        authorization.check = AsyncMock(return_value=True)
+        authorization.grant = AsyncMock()
+
+        now = datetime.now(timezone.utc)
+        agent = AgentEntity(
+            id="agent-1",
+            name="my-agent",
+            description="d",
+            acp_type=ACPType.ASYNC,
+            status=AgentStatus.READY,
+            acp_url="http://agent:5000",
+            created_at=now,
+            updated_at=now,
+        )
+        agents_use_case = MagicMock()
+        agents_use_case.register_agent = AsyncMock(return_value=agent)
+
+        api_keys_use_case = MagicMock()
+        existing_key = MagicMock()
+        existing_key.api_key = "internal-key"
+        api_keys_use_case.get_internal_api_key_by_agent_id = AsyncMock(
+            return_value=existing_key
+        )
+        return authorization, agents_use_case, api_keys_use_case
+
+    @staticmethod
+    def _request():
+        return RegisterAgentRequest(
+            name="my-agent",
+            description="d",
+            acp_url="http://agent:5000",
+            acp_type=ACPType.ASYNC,
+        )
+
+    async def test_no_principal_skips_check_and_grant(self):
+        authz, use_case, api_keys = self._mocks(principal_context=None)
+
+        resp = await register_agent(self._request(), use_case, authz, api_keys)
+
+        authz.check.assert_not_awaited()
+        authz.grant.assert_not_awaited()
+        use_case.register_agent.assert_awaited_once()
+        assert resp.agent_api_key == "internal-key"
+
+    async def test_authenticated_caller_enforces_check_and_grant(self):
+        authz, use_case, api_keys = self._mocks(
+            principal_context={"user_id": "u", "account_id": "acct"}
+        )
+
+        await register_agent(self._request(), use_case, authz, api_keys)
+
+        authz.check.assert_awaited_once()
+        authz.grant.assert_awaited_once()

--- a/agentex/tests/unit/api/test_agents_authz.py
+++ b/agentex/tests/unit/api/test_agents_authz.py
@@ -7,19 +7,20 @@ forwards the authorized-id set to the use case.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from src.adapters.authorization.exceptions import AuthorizationError
 from src.adapters.crud_store.exceptions import ItemDoesNotExist
+from src.api.routes.agents import register_agent
+from src.api.schemas.agents import RegisterAgentRequest
 from src.api.schemas.authorization_types import (
     AgentexResource,
     AgentexResourceType,
     AuthorizedOperationType,
 )
-from src.api.routes.agents import register_agent
-from src.api.schemas.agents import RegisterAgentRequest
 from src.domain.entities.agents import ACPType, AgentEntity, AgentStatus
 from src.utils.authorization_shortcuts import (
     DAuthorizedId,
@@ -282,7 +283,7 @@ class TestRegisterAgentOwnershipEnforcement:
         authorization.check = AsyncMock(return_value=True)
         authorization.grant = AsyncMock()
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         agent = AgentEntity(
             id="agent-1",
             name="my-agent",
@@ -313,8 +314,11 @@ class TestRegisterAgentOwnershipEnforcement:
             acp_type=ACPType.ASYNC,
         )
 
-    async def test_no_principal_skips_check_and_grant(self):
-        authz, use_case, api_keys = self._mocks(principal_context=None)
+    @pytest.mark.parametrize("principal_context", [None, {}, {"account_id": "acct"}])
+    async def test_unresolvable_creator_skips_check_and_grant(self, principal_context):
+        # None (whitelisted self-reg), an empty dict, or a principal with no
+        # user_id/service_account_id all mean "no creator" -> skip, don't 422.
+        authz, use_case, api_keys = self._mocks(principal_context=principal_context)
 
         resp = await register_agent(self._request(), use_case, authz, api_keys)
 
@@ -323,9 +327,22 @@ class TestRegisterAgentOwnershipEnforcement:
         use_case.register_agent.assert_awaited_once()
         assert resp.agent_api_key == "internal-key"
 
-    async def test_authenticated_caller_enforces_check_and_grant(self):
+    async def test_dict_principal_enforces_check_and_grant(self):
         authz, use_case, api_keys = self._mocks(
             principal_context={"user_id": "u", "account_id": "acct"}
+        )
+
+        await register_agent(self._request(), use_case, authz, api_keys)
+
+        authz.check.assert_awaited_once()
+        authz.grant.assert_awaited_once()
+
+    async def test_object_principal_enforces_check_and_grant(self):
+        # Object-shaped principal exercises the getattr branch of the helper.
+        authz, use_case, api_keys = self._mocks(
+            principal_context=SimpleNamespace(
+                user_id="u", service_account_id=None, account_id="acct"
+            )
         )
 
         await register_agent(self._request(), use_case, authz, api_keys)


### PR DESCRIPTION
## Summary
Deployed agent pods were stuck in `CrashLoopBackOff` on startup, 422-ing
on `POST /agents/register`.

`/agents/register` is whitelisted (deployed pods self-register on startup
without a user login), so the auth middleware leaves `principal_context`
as `None`. #270 added an enforced `authorization_service.check(create)` and
`grant()` to `register_agent`; with no principal these forward `None` to
agentex-auth, whose `_validate_principal` raises **422** → the pod crashes.

## Fix
Skip the create check and ownership grant in `register_agent` when no creator
is resolvable from the principal context. By deploy time the agent already
exists and is owned from build time (`register-build` runs before
deploy-time register), so neither applies on the self-registration path. An
authenticated caller (resolvable principal) is still enforced.

## Why not the alternatives
- *Un-whitelist `/agents/register`*: pods self-register without a user login,
  so they'd then fail auth.
- *Make agentex-auth tolerate a `None` principal*: weakens authz globally; the
  null only legitimately arises on this whitelisted self-reg path.

This mirrors the existing "no creator resolvable → skip" pattern already used
for the Spark resource registration in `_register_in_auth`.

## Scope
Companion #291 fixed the analogous 422 for `/agents/register-build` (by
un-whitelisting it so it authenticates); this PR covers the **deployed-pod
`/agents/register`** path, which #291 intentionally left whitelisted.

## Testing
Unit tests (`test_agents_authz.py`): a `None`-principal register skips
check/grant and still returns the agent (no 422); an authenticated caller
still triggers check + grant. Full `test_agents_authz.py` suite passes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `CrashLoopBackOff` on deployed agent pods by skipping the `authorization_service.check(create)` and `grant()` calls in `register_agent` when no principal is resolvable from the context. Since `/agents/register` is whitelisted and pods self-register without a user login, forwarding a `None` principal to agentex-auth was raising a 422 — this PR introduces `_has_resolvable_creator` to gate those calls only for authenticated callers.

- Adds `_has_resolvable_creator(principal_context)` helper that checks for `user_id`/`service_account_id` on both dict-shaped and attribute-shaped principals.
- Wraps the `check`/`grant` calls in `register_agent` behind `enforce_ownership`, leaving them untouched for authenticated callers.
- Adds unit tests covering all three cases (None/empty principal, dict principal, object principal) and updates the integration test to reflect that the unauthenticated self-register path no longer triggers authz calls.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is surgical, well-documented, and mirrors an existing pattern; both the unauthenticated self-register path and the authenticated path are covered by new unit tests.

The fix is narrowly scoped to gating two calls behind a well-tested helper. The helper correctly handles all principal shapes. The previously flagged untested getattr branch is now covered by test_object_principal_enforces_check_and_grant. No existing authz enforcement for authenticated callers is weakened.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/api/routes/agents.py | Adds `_has_resolvable_creator` helper and gates `check`/`grant` in `register_agent` behind it. Logic is correct and well-documented; both dict and attribute principal shapes are handled; the unauthenticated path correctly skips auth calls. |
| agentex/tests/unit/api/test_agents_authz.py | New `TestRegisterAgentOwnershipEnforcement` class covers all three paths: None/empty/no-matching-key principal skips check+grant; dict principal with user_id enforces; SimpleNamespace principal with user_id exercises the getattr branch and enforces — addressing the previously untested branch. |
| agentex/tests/integration/api/agents/test_agents_auth_api.py | Renames and updates the integration test to assert no authz calls on the unauthenticated register path, correctly reflecting the new behavior. Delete-gate assertions remain unchanged. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(authz): align register authz tests ..."](https://github.com/scaleapi/scale-agentex/commit/84e758e060c730a5ea4294cb590132f34bb1bf8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36488854)</sub>

<!-- /greptile_comment -->