### PR TITLE
fix(agentex): redact secret values from all logs via logging filter

### DIFF
--- a/agentex/src/utils/logging.py
+++ b/agentex/src/utils/logging.py
@@ -1,12 +1,15 @@
 import contextvars
 import logging
 import os
+import re
 import sys
 from collections.abc import Sequence
 
 import ddtrace
 import json_log_formatter
 from ddtrace.trace import tracer
+
+from src.utils.request_utils import REQUEST_KEY_REGEXP_BLACKLIST
 
 # Check if Datadog is configured
 _is_datadog_configured = bool(os.environ.get("DD_AGENT_HOST"))
@@ -25,6 +28,65 @@ else:
 __all__: Sequence[str] = ("make_logger", "LOG_FORMAT")
 
 ctx_var_request_id = contextvars.ContextVar[str]("request_id")
+
+# Defense in depth against credential leaks in logs. Even though no code path
+# should log a secret directly, objects like the request principal context can
+# carry an ``api_key`` and may end up interpolated into a log message (via %s or
+# an f-string). This filter masks the *value* that follows any sensitive key
+# name in the rendered message, so a credential never reaches log aggregation.
+#
+# Key names reuse REQUEST_KEY_REGEXP_BLACKLIST (the request-body scrubber's list)
+# so the two stay in sync. The pattern matches common renderings — dict repr
+# (``'api_key': 'x'``), kwargs/model repr (``api_key='x'``) and JSON
+# (``"api_key": "x"``) — preserving the surrounding quote style.
+#
+# The value sub-pattern also absorbs an optional auth-scheme prefix
+# (``Bearer``/``Basic``/...) so ``Authorization: Bearer <token>`` redacts the
+# whole credential rather than stopping at the first space. It deliberately
+# matches only the scheme word plus a single token (not the rest of the line),
+# so an unquoted tail like ``token: foo bar baz`` masks just ``foo``.
+_AUTH_SCHEME = r"(?:bearer|basic|digest|token)\s+"
+_SENSITIVE_VALUE_RE = re.compile(
+    r"(?P<key>" + "|".join(REQUEST_KEY_REGEXP_BLACKLIST) + r")"
+    r"(?P<sep>['\"]?\s*[:=]\s*)"
+    r"(?P<quote>['\"]?)"
+    r"(?P<value>" + _AUTH_SCHEME + r"[^\s'\"},]+|[^\s'\"},]+)"
+    r"(?P=quote)",
+    re.IGNORECASE,
+)
+_REDACTION_TEMPLATE = r"\g<key>\g<sep>\g<quote>[REDACTED]\g<quote>"
+
+
+def redact_sensitive_text(message: str) -> str:
+    """Mask secret values that follow a sensitive key name in ``message``."""
+    return _SENSITIVE_VALUE_RE.sub(_REDACTION_TEMPLATE, message)
+
+
+class SensitiveDataFilter(logging.Filter):
+    """Redact secret values (api keys, tokens, cookies, ...) from log messages.
+
+    Runs on every record emitted through a ``make_logger`` handler. It rewrites
+    the fully-rendered message (after %-args/f-string interpolation) so that even
+    an accidental ``logger.info("... %s", principal_context)`` cannot emit a raw
+    credential. Note: this scrubs the message text only — values passed via
+    ``extra={...}`` structured fields are out of scope and should already use
+    non-sensitive identifiers (e.g. ``api_key_id``, not the key itself).
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            # Never let redaction break logging itself.
+            return True
+        redacted = redact_sensitive_text(message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+_sensitive_data_filter = SensitiveDataFilter()
 
 
 class CustomJSONFormatter(json_log_formatter.JSONFormatter):
@@ -79,6 +141,12 @@ def make_logger(name: str) -> logging.Logger:
 
     logger.addHandler(stream_handler)
     logger.setLevel(log_level)
+
+    # Mask secret values before any handler emits the record. Attaching to the
+    # logger (not the handler) means the redaction runs once, up front, and
+    # applies to every downstream handler the record propagates to.
+    if _sensitive_data_filter not in logger.filters:
+        logger.addFilter(_sensitive_data_filter)
 
     def handle_exception(exc_type, exc_value, exc_traceback):
         if issubclass(exc_type, KeyboardInterrupt):

--- a/agentex/tests/unit/utils/test_logging_redaction.py
+++ b/agentex/tests/unit/utils/test_logging_redaction.py
@@ -1,0 +1,76 @@
+"""Tests for the log redaction safety net in src.utils.logging.
+
+Even if a future code path interpolates an object carrying a credential (e.g. a
+principal context dict with an api_key) into a log message, the value must be
+masked before the record is emitted.
+"""
+
+import logging
+
+import pytest
+from src.utils.logging import make_logger, redact_sensitive_text
+
+# Fake credential shaped like a real key; not a live secret.
+FAKE_KEY = "ssk_is_deadbeefdeadbeefdeadbeef00"  # noqa: S105
+
+pytestmark = pytest.mark.unit
+
+
+def test_redacts_api_key_in_principal_dict_repr():
+    # The exact shape that leaked: a principal context rendered via %s/f-string.
+    principal_repr = (
+        "{'api_key': '" + FAKE_KEY + "', 'user_id': 'user-1', "
+        "'service_account_id': None, 'account_id': 'acct-1', 'metadata': {}}"
+    )
+    out = redact_sensitive_text(principal_repr)
+
+    assert FAKE_KEY not in out
+    assert "[REDACTED]" in out
+    # Non-sensitive identifiers are preserved for debuggability.
+    assert "user-1" in out
+    assert "acct-1" in out
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "api_key='" + FAKE_KEY + "'",  # pydantic / kwargs repr
+        '"api_key": "' + FAKE_KEY + '"',  # json
+        "api_key=" + FAKE_KEY,  # unquoted
+        "apiKey: " + FAKE_KEY,  # camelCase
+        "token: " + FAKE_KEY,
+        "secret=" + FAKE_KEY,
+        "authorization: " + FAKE_KEY,
+        "authorization: Bearer " + FAKE_KEY,  # scheme-prefixed header
+        "Authorization=Bearer " + FAKE_KEY,
+        "cookie='" + FAKE_KEY + "'",
+    ],
+)
+def test_redacts_common_renderings(text):
+    assert FAKE_KEY not in redact_sensitive_text(text)
+
+
+def test_leaves_non_sensitive_text_untouched():
+    text = (
+        "Granting create permission on agent:abc for user_id=user-1 account_id=acct-1"
+    )
+    assert redact_sensitive_text(text) == text
+
+
+def test_unquoted_value_does_not_over_redact_rest_of_line():
+    # Only the single token after the key is masked, not the trailing words.
+    out = redact_sensitive_text("token: " + FAKE_KEY + " while processing request")
+    assert FAKE_KEY not in out
+    assert "while processing request" in out
+
+
+def test_make_logger_redacts_secret_end_to_end(caplog):
+    logger = make_logger("test_logging_redaction_e2e")
+    principal = {"api_key": FAKE_KEY, "user_id": "user-1", "account_id": "acct-1"}
+
+    with caplog.at_level(logging.INFO):
+        logger.info("Checking read permission for principal %s", principal)
+
+    assert FAKE_KEY not in caplog.text
+    # The log line still made it through, with safe identifiers intact.
+    assert "user-1" in caplog.text


### PR DESCRIPTION
## Problem

A request principal context can carry a raw `api_key` (a long-lived bearer credential). #293 removed the principal context from the authorization-service logs and hardened the request-body scrubber — but that's call-site-by-call-site. The leak originally happened because a perfectly ordinary `logger.info(..., principal_context)` interpolated a secret-bearing object. Nothing structurally prevents the *next* such line.

## Fix

Add a `SensitiveDataFilter` to every logger created by `make_logger` (`agentex/src/utils/logging.py`). It rewrites the fully-rendered log message before any handler emits it, masking the value that follows any sensitive key name to `[REDACTED]`:

- Key names reuse `REQUEST_KEY_REGEXP_BLACKLIST` (the request-body scrubber's list) — single source of truth: `api_key` / `token` / `secret` / `cookie` / `authorization` / `acting-user` (incl. camelCase `apiKey`).
- Handles dict-repr (`'api_key': 'x'`), kwargs/model repr (`api_key='x'`), and JSON (`"api_key": "x"`), preserving quote style.
- Attached to the **logger** (not the handler) so redaction runs once, up front, for every downstream handler the record propagates to.

This is defense-in-depth layered on top of #293: call sites should still avoid logging secrets, but if one slips through in the future, the value never reaches log aggregation.

### Scope / limitations
- Scrubs **message text** only. Structured `extra={...}` fields are out of scope and should continue to use non-sensitive identifiers (e.g. `api_key_id`, not the key).
- Regex is best-effort (may over-redact a benign `token: foo`); it's a safety net, not a substitute for not logging secrets. The org-wide "all logs everywhere" backstop (Datadog Sensitive Data Scanner) is a separate infra follow-up.

## Tests

`tests/unit/utils/test_logging_redaction.py`:
- redacts the exact principal-dict shape that leaked; preserves `user_id` / `account_id`
- redacts kwargs / JSON / unquoted / camelCase / `token` / `secret` / `authorization` / `cookie` renderings
- leaves non-sensitive text untouched
- end-to-end: a `make_logger` logger masks the secret in captured output while keeping safe identifiers

`uv run ruff check`/`format` clean; `pytest` for the new file + #293's logging/request_utils tests = 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `SensitiveDataFilter` (attached at the logger level in `make_logger`) that rewrites rendered log messages to mask values following any key in `REQUEST_KEY_REGEXP_BLACKLIST` before any handler emits the record. The implementation is defense-in-depth on top of #293's call-site hardening.

- **`logging.py`**: New `redact_sensitive_text` helper and `SensitiveDataFilter` class share the existing `REQUEST_KEY_REGEXP_BLACKLIST` as the single source of truth; the compiled regex handles dict-repr, kwargs, JSON, and `Bearer`-prefixed authorization headers. The filter is a module-level singleton added idempotently to each `make_logger` logger.
- **`test_logging_redaction.py`**: 15 test cases cover the exact leaked principal shape, 10 common rendering variants (including camelCase, unquoted, and scheme-prefixed), a non-sensitive text preservation check, an over-redaction boundary test, and an end-to-end `make_logger`/`caplog` integration test.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The filter logic is correct, redaction is idempotent, and the regex handles all common credential-bearing log shapes including Bearer-prefixed headers.

The filter attaches cleanly to the logger before any handler runs, modifies record.msg and record.args in place so both plain and JSON formatters see the redacted text, and the idempotency check prevents double-attaching on repeated make_logger calls for the same name. No functional defect was found in the changed files.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/utils/logging.py | Adds SensitiveDataFilter and redact_sensitive_text; logically correct, idempotent singleton attachment; minor: redact_sensitive_text called outside the try/except guard. |
| agentex/tests/unit/utils/test_logging_redaction.py | New unit tests covering principal dict leak shape, 10 rendering variants, non-sensitive preservation, over-redaction boundary, and end-to-end caplog test; password and acting-user keys not explicitly parametrized. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fsrc%2Futils%2Flogging.py%3A76-86%0AThe%20%60try%2Fexcept%60%20around%20%60getMessage%28%29%60%20states%20%22Never%20let%20redaction%20break%20logging%20itself%22%2C%20but%20%60redact_sensitive_text%60%20is%20called%20outside%20that%20guard.%20If%20%60re.sub%60%20somehow%20raises%20%28e.g.%2C%20hitting%20a%20recursion-depth%20limit%20on%20a%20pathological%20log%20string%29%2C%20the%20exception%20propagates%20through%20the%20filter%20and%20crashes%20the%20calling%20log%20statement%20%E2%80%94%20the%20exact%20failure%20mode%20the%20comment%20promises%20to%20prevent.%0A%0A%60%60%60suggestion%0A%20%20%20%20def%20filter%28self%2C%20record%3A%20logging.LogRecord%29%20-%3E%20bool%3A%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20message%20%3D%20record.getMessage%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20redacted%20%3D%20redact_sensitive_text%28message%29%0A%20%20%20%20%20%20%20%20except%20Exception%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Never%20let%20redaction%20break%20logging%20itself.%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20True%0A%20%20%20%20%20%20%20%20if%20redacted%20!%3D%20message%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20record.msg%20%3D%20redacted%0A%20%20%20%20%20%20%20%20%20%20%20%20record.args%20%3D%20%28%29%0A%20%20%20%20%20%20%20%20return%20True%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Ftests%2Funit%2Futils%2Ftest_logging_redaction.py%3A34-50%0A%60password%60%20and%20%60acting-user%60%20are%20both%20in%20%60REQUEST_KEY_REGEXP_BLACKLIST%60%20and%20therefore%20in%20the%20compiled%20regex%2C%20but%20neither%20appears%20in%20the%20parametrize%20list.%20A%20future%20edit%20that%20accidentally%20drops%20one%20of%20those%20patterns%20from%20the%20blacklist%20would%20leave%20these%20redaction%20paths%20silently%20broken%20with%20no%20test%20to%20catch%20it.%0A%0A&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fsrc%2Futils%2Flogging.py%3A76-86%0AThe%20%60try%2Fexcept%60%20around%20%60getMessage%28%29%60%20states%20%22Never%20let%20redaction%20break%20logging%20itself%22%2C%20but%20%60redact_sensitive_text%60%20is%20called%20outside%20that%20guard.%20If%20%60re.sub%60%20somehow%20raises%20%28e.g.%2C%20hitting%20a%20recursion-depth%20limit%20on%20a%20pathological%20log%20string%29%2C%20the%20exception%20propagates%20through%20the%20filter%20and%20crashes%20the%20calling%20log%20statement%20%E2%80%94%20the%20exact%20failure%20mode%20the%20comment%20promises%20to%20prevent.%0A%0A%60%60%60suggestion%0A%20%20%20%20def%20filter%28self%2C%20record%3A%20logging.LogRecord%29%20-%3E%20bool%3A%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20message%20%3D%20record.getMessage%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20redacted%20%3D%20redact_sensitive_text%28message%29%0A%20%20%20%20%20%20%20%20except%20Exception%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Never%20let%20redaction%20break%20logging%20itself.%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20True%0A%20%20%20%20%20%20%20%20if%20redacted%20!%3D%20message%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20record.msg%20%3D%20redacted%0A%20%20%20%20%20%20%20%20%20%20%20%20record.args%20%3D%20%28%29%0A%20%20%20%20%20%20%20%20return%20True%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Ftests%2Funit%2Futils%2Ftest_logging_redaction.py%3A34-50%0A%60password%60%20and%20%60acting-user%60%20are%20both%20in%20%60REQUEST_KEY_REGEXP_BLACKLIST%60%20and%20therefore%20in%20the%20compiled%20regex%2C%20but%20neither%20appears%20in%20the%20parametrize%20list.%20A%20future%20edit%20that%20accidentally%20drops%20one%20of%20those%20patterns%20from%20the%20blacklist%20would%20leave%20these%20redaction%20paths%20silently%20broken%20with%20no%20test%20to%20catch%20it.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22dm%2Fredact-principal-context-logs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dm%2Fredact-principal-context-logs%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fsrc%2Futils%2Flogging.py%3A76-86%0AThe%20%60try%2Fexcept%60%20around%20%60getMessage%28%29%60%20states%20%22Never%20let%20redaction%20break%20logging%20itself%22%2C%20but%20%60redact_sensitive_text%60%20is%20called%20outside%20that%20guard.%20If%20%60re.sub%60%20somehow%20raises%20%28e.g.%2C%20hitting%20a%20recursion-depth%20limit%20on%20a%20pathological%20log%20string%29%2C%20the%20exception%20propagates%20through%20the%20filter%20and%20crashes%20the%20calling%20log%20statement%20%E2%80%94%20the%20exact%20failure%20mode%20the%20comment%20promises%20to%20prevent.%0A%0A%60%60%60suggestion%0A%20%20%20%20def%20filter%28self%2C%20record%3A%20logging.LogRecord%29%20-%3E%20bool%3A%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20message%20%3D%20record.getMessage%28%29%0A%20%20%20%20%20%20%20%20%20%20%20%20redacted%20%3D%20redact_sensitive_text%28message%29%0A%20%20%20%20%20%20%20%20except%20Exception%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Never%20let%20redaction%20break%20logging%20itself.%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20True%0A%20%20%20%20%20%20%20%20if%20redacted%20!%3D%20message%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20record.msg%20%3D%20redacted%0A%20%20%20%20%20%20%20%20%20%20%20%20record.args%20%3D%20%28%29%0A%20%20%20%20%20%20%20%20return%20True%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Ftests%2Funit%2Futils%2Ftest_logging_redaction.py%3A34-50%0A%60password%60%20and%20%60acting-user%60%20are%20both%20in%20%60REQUEST_KEY_REGEXP_BLACKLIST%60%20and%20therefore%20in%20the%20compiled%20regex%2C%20but%20neither%20appears%20in%20the%20parametrize%20list.%20A%20future%20edit%20that%20accidentally%20drops%20one%20of%20those%20patterns%20from%20the%20blacklist%20would%20leave%20these%20redaction%20paths%20silently%20broken%20with%20no%20test%20to%20catch%20it.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
agentex/src/utils/logging.py:76-86
The `try/except` around `getMessage()` states "Never let redaction break logging itself", but `redact_sensitive_text` is called outside that guard. If `re.sub` somehow raises (e.g., hitting a recursion-depth limit on a pathological log string), the exception propagates through the filter and crashes the calling log statement — the exact failure mode the comment promises to prevent.

```suggestion
    def filter(self, record: logging.LogRecord) -> bool:
        try:
            message = record.getMessage()
            redacted = redact_sensitive_text(message)
        except Exception:
            # Never let redaction break logging itself.
            return True
        if redacted != message:
            record.msg = redacted
            record.args = ()
        return True
```

### Issue 2 of 2
agentex/tests/unit/utils/test_logging_redaction.py:34-50
`password` and `acting-user` are both in `REQUEST_KEY_REGEXP_BLACKLIST` and therefore in the compiled regex, but neither appears in the parametrize list. A future edit that accidentally drops one of those patterns from the blacklist would leave these redaction paths silently broken with no test to catch it.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(agentex): redact secret values from ..."](https://github.com/scaleapi/scale-agentex/commit/05d2558e05496a934e9960c60b85e882853bed2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36534826)</sub>

<!-- /greptile_comment -->