### PR TITLE
fix(agentex): use deployment acp url for health workflow

### DIFF
--- a/agentex/src/domain/use_cases/agents_use_case.py
+++ b/agentex/src/domain/use_cases/agents_use_case.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import Depends
+from temporalio.common import WorkflowIDReusePolicy
 
 from src.adapters.crud_store.exceptions import DuplicateItemError, ItemDoesNotExist
 from src.adapters.temporal.adapter_temporal import DTemporalAdapter
@@ -111,7 +112,7 @@ class AgentsUseCase:
                 await self.complete_deployment_registration(
                     agent, acp_url, registration_metadata
                 )
-                await self.ensure_healthcheck_workflow(agent)
+                await self.ensure_healthcheck_workflow(agent, acp_url_override=acp_url)
                 return agent
 
             # Legacy flow: update the agent directly
@@ -145,7 +146,9 @@ class AgentsUseCase:
                     await self.complete_deployment_registration(
                         agent, acp_url, registration_metadata
                     )
-                    await self.ensure_healthcheck_workflow(agent)
+                    await self.ensure_healthcheck_workflow(
+                        agent, acp_url_override=acp_url
+                    )
                     return agent
 
                 # Legacy flow: update the agent directly
@@ -244,8 +247,8 @@ class AgentsUseCase:
 
         Unlike register_agent, this does NOT populate acp_url (there is no
         running pod yet) and leaves the agent in BUILD_ONLY status so it can be
-        permissioned/shared prior to deploy. Deploy-time registration later
-        flips the agent to READY and sets the acp_url.
+        permissioned/shared prior to deploy. Deployment-scoped registration
+        later records the acp_url on the deployment, not the parent agent.
 
         Idempotent: if an agent with the same name already exists, it is
         returned unchanged so that re-building an existing agent never clobbers
@@ -334,6 +337,7 @@ class AgentsUseCase:
     async def ensure_healthcheck_workflow(
         self,
         agent: AgentEntity,
+        acp_url_override: str | None = None,
     ) -> None:
         # Checking EnvironmentVariables here to allow turning this on and off without restarting the service
         environment_variables = EnvironmentVariables.refresh()
@@ -341,12 +345,16 @@ class AgentsUseCase:
             logger.info(f"Health check workflow is not enabled for {agent.id}")
             return
         try:
+            acp_url = (
+                acp_url_override if acp_url_override is not None else agent.acp_url
+            )
             # Start new health check workflow for this agent
             await self.temporal_adapter.start_workflow(
                 workflow_id=f"healthcheck_workflow_{agent.id}",
                 workflow=HealthCheckWorkflow,
-                args=[{"agent_id": agent.id, "acp_url": agent.acp_url}],
+                args=[{"agent_id": agent.id, "acp_url": acp_url}],
                 task_queue=environment_variables.AGENTEX_SERVER_TASK_QUEUE,
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
             )
             logger.info(f"Started new health check workflow for agent {agent.id}")
         except TemporalWorkflowAlreadyExistsError:

--- a/agentex/src/domain/use_cases/deployment_use_case.py
+++ b/agentex/src/domain/use_cases/deployment_use_case.py
@@ -2,12 +2,20 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import Depends
+from temporalio.common import WorkflowIDReusePolicy
 
 from src.adapters.crud_store.exceptions import ItemDoesNotExist
+from src.adapters.temporal.adapter_temporal import DTemporalAdapter
+from src.adapters.temporal.exceptions import (
+    TemporalWorkflowAlreadyExistsError,
+    TemporalWorkflowNotFoundError,
+)
+from src.config.environment_variables import EnvironmentVariables
 from src.domain.entities.deployments import DeploymentEntity, DeploymentStatus
 from src.domain.exceptions import ClientError
 from src.domain.repositories.agent_repository import DAgentRepository
 from src.domain.repositories.deployment_repository import DDeploymentRepository
+from src.temporal.workflows.healthcheck_workflow import HealthCheckWorkflow
 from src.utils.ids import orm_id
 from src.utils.logging import make_logger
 
@@ -19,9 +27,70 @@ class DeploymentUseCase:
         self,
         deployment_repository: DDeploymentRepository,
         agent_repository: DAgentRepository,
+        temporal_adapter: DTemporalAdapter,
     ):
         self.deployment_repo = deployment_repository
         self.agent_repo = agent_repository
+        self.temporal_adapter = temporal_adapter
+
+    async def restart_healthcheck_workflow_for_deployment(
+        self,
+        deployment: DeploymentEntity,
+    ) -> None:
+        environment_variables = EnvironmentVariables.refresh()
+        if not environment_variables.ENABLE_HEALTH_CHECK_WORKFLOW:
+            logger.info(
+                "Health check workflow is not enabled for promoted deployment %s",
+                deployment.id,
+            )
+            return
+        if not deployment.acp_url:
+            logger.warning(
+                "Promoted deployment %s has no acp_url; skipping health check workflow",
+                deployment.id,
+            )
+            return
+
+        workflow_id = f"healthcheck_workflow_{deployment.agent_id}"
+        try:
+            await self.temporal_adapter.terminate_workflow(
+                workflow_id=workflow_id,
+                reason=(
+                    "Restarting health check workflow for promoted deployment "
+                    f"{deployment.id}"
+                ),
+            )
+        except TemporalWorkflowNotFoundError:
+            logger.info("No existing health check workflow to restart: %s", workflow_id)
+        except Exception as e:
+            logger.error(
+                "Failed to terminate existing health check workflow %s: %s",
+                workflow_id,
+                e,
+            )
+
+        try:
+            await self.temporal_adapter.start_workflow(
+                workflow_id=workflow_id,
+                workflow=HealthCheckWorkflow,
+                args=[{"agent_id": deployment.agent_id, "acp_url": deployment.acp_url}],
+                task_queue=environment_variables.AGENTEX_SERVER_TASK_QUEUE,
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            )
+            logger.info(
+                "Started health check workflow %s for promoted deployment %s",
+                workflow_id,
+                deployment.id,
+            )
+        except TemporalWorkflowAlreadyExistsError:
+            logger.info("Health check workflow already exists: %s", workflow_id)
+        except Exception as e:
+            logger.error(
+                "Failed to start health check workflow %s for promoted deployment %s: %s",
+                workflow_id,
+                deployment.id,
+                e,
+            )
 
     async def create_deployment(
         self,
@@ -78,10 +147,12 @@ class DeploymentUseCase:
         deployment_id: str,
     ) -> DeploymentEntity:
         logger.info(f"Promoting deployment {deployment_id} for agent {agent_id}")
-        return await self.deployment_repo.promote(
+        deployment = await self.deployment_repo.promote(
             agent_id=agent_id,
             deployment_id=deployment_id,
         )
+        await self.restart_healthcheck_workflow_for_deployment(deployment)
+        return deployment
 
     async def delete_deployment(
         self,

--- a/agentex/src/domain/use_cases/deployment_use_case.py
+++ b/agentex/src/domain/use_cases/deployment_use_case.py
@@ -2,12 +2,20 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import Depends
+from temporalio.common import WorkflowIDReusePolicy
 
 from src.adapters.crud_store.exceptions import ItemDoesNotExist
+from src.adapters.temporal.adapter_temporal import DTemporalAdapter
+from src.adapters.temporal.exceptions import (
+    TemporalWorkflowAlreadyExistsError,
+    TemporalWorkflowNotFoundError,
+)
+from src.config.environment_variables import EnvironmentVariables
 from src.domain.entities.deployments import DeploymentEntity, DeploymentStatus
 from src.domain.exceptions import ClientError
 from src.domain.repositories.agent_repository import DAgentRepository
 from src.domain.repositories.deployment_repository import DDeploymentRepository
+from src.temporal.workflows.healthcheck_workflow import HealthCheckWorkflow
 from src.utils.ids import orm_id
 from src.utils.logging import make_logger
 
@@ -19,9 +27,79 @@ class DeploymentUseCase:
         self,
         deployment_repository: DDeploymentRepository,
         agent_repository: DAgentRepository,
+        temporal_adapter: DTemporalAdapter,
     ):
         self.deployment_repo = deployment_repository
         self.agent_repo = agent_repository
+        self.temporal_adapter = temporal_adapter
+
+    async def restart_healthcheck_workflow_for_deployment(
+        self,
+        deployment: DeploymentEntity,
+    ) -> None:
+        environment_variables = EnvironmentVariables.refresh()
+        if not environment_variables.ENABLE_HEALTH_CHECK_WORKFLOW:
+            logger.info(
+                "Health check workflow is not enabled for promoted deployment %s",
+                deployment.id,
+            )
+            return
+        if not deployment.acp_url:
+            logger.warning(
+                "Promoted deployment %s has no acp_url; skipping health check workflow",
+                deployment.id,
+            )
+            return
+
+        workflow_id = f"healthcheck_workflow_{deployment.agent_id}"
+        try:
+            await self.temporal_adapter.terminate_workflow(
+                workflow_id=workflow_id,
+                reason=(
+                    "Restarting health check workflow for promoted deployment "
+                    f"{deployment.id}"
+                ),
+            )
+        except TemporalWorkflowNotFoundError:
+            logger.info("No existing health check workflow to restart: %s", workflow_id)
+        except Exception as e:
+            error_detail = getattr(e, "detail", None)
+            error_text = f"{e} {error_detail or ''}".lower()
+            if "already completed" in error_text:
+                logger.info(
+                    "Existing health check workflow already completed: %s",
+                    workflow_id,
+                )
+            else:
+                logger.error(
+                    "Failed to terminate existing health check workflow %s: %s",
+                    workflow_id,
+                    e,
+                )
+                return
+
+        try:
+            await self.temporal_adapter.start_workflow(
+                workflow_id=workflow_id,
+                workflow=HealthCheckWorkflow,
+                args=[{"agent_id": deployment.agent_id, "acp_url": deployment.acp_url}],
+                task_queue=environment_variables.AGENTEX_SERVER_TASK_QUEUE,
+                id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            )
+            logger.info(
+                "Started health check workflow %s for promoted deployment %s",
+                workflow_id,
+                deployment.id,
+            )
+        except TemporalWorkflowAlreadyExistsError:
+            logger.info("Health check workflow already exists: %s", workflow_id)
+        except Exception as e:
+            logger.error(
+                "Failed to start health check workflow %s for promoted deployment %s: %s",
+                workflow_id,
+                deployment.id,
+                e,
+            )
 
     async def create_deployment(
         self,
@@ -78,10 +156,12 @@ class DeploymentUseCase:
         deployment_id: str,
     ) -> DeploymentEntity:
         logger.info(f"Promoting deployment {deployment_id} for agent {agent_id}")
-        return await self.deployment_repo.promote(
+        deployment = await self.deployment_repo.promote(
             agent_id=agent_id,
             deployment_id=deployment_id,
         )
+        await self.restart_healthcheck_workflow_for_deployment(deployment)
+        return deployment
 
     async def delete_deployment(
         self,

--- a/agentex/tests/unit/use_cases/test_agents_use_case.py
+++ b/agentex/tests/unit/use_cases/test_agents_use_case.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import pytest
 from src.adapters.temporal.adapter_temporal import TemporalAdapter
+from src.config.environment_variables import EnvironmentVariables
 from src.domain.entities.agents import ACPType, AgentEntity, AgentStatus
 from src.domain.entities.deployments import DeploymentEntity, DeploymentStatus
 from src.domain.repositories.agent_repository import AgentRepository
@@ -32,6 +33,15 @@ def deployment_history_repository(postgres_session_maker):
 @pytest.fixture
 def temporal_adapter():
     return AsyncMock(spec=TemporalAdapter)
+
+
+@pytest.fixture
+def enable_health_check_workflow(monkeypatch):
+    monkeypatch.setenv("ENABLE_HEALTH_CHECK_WORKFLOW", "true")
+    monkeypatch.setenv("AGENTEX_SERVER_TASK_QUEUE", "agentex-server")
+    EnvironmentVariables.clear_cache()
+    yield
+    EnvironmentVariables.clear_cache()
 
 
 @pytest.fixture
@@ -196,3 +206,46 @@ async def test_deployment_aware_register_on_legacy_agent_does_not_auto_promote(
     assert refreshed_agent.acp_url == "http://legacy.example.com"
     assert deployment.is_production is False
     assert deployment.acp_url == "http://preview.example.com"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("register_by_id", [False, True])
+async def test_deployment_aware_register_uses_deployment_acp_url_for_healthcheck(
+    agents_use_case,
+    agent_repository,
+    deployment_repository,
+    temporal_adapter,
+    enable_health_check_workflow,
+    register_by_id,
+):
+    name = f"build-only-deployment-aware-{uuid4().hex[:8]}"
+    deployment_id = str(uuid4())
+    deployment_acp_url = "http://deployment.example.com"
+    build_only_agent = await agents_use_case.register_build(
+        name=name,
+        description="build-only agent",
+    )
+    temporal_adapter.start_workflow.reset_mock()
+
+    await agents_use_case.register_agent(
+        name=name,
+        description="build-only agent",
+        acp_url=deployment_acp_url,
+        agent_id=build_only_agent.id if register_by_id else None,
+        acp_type=ACPType.ASYNC,
+        registration_metadata={
+            "deployment_id": deployment_id,
+            "docker_image": "example:preview",
+        },
+    )
+
+    refreshed_agent = await agent_repository.get(id=build_only_agent.id)
+    deployment = await deployment_repository.get(id=deployment_id)
+
+    assert refreshed_agent.acp_url is None
+    assert deployment.acp_url == deployment_acp_url
+    temporal_adapter.start_workflow.assert_awaited_once()
+    assert temporal_adapter.start_workflow.await_args.kwargs["args"] == [
+        {"agent_id": build_only_agent.id, "acp_url": deployment_acp_url}
+    ]

--- a/agentex/tests/unit/use_cases/test_deployment_use_case.py
+++ b/agentex/tests/unit/use_cases/test_deployment_use_case.py
@@ -1,0 +1,130 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from src.adapters.temporal.adapter_temporal import TemporalAdapter
+from src.adapters.temporal.exceptions import TemporalWorkflowNotFoundError
+from src.config.environment_variables import EnvironmentVariables
+from src.domain.entities.deployments import DeploymentEntity, DeploymentStatus
+from src.domain.use_cases.deployment_use_case import DeploymentUseCase
+from src.temporal.workflows.healthcheck_workflow import HealthCheckWorkflow
+from temporalio.common import WorkflowIDReusePolicy
+
+
+@pytest.fixture
+def enable_health_check_workflow(monkeypatch):
+    monkeypatch.setenv("ENABLE_HEALTH_CHECK_WORKFLOW", "true")
+    monkeypatch.setenv("AGENTEX_SERVER_TASK_QUEUE", "agentex-server")
+    EnvironmentVariables.clear_cache()
+    yield
+    EnvironmentVariables.clear_cache()
+
+
+@pytest.fixture
+def deployment_repository():
+    return AsyncMock()
+
+
+@pytest.fixture
+def agent_repository():
+    return AsyncMock()
+
+
+@pytest.fixture
+def temporal_adapter():
+    return AsyncMock(spec=TemporalAdapter)
+
+
+@pytest.fixture
+def deployment_use_case(
+    deployment_repository,
+    agent_repository,
+    temporal_adapter,
+):
+    return DeploymentUseCase(
+        deployment_repository=deployment_repository,
+        agent_repository=agent_repository,
+        temporal_adapter=temporal_adapter,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_promote_deployment_restarts_healthcheck_with_promoted_acp_url(
+    deployment_use_case,
+    deployment_repository,
+    temporal_adapter,
+    enable_health_check_workflow,
+):
+    agent_id = str(uuid4())
+    deployment_id = str(uuid4())
+    acp_url = "http://promoted.example.com"
+    deployment_repository.promote.return_value = DeploymentEntity(
+        id=deployment_id,
+        agent_id=agent_id,
+        docker_image="example:prod",
+        status=DeploymentStatus.READY,
+        acp_url=acp_url,
+        is_production=True,
+    )
+
+    promoted = await deployment_use_case.promote_deployment(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+    )
+
+    assert promoted.id == deployment_id
+    deployment_repository.promote.assert_awaited_once_with(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+    )
+    temporal_adapter.terminate_workflow.assert_awaited_once_with(
+        workflow_id=f"healthcheck_workflow_{agent_id}",
+        reason=(
+            f"Restarting health check workflow for promoted deployment {deployment_id}"
+        ),
+    )
+    temporal_adapter.start_workflow.assert_awaited_once_with(
+        workflow_id=f"healthcheck_workflow_{agent_id}",
+        workflow=HealthCheckWorkflow,
+        args=[{"agent_id": agent_id, "acp_url": acp_url}],
+        task_queue="agentex-server",
+        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_promote_deployment_starts_healthcheck_when_existing_workflow_missing(
+    deployment_use_case,
+    deployment_repository,
+    temporal_adapter,
+    enable_health_check_workflow,
+):
+    agent_id = str(uuid4())
+    deployment_id = str(uuid4())
+    acp_url = "http://promoted.example.com"
+    deployment_repository.promote.return_value = DeploymentEntity(
+        id=deployment_id,
+        agent_id=agent_id,
+        docker_image="example:prod",
+        status=DeploymentStatus.READY,
+        acp_url=acp_url,
+        is_production=True,
+    )
+    temporal_adapter.terminate_workflow.side_effect = TemporalWorkflowNotFoundError(
+        message="not found"
+    )
+
+    await deployment_use_case.promote_deployment(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+    )
+
+    temporal_adapter.start_workflow.assert_awaited_once_with(
+        workflow_id=f"healthcheck_workflow_{agent_id}",
+        workflow=HealthCheckWorkflow,
+        args=[{"agent_id": agent_id, "acp_url": acp_url}],
+        task_queue="agentex-server",
+        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+    )

--- a/agentex/tests/unit/use_cases/test_deployment_use_case.py
+++ b/agentex/tests/unit/use_cases/test_deployment_use_case.py
@@ -1,0 +1,196 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from src.adapters.temporal.adapter_temporal import TemporalAdapter
+from src.adapters.temporal.exceptions import TemporalWorkflowNotFoundError
+from src.config.environment_variables import EnvironmentVariables
+from src.domain.entities.deployments import DeploymentEntity, DeploymentStatus
+from src.domain.use_cases.deployment_use_case import DeploymentUseCase
+from src.temporal.workflows.healthcheck_workflow import HealthCheckWorkflow
+from temporalio.common import WorkflowIDReusePolicy
+
+
+@pytest.fixture
+def enable_health_check_workflow(monkeypatch):
+    monkeypatch.setenv("ENABLE_HEALTH_CHECK_WORKFLOW", "true")
+    monkeypatch.setenv("AGENTEX_SERVER_TASK_QUEUE", "agentex-server")
+    EnvironmentVariables.clear_cache()
+    yield
+    EnvironmentVariables.clear_cache()
+
+
+@pytest.fixture
+def deployment_repository():
+    return AsyncMock()
+
+
+@pytest.fixture
+def agent_repository():
+    return AsyncMock()
+
+
+@pytest.fixture
+def temporal_adapter():
+    return AsyncMock(spec=TemporalAdapter)
+
+
+@pytest.fixture
+def deployment_use_case(
+    deployment_repository,
+    agent_repository,
+    temporal_adapter,
+):
+    return DeploymentUseCase(
+        deployment_repository=deployment_repository,
+        agent_repository=agent_repository,
+        temporal_adapter=temporal_adapter,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_promote_deployment_restarts_healthcheck_with_promoted_acp_url(
+    deployment_use_case,
+    deployment_repository,
+    temporal_adapter,
+    enable_health_check_workflow,
+):
+    agent_id = str(uuid4())
+    deployment_id = str(uuid4())
+    acp_url = "http://promoted.example.com"
+    deployment_repository.promote.return_value = DeploymentEntity(
+        id=deployment_id,
+        agent_id=agent_id,
+        docker_image="example:prod",
+        status=DeploymentStatus.READY,
+        acp_url=acp_url,
+        is_production=True,
+    )
+
+    promoted = await deployment_use_case.promote_deployment(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+    )
+
+    assert promoted.id == deployment_id
+    deployment_repository.promote.assert_awaited_once_with(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+    )
+    temporal_adapter.terminate_workflow.assert_awaited_once_with(
+        workflow_id=f"healthcheck_workflow_{agent_id}",
+        reason=(
+            f"Restarting health check workflow for promoted deployment {deployment_id}"
+        ),
+    )
+    temporal_adapter.start_workflow.assert_awaited_once_with(
+        workflow_id=f"healthcheck_workflow_{agent_id}",
+        workflow=HealthCheckWorkflow,
+        args=[{"agent_id": agent_id, "acp_url": acp_url}],
+        task_queue="agentex-server",
+        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_promote_deployment_starts_healthcheck_when_existing_workflow_missing(
+    deployment_use_case,
+    deployment_repository,
+    temporal_adapter,
+    enable_health_check_workflow,
+):
+    agent_id = str(uuid4())
+    deployment_id = str(uuid4())
+    acp_url = "http://promoted.example.com"
+    deployment_repository.promote.return_value = DeploymentEntity(
+        id=deployment_id,
+        agent_id=agent_id,
+        docker_image="example:prod",
+        status=DeploymentStatus.READY,
+        acp_url=acp_url,
+        is_production=True,
+    )
+    temporal_adapter.terminate_workflow.side_effect = TemporalWorkflowNotFoundError(
+        message="not found"
+    )
+
+    await deployment_use_case.promote_deployment(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+    )
+
+    temporal_adapter.start_workflow.assert_awaited_once_with(
+        workflow_id=f"healthcheck_workflow_{agent_id}",
+        workflow=HealthCheckWorkflow,
+        args=[{"agent_id": agent_id, "acp_url": acp_url}],
+        task_queue="agentex-server",
+        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_promote_deployment_does_not_start_healthcheck_when_terminate_fails(
+    deployment_use_case,
+    deployment_repository,
+    temporal_adapter,
+    enable_health_check_workflow,
+):
+    agent_id = str(uuid4())
+    deployment_id = str(uuid4())
+    deployment_repository.promote.return_value = DeploymentEntity(
+        id=deployment_id,
+        agent_id=agent_id,
+        docker_image="example:prod",
+        status=DeploymentStatus.READY,
+        acp_url="http://promoted.example.com",
+        is_production=True,
+    )
+    temporal_adapter.terminate_workflow.side_effect = RuntimeError("network error")
+
+    await deployment_use_case.promote_deployment(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+    )
+
+    temporal_adapter.terminate_workflow.assert_awaited_once()
+    temporal_adapter.start_workflow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_promote_deployment_starts_healthcheck_when_existing_workflow_completed(
+    deployment_use_case,
+    deployment_repository,
+    temporal_adapter,
+    enable_health_check_workflow,
+):
+    agent_id = str(uuid4())
+    deployment_id = str(uuid4())
+    acp_url = "http://promoted.example.com"
+    deployment_repository.promote.return_value = DeploymentEntity(
+        id=deployment_id,
+        agent_id=agent_id,
+        docker_image="example:prod",
+        status=DeploymentStatus.READY,
+        acp_url=acp_url,
+        is_production=True,
+    )
+    temporal_adapter.terminate_workflow.side_effect = RuntimeError(
+        "workflow execution already completed"
+    )
+
+    await deployment_use_case.promote_deployment(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+    )
+
+    temporal_adapter.start_workflow.assert_awaited_once_with(
+        workflow_id=f"healthcheck_workflow_{agent_id}",
+        workflow=HealthCheckWorkflow,
+        args=[{"agent_id": agent_id, "acp_url": acp_url}],
+        task_queue="agentex-server",
+        id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+    )


### PR DESCRIPTION
## Summary
- pass deployment-scoped register acp_url into the health check workflow for preview deployments
- restart the agent-level health check workflow with the promoted deployment URL on promotion
- allow health workflow ID reuse so a registration or promotion can start a new workflow after a prior unhealthy workflow completed
- keep parent agent acp_url unchanged during preview registration; deployment rows remain the preview source until promotion
- add unit coverage for build-only deployment registration and promotion health workflow behavior

## Root Cause
Build-only agents created by register_build have no agent.acp_url. Deployment-scoped register updates deployments.acp_url, but the health workflow was started from agent.acp_url, so it could poll None and mark an otherwise reachable deployment unhealthy. Promotion also updated agent.acp_url but did not refresh a running health workflow, so promoting a different deployment could leave the workflow polling a stale URL.

## Validation
```
uv run ruff check src/domain/use_cases/agents_use_case.py src/domain/use_cases/deployment_use_case.py tests/unit/use_cases/test_agents_use_case.py tests/unit/use_cases/test_deployment_use_case.py
uv run ruff format --check src/domain/use_cases/agents_use_case.py src/domain/use_cases/deployment_use_case.py tests/unit/use_cases/test_agents_use_case.py tests/unit/use_cases/test_deployment_use_case.py
uv run python scripts/run_tests.py tests/unit/use_cases/test_deployment_use_case.py --no-docker-setup
DOCKER_HOST=unix:///Users/ronak.patel/.rd/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock TESTCONTAINERS_HOST_OVERRIDE=127.0.0.1 TESTCONTAINERS_RYUK_DISABLED=true uv run python scripts/run_tests.py tests/unit/use_cases/test_agents_use_case.py --no-docker-setup
DOCKER_HOST=unix:///Users/ronak.patel/.rd/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock TESTCONTAINERS_HOST_OVERRIDE=127.0.0.1 TESTCONTAINERS_RYUK_DISABLED=true uv run python scripts/run_tests.py tests/integration/api/agents/test_agents_api.py::TestAgentsAPIIntegration::test_build_only_agent_promoted_to_ready_via_deployment --no-docker-setup
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes health check workflow polling issues for build-only agents and promoted deployments. `ensure_healthcheck_workflow` now accepts an `acp_url_override` so deployment-scoped registrations use the deployment's URL instead of `agent.acp_url` (which is `None` for build-only agents). A new `restart_healthcheck_workflow_for_deployment` method terminates any running workflow before starting a fresh one with the promoted deployment's URL. `WorkflowIDReusePolicy.ALLOW_DUPLICATE` is added to both start sites so a health check can be restarted after a prior run ended (e.g., the agent was marked unhealthy).

- **Registration fix**: `ensure_healthcheck_workflow` now receives the deployment-scoped `acp_url` as an override when `deployment_id` is present, preventing the workflow from polling `None` for build-only agents.
- **Promotion fix**: `promote_deployment` now terminates any stale health check workflow and starts a new one targeting the promoted deployment's URL; failures during terminate (non-fatal `"already completed"` case) are handled via string-matching before proceeding.
- **Test coverage**: New unit tests in `test_deployment_use_case.py` cover terminate→start, missing workflow, failed terminate (no start), and already-completed-workflow paths; `test_agents_use_case.py` gains a parametrised test verifying the deployment URL reaches the workflow args.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge. The fixes are well-scoped, both use cases are independently tested, and error paths in the terminate-then-start flow correctly guard against starting a new workflow when the old one cannot be confirmed as gone.

Both new code paths (deployment-scoped `acp_url_override` and `restart_healthcheck_workflow_for_deployment`) have direct unit test coverage. The `ALLOW_DUPLICATE` policy change is additive and only affects the no-prior-workflow or prior-completed-workflow cases. The one stale comment is cosmetic and carries no runtime risk.

No files require special attention. The "already completed" string-match detection in `deployment_use_case.py` is worth monitoring if Temporal SDK error formats change, but it has a safe fallthrough and is covered by a dedicated test.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/deployment_use_case.py | New `restart_healthcheck_workflow_for_deployment` method adds terminate-then-start logic with correct `ALLOW_DUPLICATE` policy; fallthrough to `start_workflow` is correctly guarded by `return` on unexpected terminate errors. Minor: "already completed" detection relies on case-insensitive string matching on the exception message, which could silently miss new Temporal error formats. |
| agentex/src/domain/use_cases/agents_use_case.py | Adds `acp_url_override` to `ensure_healthcheck_workflow` and threads the deployment URL through both deployment-scoped registration branches; adds `ALLOW_DUPLICATE` to allow restart after a completed workflow run. Stale comment on the `TemporalWorkflowAlreadyExistsError` catch. |
| agentex/tests/unit/use_cases/test_deployment_use_case.py | New test file with four scenarios for `restart_healthcheck_workflow_for_deployment`: happy path, missing workflow, failed terminate (asserts start is not called), and already-completed workflow — good coverage of all branches. |
| agentex/tests/unit/use_cases/test_agents_use_case.py | Adds `enable_health_check_workflow` fixture and a parametrised test confirming the deployment `acp_url` (not `agent.acp_url`) reaches the workflow start args; fixture cleans up env cache correctly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AgentsUseCase
    participant DeploymentUseCase
    participant DeploymentRepo
    participant TemporalAdapter
    participant HealthCheckWorkflow

    Note over Client,HealthCheckWorkflow: Build-only deployment registration
    Client->>AgentsUseCase: register_agent(name, acp_url, deployment_id)
    AgentsUseCase->>AgentsUseCase: complete_deployment_registration(agent, acp_url)
    AgentsUseCase->>AgentsUseCase: "ensure_healthcheck_workflow(agent, acp_url_override=acp_url)"
    AgentsUseCase->>TemporalAdapter: "start_workflow(id=healthcheck_{agent_id}, acp_url=deployment_url, ALLOW_DUPLICATE)"
    TemporalAdapter-->>HealthCheckWorkflow: starts polling deployment_url

    Note over Client,HealthCheckWorkflow: Promotion flow
    Client->>DeploymentUseCase: promote_deployment(agent_id, deployment_id)
    DeploymentUseCase->>DeploymentRepo: promote(agent_id, deployment_id)
    DeploymentRepo-->>DeploymentUseCase: promoted DeploymentEntity (with acp_url)
    DeploymentUseCase->>DeploymentUseCase: restart_healthcheck_workflow_for_deployment(deployment)
    DeploymentUseCase->>TemporalAdapter: "terminate_workflow(id=healthcheck_{agent_id})"
    alt workflow found and running
        TemporalAdapter-->>DeploymentUseCase: ok
    else TemporalWorkflowNotFoundError
        TemporalAdapter-->>DeploymentUseCase: not found (logged, continue)
    else already completed error
        TemporalAdapter-->>DeploymentUseCase: completed (logged, continue)
    else other error
        TemporalAdapter-->>DeploymentUseCase: error - return early (no start)
    end
    DeploymentUseCase->>TemporalAdapter: "start_workflow(id=healthcheck_{agent_id}, acp_url=promoted_url, ALLOW_DUPLICATE)"
    TemporalAdapter-->>HealthCheckWorkflow: starts polling promoted_url
    DeploymentUseCase-->>Client: promoted deployment
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fagents_use_case.py%3A360-362%0AThe%20comment%20%22Only%20expected%20for%20new%20registrations%22%20is%20no%20longer%20accurate.%20With%20%60ALLOW_DUPLICATE%60%2C%20this%20exception%20is%20raised%20whenever%20a%20workflow%20with%20the%20same%20ID%20is%20**currently%20running**%20%E2%80%94%20which%20can%20happen%20during%20any%20re-registration%2C%20not%20just%20new%20ones.%20The%20misleading%20comment%20could%20confuse%20someone%20debugging%20a%20case%20where%20a%20running%20workflow%20silently%20keeps%20its%20old%20URL.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20except%20TemporalWorkflowAlreadyExistsError%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Workflow%20with%20this%20ID%20is%20already%20running%3B%20leave%20it%20in%20place%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.info%28%0A%60%60%60%0A%0A&pr=297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fagents_use_case.py%3A360-362%0AThe%20comment%20%22Only%20expected%20for%20new%20registrations%22%20is%20no%20longer%20accurate.%20With%20%60ALLOW_DUPLICATE%60%2C%20this%20exception%20is%20raised%20whenever%20a%20workflow%20with%20the%20same%20ID%20is%20**currently%20running**%20%E2%80%94%20which%20can%20happen%20during%20any%20re-registration%2C%20not%20just%20new%20ones.%20The%20misleading%20comment%20could%20confuse%20someone%20debugging%20a%20case%20where%20a%20running%20workflow%20silently%20keeps%20its%20old%20URL.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20except%20TemporalWorkflowAlreadyExistsError%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Workflow%20with%20this%20ID%20is%20already%20running%3B%20leave%20it%20in%20place%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.info%28%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22codex%2Ffix-healthcheck-deployment-acp-url%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-healthcheck-deployment-acp-url%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fagents_use_case.py%3A360-362%0AThe%20comment%20%22Only%20expected%20for%20new%20registrations%22%20is%20no%20longer%20accurate.%20With%20%60ALLOW_DUPLICATE%60%2C%20this%20exception%20is%20raised%20whenever%20a%20workflow%20with%20the%20same%20ID%20is%20**currently%20running**%20%E2%80%94%20which%20can%20happen%20during%20any%20re-registration%2C%20not%20just%20new%20ones.%20The%20misleading%20comment%20could%20confuse%20someone%20debugging%20a%20case%20where%20a%20running%20workflow%20silently%20keeps%20its%20old%20URL.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20except%20TemporalWorkflowAlreadyExistsError%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%23%20Workflow%20with%20this%20ID%20is%20already%20running%3B%20leave%20it%20in%20place%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.info%28%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex/src/domain/use_cases/agents_use_case.py:360-362
The comment "Only expected for new registrations" is no longer accurate. With `ALLOW_DUPLICATE`, this exception is raised whenever a workflow with the same ID is **currently running** — which can happen during any re-registration, not just new ones. The misleading comment could confuse someone debugging a case where a running workflow silently keeps its old URL.

```suggestion
        except TemporalWorkflowAlreadyExistsError:
            # Workflow with this ID is already running; leave it in place
            logger.info(
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/cod..."](https://github.com/scaleapi/scale-agentex/commit/c212b1539ef449507e633dfdb042d90438df48ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36732034)</sub>

<!-- /greptile_comment -->