### PR TITLE
fix: model principal context without api keys

### DIFF
--- a/agentex/src/adapters/authentication/adapter_agentex_authn_proxy.py
+++ b/agentex/src/adapters/authentication/adapter_agentex_authn_proxy.py
@@ -17,6 +17,7 @@ class AgentexAuthenticationProxy(AuthenticationGateway[AgentexAuthPrincipalConte
     async def verify_headers(
         self, headers: dict[str, str]
     ) -> AgentexAuthPrincipalContext:
-        return await HttpRequestHandler.post_with_error_handling(
+        response = await HttpRequestHandler.post_with_error_handling(
             self.agentex_auth_url, "/v1/authn", headers=headers
         )
+        return AgentexAuthPrincipalContext.model_validate(response)

--- a/agentex/src/adapters/authorization/adapter_agentex_authz_proxy.py
+++ b/agentex/src/adapters/authorization/adapter_agentex_authz_proxy.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import Depends
 from src.adapters.authorization.port import (
@@ -16,6 +16,16 @@ from src.config.environment_variables import EnvVarKeys
 from src.utils.http_request_handler import HttpRequestHandler
 
 
+def _principal_context_payload(
+    principal: AgentexAuthPrincipalContext | Any,
+) -> dict[str, Any] | None:
+    if principal is None:
+        return None
+    return AgentexAuthPrincipalContext.model_validate(principal).model_dump(
+        exclude_none=True
+    )
+
+
 class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext]):
     def __init__(
         self,
@@ -30,7 +40,7 @@ class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext
         operation: AuthorizedOperationType,
     ) -> None:
         payload = {
-            "principal": principal,
+            "principal": _principal_context_payload(principal),
             "resource": resource.model_dump(),
             "operation": operation,
         }
@@ -45,7 +55,7 @@ class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext
         operation: AuthorizedOperationType,
     ) -> None:
         payload = {
-            "principal": principal,
+            "principal": _principal_context_payload(principal),
             "resource": resource.model_dump(),
             "operation": operation,
         }
@@ -60,7 +70,7 @@ class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext
         operation: AuthorizedOperationType,
     ) -> bool:
         payload = {
-            "principal": principal,
+            "principal": _principal_context_payload(principal),
             "resource": resource.model_dump(),
             "operation": operation,
         }
@@ -76,7 +86,7 @@ class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext
         filter_operation: AuthorizedOperationType = AuthorizedOperationType.read,
     ) -> Iterable[str]:
         payload = {
-            "principal": principal,
+            "principal": _principal_context_payload(principal),
             "filter_resource": filter_resource,
             "filter_operation": filter_operation,
         }
@@ -92,7 +102,7 @@ class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext
         parent: AgentexResource | None = None,
     ) -> None:
         payload = {
-            "principal": principal,
+            "principal": _principal_context_payload(principal),
             "resource": resource.model_dump(),
             "parent": parent.model_dump() if parent is not None else None,
         }
@@ -106,7 +116,7 @@ class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext
         resource: AgentexResource,
     ) -> None:
         payload = {
-            "principal": principal,
+            "principal": _principal_context_payload(principal),
             "resource": resource.model_dump(),
         }
         await HttpRequestHandler.post_with_error_handling(

--- a/agentex/src/api/authentication_cache.py
+++ b/agentex/src/api/authentication_cache.py
@@ -7,6 +7,9 @@ import time
 from collections import OrderedDict
 from typing import Any
 
+from src.api.schemas.principal_context import (
+    remove_api_key_from_principal_context,
+)
 from src.utils.cache_metrics import record_cache_access, record_cache_eviction
 from src.utils.logging import make_logger
 
@@ -240,6 +243,7 @@ class AuthenticationCache:
         self, headers: dict[str, str], principal_context: Any
     ) -> None:
         """Cache auth gateway response."""
+        principal_context = remove_api_key_from_principal_context(principal_context)
         if self._contains_api_key(principal_context):
             logger.debug("Skipping auth gateway cache for API key principal")
             return
@@ -252,8 +256,24 @@ class AuthenticationCache:
         if principal_context is None:
             return False
         if isinstance(principal_context, dict):
-            return bool(principal_context.get("api_key"))
-        return bool(getattr(principal_context, "api_key", None))
+            return any(
+                (
+                    key.replace("_", "").replace("-", "").lower() == "apikey"
+                    if isinstance(key, str)
+                    else False
+                )
+                or AuthenticationCache._contains_api_key(value)
+                for key, value in principal_context.items()
+            )
+        if isinstance(principal_context, list | tuple):
+            return any(
+                AuthenticationCache._contains_api_key(value)
+                for value in principal_context
+            )
+        return bool(
+            getattr(principal_context, "api_key", None)
+            or getattr(principal_context, "apiKey", None)
+        )
 
     # Authorization Check Cache Methods (Async)
 

--- a/agentex/src/api/authentication_cache.py
+++ b/agentex/src/api/authentication_cache.py
@@ -7,9 +7,7 @@ import time
 from collections import OrderedDict
 from typing import Any
 
-from src.api.schemas.principal_context import (
-    remove_api_key_from_principal_context,
-)
+from src.api.schemas.principal_context import AgentexAuthPrincipalContext
 from src.utils.cache_metrics import record_cache_access, record_cache_eviction
 from src.utils.logging import make_logger
 
@@ -237,43 +235,19 @@ class AuthenticationCache:
         result = await self.auth_gateway_cache.get(f"gateway:{cache_key}")
         if result is not None:
             logger.debug("Cache hit for auth gateway")
-        return result
+            return AgentexAuthPrincipalContext.model_validate(result)
+        return None
 
     async def set_auth_gateway_response(
         self, headers: dict[str, str], principal_context: Any
     ) -> None:
         """Cache auth gateway response."""
-        principal_context = remove_api_key_from_principal_context(principal_context)
-        if self._contains_api_key(principal_context):
-            logger.debug("Skipping auth gateway cache for API key principal")
-            return
+        principal_context = AgentexAuthPrincipalContext.model_validate(
+            principal_context
+        )
         cache_key = self._create_headers_cache_key(headers)
         await self.auth_gateway_cache.set(f"gateway:{cache_key}", principal_context)
         logger.debug("Cached auth gateway response")
-
-    @staticmethod
-    def _contains_api_key(principal_context: Any) -> bool:
-        if principal_context is None:
-            return False
-        if isinstance(principal_context, dict):
-            return any(
-                (
-                    key.replace("_", "").replace("-", "").lower() == "apikey"
-                    if isinstance(key, str)
-                    else False
-                )
-                or AuthenticationCache._contains_api_key(value)
-                for key, value in principal_context.items()
-            )
-        if isinstance(principal_context, list | tuple):
-            return any(
-                AuthenticationCache._contains_api_key(value)
-                for value in principal_context
-            )
-        return bool(
-            getattr(principal_context, "api_key", None)
-            or getattr(principal_context, "apiKey", None)
-        )
 
     # Authorization Check Cache Methods (Async)
 
@@ -293,7 +267,10 @@ class AuthenticationCache:
         principal_key_data = {}
         if principal_context:
             # Handle different types of principal context
-            if hasattr(principal_context, "__dict__"):
+            model_dump = getattr(principal_context, "model_dump", None)
+            if callable(model_dump):
+                context_dict = model_dump(exclude_none=True)
+            elif hasattr(principal_context, "__dict__"):
                 # If it's an object with attributes
                 context_dict = principal_context.__dict__
             elif isinstance(principal_context, dict):

--- a/agentex/src/api/authentication_middleware.py
+++ b/agentex/src/api/authentication_middleware.py
@@ -19,7 +19,7 @@ from src.api.middleware_utils import (
     verify_agent_identity,
     verify_auth_gateway,
 )
-from src.api.schemas.principal_context import remove_api_key_from_principal_context
+from src.api.schemas.principal_context import AgentexAuthPrincipalContext
 from src.config.dependencies import (
     DEnvironmentVariable,
     resolve_environment_variable_dependency,
@@ -143,8 +143,8 @@ class AgentexAuthMiddleware(BaseHTTPMiddleware):
             # Check cache first
             cached_principal = await auth_cache.get_auth_gateway_response(headers_dict)
             if cached_principal is not None:
-                request.state.principal_context = remove_api_key_from_principal_context(
-                    cached_principal
+                request.state.principal_context = (
+                    AgentexAuthPrincipalContext.model_validate(cached_principal)
                 )
                 logger.debug("Auth gateway response found in cache")
                 return await call_next(request)

--- a/agentex/src/api/authentication_middleware.py
+++ b/agentex/src/api/authentication_middleware.py
@@ -19,6 +19,7 @@ from src.api.middleware_utils import (
     verify_agent_identity,
     verify_auth_gateway,
 )
+from src.api.schemas.principal_context import remove_api_key_from_principal_context
 from src.config.dependencies import (
     DEnvironmentVariable,
     resolve_environment_variable_dependency,
@@ -142,7 +143,9 @@ class AgentexAuthMiddleware(BaseHTTPMiddleware):
             # Check cache first
             cached_principal = await auth_cache.get_auth_gateway_response(headers_dict)
             if cached_principal is not None:
-                request.state.principal_context = cached_principal
+                request.state.principal_context = remove_api_key_from_principal_context(
+                    cached_principal
+                )
                 logger.debug("Auth gateway response found in cache")
                 return await call_next(request)
 

--- a/agentex/src/api/middleware_utils.py
+++ b/agentex/src/api/middleware_utils.py
@@ -8,6 +8,7 @@ from src.adapters.authentication.adapter_agentex_authn_proxy import (
     AgentexAuthenticationProxy,
 )
 from src.adapters.orm import AgentAPIKeyORM, AgentORM
+from src.api.schemas.principal_context import remove_api_key_from_principal_context
 from src.config.dependencies import middleware_async_read_only_session_maker
 from src.utils.logging import make_logger
 
@@ -138,7 +139,9 @@ async def verify_auth_gateway(
     headers_dict = get_request_headers_to_forward(request)
 
     try:
-        principal_context = await auth_gateway.verify_headers(headers_dict)
+        principal_context = remove_api_key_from_principal_context(
+            await auth_gateway.verify_headers(headers_dict)
+        )
         request.state.principal_context = principal_context
 
         # Get route information

--- a/agentex/src/api/middleware_utils.py
+++ b/agentex/src/api/middleware_utils.py
@@ -8,7 +8,7 @@ from src.adapters.authentication.adapter_agentex_authn_proxy import (
     AgentexAuthenticationProxy,
 )
 from src.adapters.orm import AgentAPIKeyORM, AgentORM
-from src.api.schemas.principal_context import remove_api_key_from_principal_context
+from src.api.schemas.principal_context import AgentexAuthPrincipalContext
 from src.config.dependencies import middleware_async_read_only_session_maker
 from src.utils.logging import make_logger
 
@@ -139,7 +139,7 @@ async def verify_auth_gateway(
     headers_dict = get_request_headers_to_forward(request)
 
     try:
-        principal_context = remove_api_key_from_principal_context(
+        principal_context = AgentexAuthPrincipalContext.model_validate(
             await auth_gateway.verify_headers(headers_dict)
         )
         request.state.principal_context = principal_context

--- a/agentex/src/api/schemas/principal_context.py
+++ b/agentex/src/api/schemas/principal_context.py
@@ -1,3 +1,47 @@
+from types import SimpleNamespace
 from typing import Any
 
 AgentexAuthPrincipalContext = Any
+
+
+def _is_api_key_field_name(field_name: Any) -> bool:
+    if not isinstance(field_name, str):
+        return False
+    return field_name.replace("_", "").replace("-", "").lower() == "apikey"
+
+
+def remove_api_key_from_principal_context(
+    principal_context: AgentexAuthPrincipalContext,
+) -> AgentexAuthPrincipalContext:
+    """Return a principal context with API-key secret fields removed."""
+    if isinstance(principal_context, dict):
+        return {
+            key: remove_api_key_from_principal_context(value)
+            for key, value in principal_context.items()
+            if not _is_api_key_field_name(key)
+        }
+
+    if isinstance(principal_context, list):
+        return [
+            remove_api_key_from_principal_context(value) for value in principal_context
+        ]
+
+    if isinstance(principal_context, tuple):
+        return tuple(
+            remove_api_key_from_principal_context(value) for value in principal_context
+        )
+
+    model_dump = getattr(principal_context, "model_dump", None)
+    if callable(model_dump):
+        return remove_api_key_from_principal_context(model_dump())
+
+    if hasattr(principal_context, "__dict__"):
+        return SimpleNamespace(
+            **{
+                key: remove_api_key_from_principal_context(value)
+                for key, value in vars(principal_context).items()
+                if not key.startswith("_") and not _is_api_key_field_name(key)
+            }
+        )
+
+    return principal_context

--- a/agentex/src/api/schemas/principal_context.py
+++ b/agentex/src/api/schemas/principal_context.py
@@ -1,7 +1,9 @@
-from types import SimpleNamespace
+from collections.abc import Mapping
 from typing import Any
 
-AgentexAuthPrincipalContext = Any
+from pydantic import ConfigDict, model_validator
+
+from src.utils.model_utils import BaseModel
 
 
 def _is_api_key_field_name(field_name: Any) -> bool:
@@ -10,38 +12,44 @@ def _is_api_key_field_name(field_name: Any) -> bool:
     return field_name.replace("_", "").replace("-", "").lower() == "apikey"
 
 
-def remove_api_key_from_principal_context(
-    principal_context: AgentexAuthPrincipalContext,
-) -> AgentexAuthPrincipalContext:
-    """Return a principal context with API-key secret fields removed."""
-    if isinstance(principal_context, dict):
-        return {
-            key: remove_api_key_from_principal_context(value)
-            for key, value in principal_context.items()
-            if not _is_api_key_field_name(key)
-        }
+class AgentexAuthPrincipalContext(BaseModel):
+    """Principal context passed through Agentex authz.
 
-    if isinstance(principal_context, list):
-        return [
-            remove_api_key_from_principal_context(value) for value in principal_context
-        ]
+    The authn service can return the credential used to authenticate the caller,
+    but Agentex only needs the resolved principal identifiers. Keep the API key
+    out of the base object entirely so it cannot be logged or forwarded through
+    authz payloads.
+    """
 
-    if isinstance(principal_context, tuple):
-        return tuple(
-            remove_api_key_from_principal_context(value) for value in principal_context
-        )
+    model_config = ConfigDict(
+        extra="allow",
+        from_attributes=True,
+        populate_by_name=True,
+    )
 
-    model_dump = getattr(principal_context, "model_dump", None)
-    if callable(model_dump):
-        return remove_api_key_from_principal_context(model_dump())
+    user_id: str | None = None
+    service_account_id: str | None = None
+    account_id: str | None = None
+    agent_id: str | None = None
+    id: str | None = None
+    sub: str | None = None
+    email: str | None = None
 
-    if hasattr(principal_context, "__dict__"):
-        return SimpleNamespace(
-            **{
-                key: remove_api_key_from_principal_context(value)
-                for key, value in vars(principal_context).items()
+    @model_validator(mode="before")
+    @classmethod
+    def remove_api_key(cls, data: Any) -> Any:
+        if isinstance(data, Mapping):
+            return {
+                key: value
+                for key, value in data.items()
+                if not _is_api_key_field_name(key)
+            }
+
+        if hasattr(data, "__dict__"):
+            return {
+                key: value
+                for key, value in vars(data).items()
                 if not key.startswith("_") and not _is_api_key_field_name(key)
             }
-        )
 
-    return principal_context
+        return data

--- a/agentex/src/domain/services/schedule_service.py
+++ b/agentex/src/domain/services/schedule_service.py
@@ -132,8 +132,8 @@ class ScheduleService:
         identity is resolvable and registration is skipped.
         """
         principal_context = self.authorization_service.principal_context
-        # principal_context is `Any` (a dict from /v1/authn), not a typed model,
-        # so getattr always yields None and silently skips the Spark register.
+        # Keep dict support for legacy tests/mocks; runtime authn normalizes
+        # this to an AgentexAuthPrincipalContext object.
         if isinstance(principal_context, dict):
             user_id = principal_context.get("user_id")
             service_account_id = principal_context.get("service_account_id")

--- a/agentex/src/domain/use_cases/agent_api_keys_use_case.py
+++ b/agentex/src/domain/use_cases/agent_api_keys_use_case.py
@@ -120,8 +120,8 @@ class AgentAPIKeysUseCase:
         persisted api key that cannot be authorized.
         """
         principal_context = self.authorization_service.principal_context
-        # principal_context is `Any` (a dict from /v1/authn), not a typed model,
-        # so getattr always yields None and silently skips the Spark register.
+        # Keep dict support for legacy tests/mocks; runtime authn normalizes
+        # this to an AgentexAuthPrincipalContext object.
         if isinstance(principal_context, dict):
             user_id = principal_context.get("user_id")
             service_account_id = principal_context.get("service_account_id")

--- a/agentex/src/domain/use_cases/agents_use_case.py
+++ b/agentex/src/domain/use_cases/agents_use_case.py
@@ -68,10 +68,8 @@ class AgentsUseCase:
         a resource it never registered.
         """
         principal_context = self.authorization_service.principal_context
-        # principal_context is `Any` (a dict from /v1/authn), not a typed model,
-        # so attribute access via getattr always yields None and silently skips
-        # the Spark resource registration. Read from the dict (fall back to attr
-        # access for any object-shaped principal).
+        # Keep dict support for legacy tests/mocks; runtime authn normalizes
+        # this to an AgentexAuthPrincipalContext object.
         if isinstance(principal_context, dict):
             user_id = principal_context.get("user_id")
             service_account_id = principal_context.get("service_account_id")

--- a/agentex/tests/unit/api/test_authentication_cache_metrics.py
+++ b/agentex/tests/unit/api/test_authentication_cache_metrics.py
@@ -94,11 +94,14 @@ def test_authentication_cache_assigns_distinct_names():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_auth_gateway_response_with_api_key_principal_is_not_cached():
+async def test_auth_gateway_response_with_api_key_principal_is_sanitized_before_cache():
     cache = AuthenticationCache()
     headers = {"x-api-key": "secret-key", "x-selected-account-id": "acct-1"}
     principal = {"user_id": "user-1", "account_id": "acct-1", "api_key": "secret-key"}
 
     await cache.set_auth_gateway_response(headers, principal)
 
-    assert await cache.get_auth_gateway_response(headers) is None
+    assert await cache.get_auth_gateway_response(headers) == {
+        "user_id": "user-1",
+        "account_id": "acct-1",
+    }

--- a/agentex/tests/unit/api/test_authentication_cache_metrics.py
+++ b/agentex/tests/unit/api/test_authentication_cache_metrics.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 from src.api.authentication_cache import AsyncTTLCache, AuthenticationCache
+from src.api.schemas.principal_context import AgentexAuthPrincipalContext
 
 
 @pytest.mark.unit
@@ -101,7 +102,10 @@ async def test_auth_gateway_response_with_api_key_principal_is_sanitized_before_
 
     await cache.set_auth_gateway_response(headers, principal)
 
-    assert await cache.get_auth_gateway_response(headers) == {
+    cached_principal = await cache.get_auth_gateway_response(headers)
+
+    assert isinstance(cached_principal, AgentexAuthPrincipalContext)
+    assert cached_principal.model_dump(exclude_none=True) == {
         "user_id": "user-1",
         "account_id": "acct-1",
     }

--- a/agentex/tests/unit/api/test_principal_context.py
+++ b/agentex/tests/unit/api/test_principal_context.py
@@ -21,6 +21,7 @@ def test_principal_context_model_removes_api_key_from_base_object():
     principal = AgentexAuthPrincipalContext.model_validate(principal_context)
 
     assert not hasattr(principal, "api_key")
+    assert "api_key" not in (principal.model_extra or {})
     assert principal.model_dump(exclude_none=True) == {
         "user_id": "user-1",
         "account_id": "acct-1",
@@ -38,6 +39,8 @@ def test_principal_context_model_removes_api_key_name_variants():
         }
     )
 
+    assert not hasattr(principal, "apiKey")
+    assert principal.model_extra == {}
     assert principal.model_dump(exclude_none=True) == {"user_id": "user-1"}
 
 
@@ -80,6 +83,7 @@ async def test_verify_auth_gateway_stores_sanitized_principal_context():
 
     assert response is None
     assert isinstance(request.state.principal_context, AgentexAuthPrincipalContext)
+    assert not hasattr(request.state.principal_context, "api_key")
     assert request.state.principal_context.model_dump(exclude_none=True) == {
         "user_id": "user-1",
         "account_id": "acct-1",

--- a/agentex/tests/unit/api/test_principal_context.py
+++ b/agentex/tests/unit/api/test_principal_context.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from src.api.middleware_utils import verify_auth_gateway
+from src.api.schemas.principal_context import remove_api_key_from_principal_context
+
+
+@pytest.mark.unit
+def test_remove_api_key_from_principal_context_removes_key_variants_recursively():
+    principal_context = {
+        "user_id": "user-1",
+        "account_id": "acct-1",
+        "api_key": "secret-1",
+        "nested": {
+            "apiKey": "secret-2",
+            "items": [{"api-key": "secret-3", "safe": "kept"}],
+        },
+    }
+
+    assert remove_api_key_from_principal_context(principal_context) == {
+        "user_id": "user-1",
+        "account_id": "acct-1",
+        "nested": {"items": [{"safe": "kept"}]},
+    }
+
+
+@pytest.mark.unit
+def test_remove_api_key_from_principal_context_preserves_object_shape():
+    principal_context = SimpleNamespace(
+        user_id="user-1",
+        account_id="acct-1",
+        api_key="secret",
+    )
+
+    sanitized = remove_api_key_from_principal_context(principal_context)
+
+    assert sanitized.user_id == "user-1"
+    assert sanitized.account_id == "acct-1"
+    assert not hasattr(sanitized, "api_key")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_verify_auth_gateway_stores_sanitized_principal_context():
+    request = SimpleNamespace(
+        headers={"x-api-key": "secret-key"},
+        state=SimpleNamespace(),
+        method="GET",
+        url=SimpleNamespace(path="/agents"),
+    )
+    auth_gateway = SimpleNamespace(
+        verify_headers=AsyncMock(
+            return_value={
+                "user_id": "user-1",
+                "account_id": "acct-1",
+                "api_key": "secret-key",
+            }
+        )
+    )
+
+    response = await verify_auth_gateway(request, auth_gateway)
+
+    assert response is None
+    assert request.state.principal_context == {
+        "user_id": "user-1",
+        "account_id": "acct-1",
+    }

--- a/agentex/tests/unit/api/test_principal_context.py
+++ b/agentex/tests/unit/api/test_principal_context.py
@@ -2,42 +2,59 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from src.adapters.authorization.adapter_agentex_authz_proxy import (
+    _principal_context_payload,
+)
 from src.api.middleware_utils import verify_auth_gateway
-from src.api.schemas.principal_context import remove_api_key_from_principal_context
+from src.api.schemas.principal_context import AgentexAuthPrincipalContext
 
 
 @pytest.mark.unit
-def test_remove_api_key_from_principal_context_removes_key_variants_recursively():
+def test_principal_context_model_removes_api_key_from_base_object():
     principal_context = {
         "user_id": "user-1",
         "account_id": "acct-1",
-        "api_key": "secret-1",
-        "nested": {
-            "apiKey": "secret-2",
-            "items": [{"api-key": "secret-3", "safe": "kept"}],
-        },
+        "api_key": "secret",
+        "workspace_id": "workspace-1",
     }
 
-    assert remove_api_key_from_principal_context(principal_context) == {
+    principal = AgentexAuthPrincipalContext.model_validate(principal_context)
+
+    assert not hasattr(principal, "api_key")
+    assert principal.model_dump(exclude_none=True) == {
         "user_id": "user-1",
         "account_id": "acct-1",
-        "nested": {"items": [{"safe": "kept"}]},
+        "workspace_id": "workspace-1",
     }
 
 
 @pytest.mark.unit
-def test_remove_api_key_from_principal_context_preserves_object_shape():
-    principal_context = SimpleNamespace(
-        user_id="user-1",
-        account_id="acct-1",
-        api_key="secret",
+def test_principal_context_model_removes_api_key_name_variants():
+    principal = AgentexAuthPrincipalContext.model_validate(
+        {
+            "user_id": "user-1",
+            "apiKey": "secret-1",
+            "api-key": "secret-2",
+        }
     )
 
-    sanitized = remove_api_key_from_principal_context(principal_context)
+    assert principal.model_dump(exclude_none=True) == {"user_id": "user-1"}
 
-    assert sanitized.user_id == "user-1"
-    assert sanitized.account_id == "acct-1"
-    assert not hasattr(sanitized, "api_key")
+
+@pytest.mark.unit
+def test_principal_context_payload_serializes_without_api_key():
+    payload = _principal_context_payload(
+        {
+            "user_id": "user-1",
+            "account_id": "acct-1",
+            "api_key": "secret-key",
+        }
+    )
+
+    assert payload == {
+        "user_id": "user-1",
+        "account_id": "acct-1",
+    }
 
 
 @pytest.mark.unit
@@ -62,7 +79,8 @@ async def test_verify_auth_gateway_stores_sanitized_principal_context():
     response = await verify_auth_gateway(request, auth_gateway)
 
     assert response is None
-    assert request.state.principal_context == {
+    assert isinstance(request.state.principal_context, AgentexAuthPrincipalContext)
+    assert request.state.principal_context.model_dump(exclude_none=True) == {
         "user_id": "user-1",
         "account_id": "acct-1",
     }


### PR DESCRIPTION
## Summary

- Define `AgentexAuthPrincipalContext` as a typed base model that omits API-key fields from the object itself.
- Normalize authn responses and cached auth gateway principals through that model before they reach request state.
- Serialize authz principal payloads from the typed model so API keys are not forwarded to authz.
- Add tests asserting `api_key`/`apiKey` are absent as object attributes and are not retained in model extras.

## Validation

- `uv run --project agentex ruff check agentex/src/api/schemas/principal_context.py agentex/src/adapters/authentication/adapter_agentex_authn_proxy.py agentex/src/adapters/authorization/adapter_agentex_authz_proxy.py agentex/src/api/middleware_utils.py agentex/src/api/authentication_middleware.py agentex/src/api/authentication_cache.py agentex/src/domain/services/schedule_service.py agentex/src/domain/use_cases/agent_api_keys_use_case.py agentex/src/domain/use_cases/agents_use_case.py agentex/tests/unit/api/test_principal_context.py agentex/tests/unit/api/test_authentication_cache_metrics.py`
- `uv run --project agentex --group test pytest agentex/tests/unit/api/test_principal_context.py agentex/tests/unit/api/test_authentication_cache_metrics.py`
- `uv run --project agentex python - <<'PY' ...` runtime check confirmed `hasattr(principal, "api_key") == False` and `model_extra == {}`
- `git diff --check`

## Notes

- `agentex/tests/integration/api/agents/test_agents_auth_api.py` was attempted but did not reach the changed code because local Docker/testcontainers setup could not connect to the Docker socket.
