### PR TITLE
fix: avoid logging principal context secrets

### DIFF
--- a/agentex/src/api/app.py
+++ b/agentex/src/api/app.py
@@ -145,7 +145,12 @@ def format_error_response(detail: str, status_code: int) -> JSONResponse:
 @fastapi_app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     exc_str = f"{exc}".replace("\n", " ").replace("   ", " ")
-    logger.error(f"{request}: {exc_str}")
+    logger.error(
+        "Request validation failed for %s %s: %s errors",
+        request.method,
+        request.url.path,
+        len(exc.errors()),
+    )
     content = {"status_code": 10422, "message": exc_str, "data": None}
     return JSONResponse(
         content=content, status_code=status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/agentex/src/api/logged_api_route.py
+++ b/agentex/src/api/logged_api_route.py
@@ -27,7 +27,7 @@ def log_request(
         extra={
             "method": request.method,
             "path": raw_path,
-            "query_params": request.query_params,
+            "query_params": strip_sensitive_items(request.query_params),
             "headers": strip_sensitive_items(request.headers),
             "body": request_dict,
             "request_id": request_id,
@@ -42,7 +42,7 @@ def log_response(request_id: str, request: Request, response: Response):
             "status_code": response.status_code,
             "method": request.method,
             "path": request.url.path,
-            "headers": response.headers,
+            "headers": strip_sensitive_items(response.headers),
             "request_id": request_id,
         },
     )

--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -195,15 +195,18 @@ async def register_agent(
     If agent_id is not provided, the system will look for an existing agent by name and update it,
     or create a new one if it doesn't exist.
     """
-    enforce_ownership = _has_resolvable_creator(
-        authorization_service.principal_context
-    )
+    enforce_ownership = _has_resolvable_creator(authorization_service.principal_context)
     if enforce_ownership:
         await authorization_service.check(
             AgentexResource.agent("*"),
             AuthorizedOperationType.create,
         )
-    logger.info(f"Registering agent: {request}")
+    logger.info(
+        "Registering agent name=%s agent_id=%s acp_type=%s",
+        request.name,
+        request.agent_id,
+        request.acp_type,
+    )
     try:
         agent_entity = await agents_use_case.register_agent(
             name=request.name,
@@ -493,8 +496,11 @@ async def _handle_agent_rpc(
         and request.params.stream
     )
 
-    logger.info(f"Is streaming request: {is_streaming_request}")
-    logger.info(f"Request: {request}")
+    logger.info(
+        "Handling agent RPC request method=%s is_streaming=%s",
+        request.method,
+        is_streaming_request,
+    )
 
     if is_streaming_request:
         return await _handle_streaming_rpc(

--- a/agentex/src/domain/entities/agents_rpc.py
+++ b/agentex/src/domain/entities/agents_rpc.py
@@ -225,7 +225,7 @@ class AgentRPCRequestEntity(JSONRPCRequest):
                 content=content_entity,
             )
         else:
-            logger.error(f"Invalid method from request: {request}")
+            logger.error("Invalid agent RPC method: %s", request.method)
             raise ValueError(f"Invalid method: {request.method}")
 
         return cls(

--- a/agentex/src/domain/services/authorization_service.py
+++ b/agentex/src/domain/services/authorization_service.py
@@ -49,11 +49,10 @@ class AuthorizationService:
             return None
 
         logger.info(
-            "[authorization_service] Granting %s permission on %s:%s for principal %s",
+            "[authorization_service] Granting %s permission on %s:%s",
             AuthorizedOperationType.create,
             resource.type,
             resource.selector,
-            self.principal_context,
         )
         result = await self.gateway.grant(
             principal_context
@@ -72,11 +71,10 @@ class AuthorizationService:
             return None
 
         logger.info(
-            "[authorization_service] Revoking %s permission on %s:%s for principal %s",
+            "[authorization_service] Revoking %s permission on %s:%s",
             AuthorizedOperationType.delete,
             resource.type,
             resource.selector,
-            self.principal_context,
         )
 
         result = await self.gateway.revoke(
@@ -120,22 +118,20 @@ class AuthorizationService:
 
         if cached_result is not None:
             logger.info(
-                "[authorization_service] Using cached result for %s permission on %s:%s for principal %s: %s",
+                "[authorization_service] Using cached result for %s permission on %s:%s: %s",
                 operation,
                 resource.type,
                 resource.selector,
-                effective_principal,
                 "allowed" if cached_result else "denied",
             )
             return cached_result
 
         # Not in cache, perform actual check
         logger.info(
-            "[authorization_service] Checking %s permission on %s:%s for principal %s",
+            "[authorization_service] Checking %s permission on %s:%s",
             operation,
             resource.type,
             resource.selector,
-            effective_principal,
         )
         result = await self.gateway.check(
             effective_principal,
@@ -171,10 +167,9 @@ class AuthorizationService:
             return None
 
         logger.info(
-            "[authorization_service] Listing resources of type %s with %s permission for principal %s",
+            "[authorization_service] Listing resources of type %s with %s permission",
             filter_resource,
             filter_operation,
-            self.principal_context,
         )
         result = await self.gateway.list_resources(
             principal_context
@@ -213,10 +208,9 @@ class AuthorizationService:
             else self.principal_context
         )
         logger.info(
-            "[authorization_service] Registering %s:%s for principal %s (parent=%s)",
+            "[authorization_service] Registering %s:%s (parent=%s)",
             resource.type,
             resource.selector,
-            effective_principal,
             f"{parent.type}:{parent.selector}" if parent is not None else None,
         )
         await self.gateway.register_resource(effective_principal, resource, parent)
@@ -238,10 +232,9 @@ class AuthorizationService:
             else self.principal_context
         )
         logger.info(
-            "[authorization_service] Deregistering %s:%s for principal %s",
+            "[authorization_service] Deregistering %s:%s",
             resource.type,
             resource.selector,
-            effective_principal,
         )
         await self.gateway.deregister_resource(effective_principal, resource)
 

--- a/agentex/src/utils/request_utils.py
+++ b/agentex/src/utils/request_utils.py
@@ -3,11 +3,10 @@ import re
 from typing import Any
 from uuid import uuid4
 
-from starlette.datastructures import FormData, Headers, UploadFile
+from starlette.datastructures import FormData, Headers, QueryParams, UploadFile
 
 REQUEST_KEY_REGEXP_BLACKLIST = [
-    r"api_key",
-    r"api-key",
+    r"api[_-]?key",
     r"cookie",
     r"password",
     r"secret",
@@ -35,6 +34,8 @@ def strip_sensitive_items(value: Any) -> Any:
         return [strip_sensitive_items(e) for e in value]
     if isinstance(value, Headers):
         return Headers(strip_sensitive_items(dict(value)))
+    if isinstance(value, QueryParams):
+        return QueryParams(strip_sensitive_items(dict(value)))
     return value
 
 
@@ -42,7 +43,7 @@ def decode_request_body(request_body: bytes):
     try:
         request_dict = strip_sensitive_items(json.loads(request_body.decode("utf-8")))
     except json.JSONDecodeError:
-        request_dict = request_body.decode("utf-8")
+        request_dict = "[non-json request body omitted]"
     except UnicodeDecodeError:
         request_dict = {}
     return request_dict

--- a/agentex/tests/unit/services/test_authorization_service_logging.py
+++ b/agentex/tests/unit/services/test_authorization_service_logging.py
@@ -1,0 +1,48 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from src.api.schemas.authorization_types import (
+    AgentexResource,
+    AgentexResourceType,
+    AuthorizedOperationType,
+)
+from src.domain.services.authorization_service import AuthorizationService
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_authorization_service_logs_do_not_serialize_principal(caplog):
+    secret = "secret-api-key-value"
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            principal_context={
+                "user_id": "user-1",
+                "account_id": "acct-1",
+                "api_key": secret,
+            },
+            agent_identity=None,
+        )
+    )
+    gateway = MagicMock()
+    gateway.grant = AsyncMock()
+    gateway.revoke = AsyncMock()
+    gateway.check = AsyncMock(return_value=True)
+    gateway.list_resources = AsyncMock(return_value=[])
+    gateway.register_resource = AsyncMock()
+    gateway.deregister_resource = AsyncMock()
+    service = AuthorizationService(enabled=True, gateway=gateway, request=request)
+
+    with caplog.at_level(logging.INFO):
+        await service.grant(AgentexResource.agent("agent-1"))
+        await service.revoke(AgentexResource.agent("agent-1"))
+        await service.check(
+            AgentexResource.agent("agent-1"), AuthorizedOperationType.read
+        )
+        await service.list_resources(AgentexResourceType.agent)
+        await service.register_resource(AgentexResource.agent("agent-1"))
+        await service.deregister_resource(AgentexResource.agent("agent-1"))
+
+    assert secret not in caplog.text
+    assert "principal" not in caplog.text

--- a/agentex/tests/unit/utils/test_request_utils.py
+++ b/agentex/tests/unit/utils/test_request_utils.py
@@ -1,0 +1,48 @@
+import pytest
+from src.utils.request_utils import decode_request_body, strip_sensitive_items
+from starlette.datastructures import Headers, QueryParams
+
+
+@pytest.mark.unit
+def test_decode_request_body_strips_api_key_fields():
+    decoded = decode_request_body(
+        b"""
+        {
+            "name": "safe",
+            "api_key": "secret-1",
+            "apiKey": "secret-2",
+            "nested": {
+                "x-agent-api-key": "secret-3",
+                "visible": "kept"
+            }
+        }
+        """
+    )
+
+    assert decoded == {"name": "safe", "nested": {"visible": "kept"}}
+
+
+@pytest.mark.unit
+def test_decode_request_body_omits_non_json_bodies():
+    decoded = decode_request_body(b"api_key=secret&name=safe")
+
+    assert decoded == "[non-json request body omitted]"
+
+
+@pytest.mark.unit
+def test_strip_sensitive_items_handles_headers_and_query_params():
+    headers = strip_sensitive_items(
+        Headers(
+            {
+                "x-api-key": "secret-1",
+                "Authorization": "Bearer secret-2",
+                "x-request-id": "req-1",
+            }
+        )
+    )
+    query_params = strip_sensitive_items(
+        QueryParams("apiKey=secret-3&token=secret-4&name=safe")
+    )
+
+    assert dict(headers) == {"x-request-id": "req-1"}
+    assert dict(query_params) == {"name": "safe"}


### PR DESCRIPTION
## Summary

- Stop authorization-service logs from serializing `principal_context`, which can contain API-key principals.
- Harden request logging by scrubbing query params and response headers, catching `apiKey` variants, and omitting non-JSON request bodies.
- Replace whole request-model logs in agent registration/RPC paths with metadata-only logs.

## Root Cause

Several authz logs included the full principal object, and generic request logging still had raw metadata paths that could expose API keys outside the existing header/body scrubber coverage.

## Validation

- `uv run --project agentex ruff check agentex/src/utils/request_utils.py agentex/src/api/logged_api_route.py agentex/src/domain/services/authorization_service.py agentex/src/api/routes/agents.py agentex/src/domain/entities/agents_rpc.py agentex/src/api/app.py agentex/tests/unit/utils/test_request_utils.py agentex/tests/unit/services/test_authorization_service_logging.py`
- `uv run --project agentex --group test pytest agentex/tests/unit/utils/test_request_utils.py agentex/tests/unit/services/test_authorization_service_logging.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes several secret-exposure paths in service logs: principal contexts (which may carry API keys) are removed from all `AuthorizationService` log calls, query params and response headers are now passed through the existing `strip_sensitive_items` scrubber, non-JSON request bodies are omitted entirely, and agent registration/RPC logs are reduced to metadata-only fields.

- `request_utils.py`: the `api_key`/`api-key` patterns are consolidated to `api[_-]?key`, which now also catches camelCase `apiKey`; `QueryParams` handling mirrors the existing `Headers` path; non-JSON bodies return a fixed sentinel string instead of a raw UTF-8 decode.
- `authorization_service.py`: all six logger call sites that previously interpolated `self.principal_context` or `effective_principal` are updated; a handful of unchanged f-string logs remain for post-operation confirmations but reference only resource type/selector.
- New unit tests assert both that the secret value is absent from `caplog.text` and that `apiKey` camelCase variants are stripped correctly.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are purely additive scrubbing of log output with no effect on request processing or authorization logic.

All six principal-context log sites in AuthorizationService are cleaned up, query params and response headers are now passed through the existing scrubber, non-JSON bodies are replaced with a sentinel, and camelCase apiKey variants are caught by the consolidated regex. The new unit tests directly assert the secret value is absent from log output. No auth, data-path, or schema changes are included.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/utils/request_utils.py | Consolidates api_key/api-key patterns into api[_-]?key (catching camelCase apiKey), adds QueryParams scrubbing, and omits non-JSON request bodies instead of logging them raw. |
| agentex/src/domain/services/authorization_service.py | Removes principal_context from all six authorization log call sites; residual f-string log lines remain but only reference resource type/selector, not sensitive principal data. |
| agentex/src/api/logged_api_route.py | Applies strip_sensitive_items to both query_params (new) and response headers (new); request headers were already scrubbed. |
| agentex/src/api/routes/agents.py | Replaces two full-model f-string logs (register_agent and _handle_agent_rpc) with structured metadata-only format strings. |
| agentex/src/domain/entities/agents_rpc.py | Replaces full-request f-string error log with method-only log, preventing RPC request body from appearing in error output. |
| agentex/src/api/app.py | Fixes validation exception handler to log method, path, and error count instead of the full Request repr (which could include query params and headers). |
| agentex/tests/unit/utils/test_request_utils.py | New unit tests covering camelCase apiKey stripping, non-JSON body omission, and QueryParams/Headers scrubbing. |
| agentex/tests/unit/services/test_authorization_service_logging.py | New unit test asserting that all six AuthorizationService methods produce no log output containing the secret value or the word 'principal'. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant LoggedAPIRoute
    participant RequestUtils
    participant AuthService
    participant Gateway

    Client->>LoggedAPIRoute: HTTP Request (headers, query_params, body)
    LoggedAPIRoute->>RequestUtils: strip_sensitive_items(query_params) [NEW]
    LoggedAPIRoute->>RequestUtils: strip_sensitive_items(headers)
    LoggedAPIRoute->>RequestUtils: decode_request_body(body)
    Note over RequestUtils: Scrubs api[_-]?key, token,<br/>authorization, cookie, etc.<br/>Non-JSON body → sentinel string
    LoggedAPIRoute->>LoggedAPIRoute: log_request (scrubbed)
    LoggedAPIRoute->>AuthService: check/grant/revoke/list/register/deregister
    Note over AuthService: Logs resource type:selector only<br/>principal_context NOT logged [FIXED]
    AuthService->>Gateway: gateway.check(effective_principal, resource, op)
    Gateway-->>AuthService: result
    AuthService-->>LoggedAPIRoute: result
    LoggedAPIRoute->>RequestUtils: strip_sensitive_items(response.headers) [NEW]
    LoggedAPIRoute->>LoggedAPIRoute: log_response (scrubbed headers)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid logging principal context sec..."](https://github.com/scaleapi/scale-agentex/commit/f4c7dba0ca519b821e0c726233055f2deb6f0027) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36532900)</sub>

<!-- /greptile_comment -->