### PR TITLE
fix(authz): preserve 403 for readable resources

### DIFF
--- a/agentex/src/utils/agent_api_key_authorization.py
+++ b/agentex/src/utils/agent_api_key_authorization.py
@@ -1,8 +1,9 @@
-from src.adapters.authorization.exceptions import AuthorizationError
-from src.adapters.crud_store.exceptions import ItemDoesNotExist
 from src.api.schemas.authorization_types import (
     AgentexResource,
     AuthorizedOperationType,
+)
+from src.utils.visibility_authorization import (
+    check_resource_or_collapse_unreadable_to_404,
 )
 
 # Identifier-free 404 detail, reused by the denied-resource branch below and
@@ -15,15 +16,10 @@ async def _check_api_key_or_collapse_to_404(
     api_key_id: str,
     operation: AuthorizedOperationType,
 ) -> None:
-    """Check an api_key resource; collapse any denial to 404 to avoid leaking
-    cross-tenant existence. Mirrors ``_check_task_or_collapse_to_404``.
-
-    TODO: Restore the 403/404 split once api_keys carry tenant scope.
-    """
-    try:
-        await authorization.check(
-            resource=AgentexResource.api_key(api_key_id),
-            operation=operation,
-        )
-    except AuthorizationError:
-        raise ItemDoesNotExist(API_KEY_NOT_FOUND_MESSAGE) from None
+    """Check an api_key resource while hiding unreadable api_keys."""
+    await check_resource_or_collapse_unreadable_to_404(
+        authorization=authorization,
+        resource=AgentexResource.api_key(api_key_id),
+        operation=operation,
+        not_found_message=API_KEY_NOT_FOUND_MESSAGE,
+    )

--- a/agentex/src/utils/authorization_shortcuts.py
+++ b/agentex/src/utils/authorization_shortcuts.py
@@ -2,8 +2,6 @@ from typing import Annotated
 
 from fastapi import Depends, Path, Query, Request
 
-from src.adapters.authorization.exceptions import AuthorizationError
-from src.adapters.crud_store.exceptions import ItemDoesNotExist
 from src.api.schemas.authorization_types import (
     AgentexResource,
     AgentexResourceType,
@@ -23,6 +21,9 @@ from src.domain.services.authorization_service import (
 )
 from src.utils.agent_api_key_authorization import _check_api_key_or_collapse_to_404
 from src.utils.task_authorization import check_task_or_collapse_to_404
+from src.utils.visibility_authorization import (
+    check_resource_or_collapse_unreadable_to_404,
+)
 
 
 async def _get_parent_task_id(
@@ -49,22 +50,17 @@ async def _check_agent_or_collapse_to_404(
     agent_id: str,
     operation: AuthorizedOperationType,
 ) -> None:
-    """Check an agent resource; collapse any denial to 404.
+    """Check an agent resource while hiding unreadable agents.
 
-    Collapsing a denied check into 404 stops callers from distinguishing 403
-    (exists, no access) from 404 (absent) and thereby probing whether an agent
-    exists in another tenant. Mirrors the task/api_key collapse helpers.
-
-    TODO: fold this into a single generic collapse helper, and restore the
-    403/404 split once agents carry tenant scope at the data layer.
+    Denied reads collapse to 404. Denied stronger operations preserve 403 when
+    the caller can still read the agent, and collapse to 404 otherwise.
     """
-    try:
-        await authorization.check(
-            resource=AgentexResource.agent(agent_id),
-            operation=operation,
-        )
-    except AuthorizationError:
-        raise ItemDoesNotExist(f"Item with id '{agent_id}' does not exist.") from None
+    await check_resource_or_collapse_unreadable_to_404(
+        authorization=authorization,
+        resource=AgentexResource.agent(agent_id),
+        operation=operation,
+        not_found_message=f"Item with id '{agent_id}' does not exist.",
+    )
 
 
 def DAuthorizedId(
@@ -97,13 +93,10 @@ def DAuthorizedId(
         elif resource_type == AgentexResourceType.task:
             await check_task_or_collapse_to_404(authorization, resource_id, operation)
         elif resource_type == AgentexResourceType.api_key:
-            # Collapse api_key denials to 404 so name/id probes can't
-            # distinguish "present in another tenant" from "absent".
             await _check_api_key_or_collapse_to_404(
                 authorization, resource_id, operation
             )
         elif resource_type == AgentexResourceType.agent:
-            # Collapse agent denials to 404 for the same discoverability reason.
             await _check_agent_or_collapse_to_404(authorization, resource_id, operation)
         else:
             await authorization.check(
@@ -176,6 +169,19 @@ def DAuthorizedBodyId(
 
         if resource_type == AgentexResourceType.task:
             await check_task_or_collapse_to_404(authorization, field_value, operation)
+        elif resource_type == AgentexResourceType.agent:
+            await _check_agent_or_collapse_to_404(authorization, field_value, operation)
+        elif resource_type == AgentexResourceType.api_key:
+            await _check_api_key_or_collapse_to_404(
+                authorization, field_value, operation
+            )
+        elif resource_type == AgentexResourceType.schedule:
+            await check_resource_or_collapse_unreadable_to_404(
+                authorization=authorization,
+                resource=AgentexResource.schedule(field_value),
+                operation=operation,
+                not_found_message=f"Item with id '{field_value}' does not exist.",
+            )
         else:
             await authorization.check(
                 resource=AgentexResource(type=resource_type, selector=field_value),

--- a/agentex/src/utils/schedule_authorization.py
+++ b/agentex/src/utils/schedule_authorization.py
@@ -1,10 +1,11 @@
-from src.adapters.authorization.exceptions import AuthorizationError
-from src.adapters.crud_store.exceptions import ItemDoesNotExist
 from src.api.schemas.authorization_types import (
     AgentexResource,
     AuthorizedOperationType,
 )
 from src.domain.services.authorization_service import AuthorizationService
+from src.utils.visibility_authorization import (
+    check_resource_or_collapse_unreadable_to_404,
+)
 
 
 async def _check_schedule_or_collapse_to_404(
@@ -12,38 +13,10 @@ async def _check_schedule_or_collapse_to_404(
     schedule_id: str,
     operation: AuthorizedOperationType,
 ) -> None:
-    """Issue a check on an agent_schedule resource. On any denial, surface 404 —
-    even when the schedule exists.
-
-    Same rationale as the task / api_key equivalents: the deny-reason
-    discriminator needed to safely return 403 (in-tenant but lacking the
-    operation) vs 404 (cross-tenant or absent) is not available here. Schedules
-    have no Postgres row and no tenant column — Temporal is the store and the
-    selector is ``{agent_id}--{schedule_name}`` — so a 403/404 split would let a
-    caller who can resolve an ``agent_id`` probe another tenant's schedule names
-    by comparing "exists but denied (403)" against "absent (404)".
-
-    Because the single-resource routes run this check *before* the Temporal
-    lookup, a denied schedule and an absent schedule both exit here with the
-    same generic body, so the two cases are indistinguishable under enforcement.
-
-    Until schedules carry tenant scope at the data layer (or the authorization
-    service's deny distinguishes "cross-tenant" from "in-tenant lacking
-    permission"), the safer default is to collapse both into 404. Trade-off: a
-    user with ``read`` but not ``update`` permission on an in-tenant schedule
-    sees 404 on pause/trigger/delete attempts instead of 403. UX regression for
-    in-tenant permission granularity, but eliminates the cross-tenant existence
-    leak.
-
-    TODO: Restore the 403/404 split for same-tenant calls once schedules carry
-    tenant/account_id scope at the data layer.
-    """
-    try:
-        await authorization.check(
-            resource=AgentexResource.schedule(schedule_id),
-            operation=operation,
-        )
-    except AuthorizationError:
-        raise ItemDoesNotExist(
-            f"Item with id '{schedule_id}' does not exist."
-        ) from None
+    """Check an agent_schedule resource while hiding unreadable schedules."""
+    await check_resource_or_collapse_unreadable_to_404(
+        authorization=authorization,
+        resource=AgentexResource.schedule(schedule_id),
+        operation=operation,
+        not_found_message=f"Item with id '{schedule_id}' does not exist.",
+    )

--- a/agentex/src/utils/task_authorization.py
+++ b/agentex/src/utils/task_authorization.py
@@ -1,10 +1,11 @@
-from src.adapters.authorization.exceptions import AuthorizationError
-from src.adapters.crud_store.exceptions import ItemDoesNotExist
 from src.api.schemas.authorization_types import (
     AgentexResource,
     AuthorizedOperationType,
 )
 from src.domain.services.authorization_service import AuthorizationService
+from src.utils.visibility_authorization import (
+    check_resource_or_collapse_unreadable_to_404,
+)
 
 
 async def check_task_or_collapse_to_404(
@@ -12,29 +13,14 @@ async def check_task_or_collapse_to_404(
     task_id: str,
     operation: AuthorizedOperationType,
 ) -> None:
-    """Issue a check on a task resource. On any denial, surface 404 — even when
-    the task exists.
+    """Check a task resource while hiding unreadable tasks.
 
-    The 403/404 split cannot be done safely here: ``TaskORM`` has no tenant
-    column, ``task_repository.get`` does an unfiltered primary-key lookup, and
-    ``AuthorizationError`` carries no deny-reason discriminator. Returning 403
-    when the row exists and 404 when it doesn't leaks cross-tenant existence
-    (caller probes "does task X exist?" and gets distinguishable responses).
-
-    Until tasks carry tenant scope (or agentex-auth's deny distinguishes
-    "cross-tenant" from "in-tenant lacking permission"), the safer default is
-    to collapse both into 404. Trade-off: a user with ``read`` but not
-    ``update`` permission on an in-tenant task sees 404 on update attempts
-    instead of 403. UX regression for in-tenant permission granularity, but
-    eliminates the cross-tenant existence leak.
-
-    TODO: Restore the 403/404 split once tasks carry tenant scope at the
-    data layer (task rows currently have no tenant column).
+    Denied reads collapse to 404. Denied stronger operations preserve 403 when
+    the caller can still read the task, and collapse to 404 otherwise.
     """
-    try:
-        await authorization.check(
-            resource=AgentexResource.task(task_id),
-            operation=operation,
-        )
-    except AuthorizationError:
-        raise ItemDoesNotExist(f"Item with id '{task_id}' does not exist.") from None
+    await check_resource_or_collapse_unreadable_to_404(
+        authorization=authorization,
+        resource=AgentexResource.task(task_id),
+        operation=operation,
+        not_found_message=f"Item with id '{task_id}' does not exist.",
+    )

--- a/agentex/src/utils/visibility_authorization.py
+++ b/agentex/src/utils/visibility_authorization.py
@@ -1,0 +1,37 @@
+from src.adapters.authorization.exceptions import AuthorizationError
+from src.adapters.crud_store.exceptions import ItemDoesNotExist
+from src.api.schemas.authorization_types import (
+    AgentexResource,
+    AuthorizedOperationType,
+)
+from src.domain.services.authorization_service import AuthorizationService
+
+
+async def check_resource_or_collapse_unreadable_to_404(
+    authorization: AuthorizationService,
+    resource: AgentexResource,
+    operation: AuthorizedOperationType,
+    not_found_message: str,
+) -> None:
+    """Check a resource while hiding only resources the caller cannot read.
+
+    If the requested operation is denied, a denied ``read`` check still
+    collapses to 404 to avoid resource-existence probing. For stronger
+    operations, a successful follow-up ``read`` check means the caller can
+    already see the resource, so the original authorization denial is preserved
+    as 403. If ``read`` is also denied, the response stays 404.
+    """
+    try:
+        await authorization.check(resource=resource, operation=operation)
+    except AuthorizationError as exc:
+        if operation != AuthorizedOperationType.read:
+            try:
+                await authorization.check(
+                    resource=resource,
+                    operation=AuthorizedOperationType.read,
+                )
+            except AuthorizationError:
+                pass
+            else:
+                raise exc
+        raise ItemDoesNotExist(not_found_message) from None

--- a/agentex/tests/integration/api/states/test_states_authz_api.py
+++ b/agentex/tests/integration/api/states/test_states_authz_api.py
@@ -160,19 +160,21 @@ class TestStatesAuthzAPIIntegration:
                 },
             )
 
-        # Denied parent-task checks collapse to 404 so task ids cannot be
-        # probed through the states API.
-        assert response.status_code == 404
+        # The task is readable, so a denied stronger operation should surface
+        # as 403 rather than pretending the visible task does not exist.
+        assert response.status_code == 403
         check_calls = [
             call
             for call in post_with_error_handling_mock.call_args_list
             if call[0][1] == "/v1/authz/check"
         ]
-        assert len(check_calls) == 1
-        authz_data = check_calls[0][1]["json"]
-        assert authz_data["resource"]["type"] == AgentexResourceType.task.value
-        assert authz_data["resource"]["selector"] == test_task.id
-        assert authz_data["operation"] == "update"
+        assert len(check_calls) == 2
+        operations = [call[1]["json"]["operation"] for call in check_calls]
+        assert operations == ["update", "read"]
+        for call in check_calls:
+            authz_data = call[1]["json"]
+            assert authz_data["resource"]["type"] == AgentexResourceType.task.value
+            assert authz_data["resource"]["selector"] == test_task.id
 
     @pytest.mark.asyncio
     @patch(
@@ -323,17 +325,19 @@ class TestStatesAuthzAPIIntegration:
                 },
             )
 
-        assert response.status_code == 404
+        assert response.status_code == 403
         check_calls = [
             call
             for call in post_with_error_handling_mock.call_args_list
             if call[0][1] == "/v1/authz/check"
         ]
-        assert len(check_calls) == 1
-        authz_data = check_calls[0][1]["json"]
-        assert authz_data["resource"]["type"] == AgentexResourceType.task.value
-        assert authz_data["resource"]["selector"] == test_task.id
-        assert authz_data["operation"] == "update"
+        assert len(check_calls) == 2
+        operations = [call[1]["json"]["operation"] for call in check_calls]
+        assert operations == ["update", "read"]
+        for call in check_calls:
+            authz_data = call[1]["json"]
+            assert authz_data["resource"]["type"] == AgentexResourceType.task.value
+            assert authz_data["resource"]["selector"] == test_task.id
 
     @pytest.mark.asyncio
     @patch(
@@ -361,17 +365,19 @@ class TestStatesAuthzAPIIntegration:
         ) as post_with_error_handling_mock:
             response = await isolated_client.delete(f"/states/{test_state.id}")
 
-        assert response.status_code == 404
+        assert response.status_code == 403
         check_calls = [
             call
             for call in post_with_error_handling_mock.call_args_list
             if call[0][1] == "/v1/authz/check"
         ]
-        assert len(check_calls) == 1
-        authz_data = check_calls[0][1]["json"]
-        assert authz_data["resource"]["type"] == AgentexResourceType.task.value
-        assert authz_data["resource"]["selector"] == test_task.id
-        assert authz_data["operation"] == "delete"
+        assert len(check_calls) == 2
+        operations = [call[1]["json"]["operation"] for call in check_calls]
+        assert operations == ["delete", "read"]
+        for call in check_calls:
+            authz_data = call[1]["json"]
+            assert authz_data["resource"]["type"] == AgentexResourceType.task.value
+            assert authz_data["resource"]["selector"] == test_task.id
 
     @pytest.mark.asyncio
     @patch(

--- a/agentex/tests/unit/api/test_agent_api_keys_authz.py
+++ b/agentex/tests/unit/api/test_agent_api_keys_authz.py
@@ -1,8 +1,8 @@
 """Tests for agent_api_keys route authorization.
 
 Asserts the route layer issues correct ``check`` calls and collapses denials
-to 404. Two-factor expansion is owned by the authorization service;
-not tested here.
+to 404 only when the api_key is unreadable. Two-factor expansion is owned by
+the authorization service; not tested here.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ def _dep_callable(annotation):
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestCheckApiKeyOrCollapseTo404:
-    """Helper collapses every denial to 404 (no cross-tenant existence leak)."""
+    """Helper collapses unreadable api_keys while preserving denied operations."""
 
     async def test_allowed_check_returns_normally(self):
         authorization = MagicMock()
@@ -46,8 +46,20 @@ class TestCheckApiKeyOrCollapseTo404:
         assert called_kwargs["resource"] == AgentexResource.api_key("api-key-1")
         assert called_kwargs["operation"] == AuthorizedOperationType.read
 
-    async def test_denied_collapses_to_not_found_regardless_of_existence(self):
-        """Denial surfaces as 404 regardless of existence."""
+    async def test_denied_read_collapses_to_not_found(self):
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+
+        with pytest.raises(ItemDoesNotExist):
+            await _check_api_key_or_collapse_to_404(
+                authorization,
+                "api-key-1",
+                AuthorizedOperationType.read,
+            )
+
+        authorization.check.assert_awaited_once()
+
+    async def test_denied_non_read_collapses_to_not_found_when_read_denied(self):
         authorization = MagicMock()
         authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
 
@@ -57,6 +69,25 @@ class TestCheckApiKeyOrCollapseTo404:
                 "api-key-1",
                 AuthorizedOperationType.delete,
             )
+
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.delete
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+
+    async def test_denied_non_read_surfaces_authorization_error_when_read_allowed(self):
+        authorization = MagicMock()
+        operation_denied = AuthorizationError("denied")
+        authorization.check = AsyncMock(side_effect=[operation_denied, True])
+
+        with pytest.raises(AuthorizationError) as exc_info:
+            await _check_api_key_or_collapse_to_404(
+                authorization,
+                "api-key-1",
+                AuthorizedOperationType.delete,
+            )
+
+        assert exc_info.value is operation_denied
 
     async def test_uses_delete_operation_on_delete_routes(self):
         """Helper forwards the operation verbatim."""
@@ -76,7 +107,7 @@ class TestCheckApiKeyOrCollapseTo404:
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestDAuthorizedIdApiKeyWrap:
-    """``DAuthorizedId(api_key, ...)`` routes through the collapse wrap → 404 on denial."""
+    """``DAuthorizedId(api_key, ...)`` routes through the api_key authz wrapper."""
 
     async def test_api_key_id_routes_through_wrap_on_denial(self):
         annotation = DAuthorizedId(
@@ -137,11 +168,35 @@ class TestDAuthorizedIdApiKeyWrap:
         called_kwargs = authorization.check.await_args.kwargs
         assert called_kwargs["operation"] == AuthorizedOperationType.delete
 
+    async def test_api_key_delete_denied_when_readable_surfaces_authorization_error(
+        self,
+    ):
+        annotation = DAuthorizedId(
+            AgentexResourceType.api_key,
+            AuthorizedOperationType.delete,
+            param_name="id",
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(
+            side_effect=[AuthorizationError("delete denied"), True]
+        )
+
+        with pytest.raises(AuthorizationError):
+            await dep(
+                authorization,
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                "api-key-readable",
+            )
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestNameRouteCollapse:
-    """Name-route handlers call the collapse helper inline → 404 on denial."""
+    """Name-route handlers call the api_key visibility helper inline."""
 
     async def test_get_by_name_handler_collapses_denial_to_404(self):
         from src.api.routes.agent_api_keys import get_agent_api_key_by_name
@@ -198,8 +253,38 @@ class TestNameRouteCollapse:
 
         # Crucially: the delete is NOT invoked when the check fails.
         api_key_use_case.delete_by_agent_id_and_key_name.assert_not_called()
-        called_kwargs = authorization.check.await_args.kwargs
-        assert called_kwargs["operation"] == AuthorizedOperationType.delete
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.delete
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+
+    async def test_delete_by_name_handler_surfaces_403_when_readable(self):
+        from src.api.routes.agent_api_keys import delete_agent_api_key_by_name
+
+        agent_use_case = MagicMock()
+        agent_use_case.get = AsyncMock(return_value=MagicMock(id="agent-1"))
+        api_key_use_case = MagicMock()
+        api_key_use_case.get_by_agent_id_and_name = AsyncMock(
+            return_value=MagicMock(id="api-key-named")
+        )
+        api_key_use_case.delete_by_agent_id_and_key_name = AsyncMock()
+        authorization = MagicMock()
+        authorization.check = AsyncMock(
+            side_effect=[AuthorizationError("delete denied"), True]
+        )
+        authorization.principal_context = MagicMock(account_id="acct-1")
+
+        with pytest.raises(AuthorizationError):
+            await delete_agent_api_key_by_name(
+                api_key_name="prod-key",
+                agent_api_key_use_case=api_key_use_case,
+                agent_use_case=agent_use_case,
+                authorization_service=authorization,
+                agent_id="agent-1",
+                agent_name=None,
+            )
+
+        api_key_use_case.delete_by_agent_id_and_key_name.assert_not_called()
 
     async def test_absent_and_denied_404_bodies_are_identical(self):
         """Absent-row and denied-row 404 bodies must be byte-for-byte identical."""

--- a/agentex/tests/unit/api/test_agents_authz.py
+++ b/agentex/tests/unit/api/test_agents_authz.py
@@ -1,8 +1,8 @@
-"""Agent direct-route authorization: denied reads/deletes collapse to 404.
+"""Agent direct-route authorization preserves 403 for readable resources.
 
-Asserts the route layer issues the right ``check`` calls and collapses a denial
-to 404 (so callers can't probe cross-tenant existence), and that list filtering
-forwards the authorized-id set to the use case.
+Asserts the route layer issues the right ``check`` calls, collapses unreadable
+resources to 404 (so callers can't probe cross-tenant existence), and preserves
+403 for denied stronger operations on resources the caller can already read.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ def _dep_callable(annotation):
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestCheckAgentOrCollapseTo404:
-    """Helper collapses every denial to 404 (no cross-tenant existence leak)."""
+    """Helper collapses unreadable agents while preserving denied operations."""
 
     async def test_allowed_check_returns_normally(self):
         authorization = MagicMock()
@@ -55,7 +55,7 @@ class TestCheckAgentOrCollapseTo404:
         assert called_kwargs["resource"] == AgentexResource.agent("agent-1")
         assert called_kwargs["operation"] == AuthorizedOperationType.read
 
-    async def test_denied_collapses_to_not_found(self):
+    async def test_denied_read_collapses_to_not_found(self):
         authorization = MagicMock()
         authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
 
@@ -63,8 +63,44 @@ class TestCheckAgentOrCollapseTo404:
             await _check_agent_or_collapse_to_404(
                 authorization,
                 "agent-1",
-                AuthorizedOperationType.delete,
+                AuthorizedOperationType.read,
             )
+
+        authorization.check.assert_awaited_once()
+
+    async def test_denied_non_read_collapses_to_not_found_when_read_denied(self):
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+
+        with pytest.raises(ItemDoesNotExist):
+            await _check_agent_or_collapse_to_404(
+                authorization,
+                "agent-1",
+                AuthorizedOperationType.execute,
+            )
+
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.execute
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+
+    async def test_denied_non_read_surfaces_authorization_error_when_read_allowed(self):
+        authorization = MagicMock()
+        operation_denied = AuthorizationError("denied")
+        authorization.check = AsyncMock(side_effect=[operation_denied, True])
+
+        with pytest.raises(AuthorizationError) as exc_info:
+            await _check_agent_or_collapse_to_404(
+                authorization,
+                "agent-1",
+                AuthorizedOperationType.execute,
+            )
+
+        assert exc_info.value is operation_denied
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.execute
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
 
     async def test_operation_forwarded_verbatim(self):
         authorization = MagicMock()
@@ -83,7 +119,7 @@ class TestCheckAgentOrCollapseTo404:
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestDAuthorizedIdAgentWrap:
-    """``DAuthorizedId(agent, ...)`` routes through the collapse wrap → 404 on denial."""
+    """``DAuthorizedId(agent, ...)`` routes through the agent authz wrapper."""
 
     async def test_agent_id_returns_resource_id_when_allowed(self):
         annotation = DAuthorizedId(
@@ -115,6 +151,31 @@ class TestDAuthorizedIdAgentWrap:
         with pytest.raises(ItemDoesNotExist):
             await dep(authorization, MagicMock(), MagicMock(), MagicMock(), "agent-7")
 
+    async def test_agent_execute_denied_when_readable_surfaces_authorization_error(
+        self,
+    ):
+        annotation = DAuthorizedId(
+            AgentexResourceType.agent, AuthorizedOperationType.execute
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(
+            side_effect=[AuthorizationError("execute denied"), True]
+        )
+
+        with pytest.raises(AuthorizationError):
+            await dep(
+                authorization, MagicMock(), MagicMock(), MagicMock(), "agent-exec"
+            )
+
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["resource"] == AgentexResource.agent("agent-exec")
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.execute
+        assert second_call.kwargs["resource"] == AgentexResource.agent("agent-exec")
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+
     async def test_agent_delete_op_propagated_to_check(self):
         annotation = DAuthorizedId(
             AgentexResourceType.agent, AuthorizedOperationType.delete
@@ -133,7 +194,7 @@ class TestDAuthorizedIdAgentWrap:
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestDAuthorizedNameAgentWrap:
-    """``DAuthorizedName(agent, ...)``: lookup-then-collapse on the resolved id."""
+    """``DAuthorizedName(agent, ...)`` authorizes the resolved id."""
 
     async def test_present_but_denied_collapses_to_404(self):
         annotation = DAuthorizedName(
@@ -154,6 +215,31 @@ class TestDAuthorizedNameAgentWrap:
         agent_repository.get.assert_awaited_once_with(name="prod-agent")
         called_kwargs = authorization.check.await_args.kwargs
         assert called_kwargs["resource"] == AgentexResource.agent("agent-resolved")
+
+    async def test_execute_denied_when_readable_surfaces_authorization_error(self):
+        annotation = DAuthorizedName(
+            AgentexResourceType.agent, AuthorizedOperationType.execute
+        )
+        dep = _dep_callable(annotation)
+
+        agent_repository = MagicMock()
+        agent_repository.get = AsyncMock(return_value=MagicMock(id="agent-resolved"))
+        task_repository = MagicMock()
+        authorization = MagicMock()
+        authorization.check = AsyncMock(
+            side_effect=[AuthorizationError("execute denied"), True]
+        )
+
+        with pytest.raises(AuthorizationError):
+            await dep(authorization, agent_repository, task_repository, "prod-agent")
+
+        agent_repository.get.assert_awaited_once_with(name="prod-agent")
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["resource"] == AgentexResource.agent("agent-resolved")
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.execute
+        assert second_call.kwargs["resource"] == AgentexResource.agent("agent-resolved")
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
 
     async def test_absent_name_surfaces_native_404_without_checking(self):
         annotation = DAuthorizedName(
@@ -177,7 +263,7 @@ class TestDAuthorizedNameAgentWrap:
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestDAuthorizedQueryAgentWrap:
-    """``DAuthorizedQuery(agent, ...)`` also collapses denied checks to 404."""
+    """``DAuthorizedQuery(agent, ...)`` routes through the agent authz wrapper."""
 
     async def test_agent_query_returns_resource_id_when_allowed(self):
         annotation = DAuthorizedQuery(

--- a/agentex/tests/unit/api/test_schedules_authz.py
+++ b/agentex/tests/unit/api/test_schedules_authz.py
@@ -3,10 +3,10 @@
 Mirrors the structure of the agent_api_key and task route-authorization tests.
 Covers:
 
-  1. The ``_check_schedule_or_collapse_to_404`` helper (allow + denied-collapse).
+  1. The ``_check_schedule_or_collapse_to_404`` helper.
   2. ``DAuthorizedScheduleId`` builds the composite ``{agent_id}--{schedule_name}``
-     selector, returns the schedule name when allowed, and collapses denials to
-     404 (the no-existence-leak path).
+     selector, returns the schedule name when allowed, and preserves 403 for
+     denied operations on readable schedules.
   3. ``create_schedule`` enforces parent ``agent.update`` (the only route where
      no schedule resource exists yet, so the authorization service can't
      transitively gate it).
@@ -17,8 +17,7 @@ Cross-tenant and transitive-expansion checks belong in an end-to-end suite
 gated on a live authorization-service cluster (the ``agent_schedule.update``
 permission transitively requires ``parent_agent->update`` in the authorization
 policy, which this repo does not own). Here we only assert that the route layer
-issues the correct ``check`` call with the correct operation and surfaces
-denials as 404.
+issues the correct ``check`` call with the correct operation.
 """
 
 from __future__ import annotations
@@ -45,8 +44,7 @@ def _dep_callable(annotation):
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestCheckScheduleOrCollapseTo404:
-    """The schedule-resource authz wrap collapses every denial to 404 so callers
-    can't distinguish "present in another tenant" from "absent"."""
+    """The schedule-resource authz wrap hides unreadable schedules."""
 
     async def test_allowed_check_returns_normally(self):
         authorization = MagicMock()
@@ -63,10 +61,20 @@ class TestCheckScheduleOrCollapseTo404:
         assert called_kwargs["resource"] == AgentexResource.schedule("agent-1--nightly")
         assert called_kwargs["operation"] == AuthorizedOperationType.read
 
-    async def test_denied_collapses_to_not_found_regardless_of_existence(self):
-        """Both "denied + schedule exists" and "denied + schedule missing"
-        surface as ``ItemDoesNotExist`` (→ 404). The wrap doesn't consult
-        Temporal — collapsing avoids the cross-tenant existence leak."""
+    async def test_denied_read_collapses_to_not_found(self):
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+
+        with pytest.raises(ItemDoesNotExist):
+            await _check_schedule_or_collapse_to_404(
+                authorization,
+                "agent-1--nightly",
+                AuthorizedOperationType.read,
+            )
+
+        authorization.check.assert_awaited_once()
+
+    async def test_denied_non_read_collapses_to_not_found_when_read_denied(self):
         authorization = MagicMock()
         authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
 
@@ -76,6 +84,25 @@ class TestCheckScheduleOrCollapseTo404:
                 "agent-1--nightly",
                 AuthorizedOperationType.delete,
             )
+
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.delete
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+
+    async def test_denied_non_read_surfaces_authorization_error_when_read_allowed(self):
+        authorization = MagicMock()
+        operation_denied = AuthorizationError("denied")
+        authorization.check = AsyncMock(side_effect=[operation_denied, True])
+
+        with pytest.raises(AuthorizationError) as exc_info:
+            await _check_schedule_or_collapse_to_404(
+                authorization,
+                "agent-1--nightly",
+                AuthorizedOperationType.delete,
+            )
+
+        assert exc_info.value is operation_denied
 
     async def test_forwards_operation_verbatim(self):
         """The transitive expansion for ``update``/``delete`` in the
@@ -99,7 +126,7 @@ class TestCheckScheduleOrCollapseTo404:
 class TestSingleResourceRouteAuthz:
     """The single-resource routes (get/pause/unpause/trigger/delete) check the
     schedule resource on the composite ``{agent_id}--{schedule_name}`` selector
-    inline, collapsing denials to 404 — mirroring the agent_api_key name routes.
+    inline, mirroring the agent_api_key name routes.
     Verifies per-route operation routing and that a denial skips the use case."""
 
     async def test_get_authorized_checks_read_and_calls_use_case(self):
@@ -178,10 +205,29 @@ class TestSingleResourceRouteAuthz:
                 authorization=authorization,
             )
         use_case.delete_schedule.assert_not_called()
-        assert (
-            authorization.check.await_args.kwargs["operation"]
-            == AuthorizedOperationType.delete
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.delete
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+
+    async def test_delete_denied_when_readable_surfaces_authorization_error(self):
+        from src.api.routes.schedules import delete_schedule
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(
+            side_effect=[AuthorizationError("delete denied"), True]
         )
+        use_case = MagicMock()
+        use_case.delete_schedule = AsyncMock()
+
+        with pytest.raises(AuthorizationError):
+            await delete_schedule(
+                agent_id="agent-1",
+                schedule_name="nightly",
+                schedules_use_case=use_case,
+                authorization=authorization,
+            )
+        use_case.delete_schedule.assert_not_called()
 
 
 @pytest.mark.unit
@@ -190,8 +236,8 @@ class TestCreateParentAgentCheck:
     """``create_schedule`` is the only route where no schedule resource exists
     yet, so the authorization service cannot transitively gate on it. The
     route's ``agent_id`` guard MUST check ``agent.update`` on the parent, and a
-    denial collapses to 404 — like every other agent check — so the schedules
-    endpoint can't be used to probe cross-tenant agent existence."""
+    denial collapses to 404 when the parent is unreadable. A caller who can
+    read the parent but not update it sees 403."""
 
     @staticmethod
     def _agent_id_dep():
@@ -225,6 +271,25 @@ class TestCreateParentAgentCheck:
         # Parent-agent denial collapses to 404 so creating a schedule under an
         # agent in another tenant can't reveal that the agent exists.
         with pytest.raises(ItemDoesNotExist):
+            await dep(
+                authorization,
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+                resource_id="agent-1",
+            )
+
+    async def test_create_denied_when_parent_readable_surfaces_authorization_error(
+        self,
+    ):
+        dep = self._agent_id_dep()
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(
+            side_effect=[AuthorizationError("update denied"), True]
+        )
+
+        with pytest.raises(AuthorizationError):
             await dep(
                 authorization,
                 MagicMock(),

--- a/agentex/tests/unit/api/test_tasks_authz.py
+++ b/agentex/tests/unit/api/test_tasks_authz.py
@@ -1,10 +1,10 @@
-"""Tests for per-RPC operation routing and 404/403 authorization wrap on task routes.
+"""Tests for per-RPC operation routing and task visibility authorization.
 
 Covers:
   1. Per-RPC operation routing: MESSAGE_SEND/EVENT_SEND map to ``update``,
      TASK_CANCEL maps to ``cancel``, TASK_CREATE stays ``create``.
-  2. 404 collapse on authorization denials (callers cannot probe cross-tenant
-     task existence via 403 vs 404 response codes).
+  2. Visibility-aware authorization: denied reads collapse to 404, while
+     denied stronger operations preserve 403 when the task remains readable.
 
 End-to-end tests (cross-tenant isolation, cancel-owner-only enforcement,
 list filtering) belong in a separate integration suite that requires a live
@@ -266,11 +266,9 @@ class TestUpdatePermissionRoutingForRewiredCallSites:
         assert call_kwargs["resource"] == AgentexResource.task("task-msg")
         assert call_kwargs["operation"] == AuthorizedOperationType.update
 
-    async def test_update_check_denial_collapses_to_404(self):
-        """For the rewired call sites, an ``AuthorizationError`` on
-        ``update`` must still collapse to 404 — the same envelope that
-        ``execute`` had — so the rewire doesn't accidentally narrow the
-        error surface."""
+    async def test_update_check_denial_collapses_to_404_when_read_denied(self):
+        """If ``update`` and the follow-up ``read`` are both denied, the
+        helper still returns the non-enumerating 404 envelope."""
         authorization = MagicMock()
         authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
 
@@ -280,6 +278,25 @@ class TestUpdatePermissionRoutingForRewiredCallSites:
                 "task-msg",
                 AuthorizedOperationType.update,
             )
+
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.update
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+
+    async def test_update_check_denial_surfaces_403_when_read_allowed(self):
+        authorization = MagicMock()
+        operation_denied = AuthorizationError("denied")
+        authorization.check = AsyncMock(side_effect=[operation_denied, True])
+
+        with pytest.raises(AuthorizationError) as exc_info:
+            await check_task_or_collapse_to_404(
+                authorization,
+                "task-msg",
+                AuthorizedOperationType.update,
+            )
+
+        assert exc_info.value is operation_denied
 
 
 @pytest.mark.unit
@@ -327,8 +344,7 @@ class TestTaskDeleteAuthWrites:
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestCheckTaskOrCollapseTo404:
-    """The task-resource authz wrap collapses every denial to 404 so callers
-    can't distinguish "present in another tenant" from "absent"."""
+    """The task-resource authz wrap hides unreadable tasks."""
 
     async def test_allowed_check_returns_normally(self):
         authorization = MagicMock()
@@ -342,10 +358,20 @@ class TestCheckTaskOrCollapseTo404:
 
         authorization.check.assert_awaited_once()
 
-    async def test_denied_collapses_to_not_found_regardless_of_existence(self):
-        """Both "denied + task exists" and "denied + task missing" surface as
-        ``ItemDoesNotExist`` (→ 404). The wrap doesn't consult any repository
-        — collapsing avoids the cross-tenant existence leak."""
+    async def test_denied_read_collapses_to_not_found(self):
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+
+        with pytest.raises(ItemDoesNotExist):
+            await check_task_or_collapse_to_404(
+                authorization,
+                "task-1",
+                AuthorizedOperationType.read,
+            )
+
+        authorization.check.assert_awaited_once()
+
+    async def test_denied_non_read_collapses_to_not_found_when_read_denied(self):
         authorization = MagicMock()
         authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
 
@@ -356,13 +382,31 @@ class TestCheckTaskOrCollapseTo404:
                 AuthorizedOperationType.update,
             )
 
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.update
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+
+    async def test_denied_non_read_surfaces_authorization_error_when_read_allowed(self):
+        authorization = MagicMock()
+        operation_denied = AuthorizationError("denied")
+        authorization.check = AsyncMock(side_effect=[operation_denied, True])
+
+        with pytest.raises(AuthorizationError) as exc_info:
+            await check_task_or_collapse_to_404(
+                authorization,
+                "task-1",
+                AuthorizedOperationType.update,
+            )
+
+        assert exc_info.value is operation_denied
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestDAuthorizedBodyIdTaskWrap:
     """``DAuthorizedBodyId`` must route task-resource body-id checks through
-    the task-collapse wrap so denied body-id calls return 404 instead of 403 —
-    matching the path/query variants."""
+    the task visibility wrapper, matching the path/query variants."""
 
     @staticmethod
     def _make_request(task_id: str) -> MagicMock:
@@ -371,8 +415,6 @@ class TestDAuthorizedBodyIdTaskWrap:
         return request
 
     async def test_task_body_id_routes_through_wrap_on_denial(self):
-        """The body-id wrap goes through the task-collapse helper, which
-        collapses any denial to 404 — including for tasks that exist."""
         annotation = DAuthorizedBodyId(
             AgentexResourceType.task, AuthorizedOperationType.update
         )
@@ -382,6 +424,24 @@ class TestDAuthorizedBodyIdTaskWrap:
         authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
 
         with pytest.raises(ItemDoesNotExist):
+            await dep(self._make_request("task-7"), authorization)
+
+        assert authorization.check.await_count == 2
+
+    async def test_task_body_id_update_denied_when_readable_surfaces_authorization_error(
+        self,
+    ):
+        annotation = DAuthorizedBodyId(
+            AgentexResourceType.task, AuthorizedOperationType.update
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(
+            side_effect=[AuthorizationError("update denied"), True]
+        )
+
+        with pytest.raises(AuthorizationError):
             await dep(self._make_request("task-7"), authorization)
 
     async def test_task_body_id_returns_field_value_when_allowed(self):
@@ -397,7 +457,7 @@ class TestDAuthorizedBodyIdTaskWrap:
 
         assert result == "task-9"
 
-    async def test_non_task_body_id_skips_wrap(self):
+    async def test_agent_body_id_uses_visibility_wrap(self):
         annotation = DAuthorizedBodyId(
             AgentexResourceType.agent, AuthorizedOperationType.read
         )
@@ -411,12 +471,9 @@ class TestDAuthorizedBodyIdTaskWrap:
         result = await dep(request, authorization)
 
         assert result == "agent-1"
-        # Non-task resources go straight to authorization.check, never to the wrap.
         authorization.check.assert_awaited_once()
         called_kwargs = authorization.check.await_args.kwargs
-        assert called_kwargs["resource"] == AgentexResource(
-            type=AgentexResourceType.agent, selector="agent-1"
-        )
+        assert called_kwargs["resource"] == AgentexResource.agent("agent-1")
 
 
 @pytest.mark.unit
@@ -429,9 +486,6 @@ class TestDAuthorizedNameTaskWrap:
     cross-tenant existence leak the other surfaces eliminate."""
 
     async def test_task_name_routes_through_wrap_on_denial(self):
-        """Present-but-denied tasks (looked up by name) surface as
-        ``ItemDoesNotExist`` (→ 404), same as absent. The lookup itself
-        succeeds — the wrap intercepts the subsequent authz check."""
         annotation = DAuthorizedName(
             AgentexResourceType.task, AuthorizedOperationType.update
         )
@@ -449,7 +503,26 @@ class TestDAuthorizedNameTaskWrap:
         # The wrap fires AFTER the lookup — the repo is consulted to resolve
         # name → id; the leak is only on the authz response, not the lookup.
         task_repository.get.assert_awaited_once_with(name="task-name-x")
-        authorization.check.assert_awaited_once()
+        assert authorization.check.await_count == 2
+
+    async def test_task_name_update_denied_when_readable_surfaces_authorization_error(
+        self,
+    ):
+        annotation = DAuthorizedName(
+            AgentexResourceType.task, AuthorizedOperationType.update
+        )
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(
+            side_effect=[AuthorizationError("update denied"), True]
+        )
+        agent_repository = MagicMock()
+        task_repository = MagicMock()
+        task_repository.get = AsyncMock(return_value=MagicMock(id="task-resolved"))
+
+        with pytest.raises(AuthorizationError):
+            await dep(authorization, agent_repository, task_repository, "task-name-x")
 
     async def test_task_name_returns_resource_name_when_allowed(self):
         annotation = DAuthorizedName(


### PR DESCRIPTION
## Summary

Adds a shared visibility-aware authorization helper and routes Agentex resource checks through it for agent, task, API key, and schedule resources.

With this change:
- `read` denied returns 404.
- non-read denied with `read` allowed returns 403.
- non-read denied with `read` denied returns 404.

That keeps unreadable resources collapsed to not-found while returning a useful forbidden response when the caller can see the resource but lacks the requested action, such as a viewer trying to create a task for an agent. The state-route integration assertions were also updated for the same readable-parent-task behavior.

Companion backend PR: https://github.com/scaleapi/scaleapi/pull/146772

## Validation

- `uv run --group test pytest tests/unit/api/test_agents_authz.py tests/unit/api/test_tasks_authz.py tests/unit/api/test_agent_api_keys_authz.py tests/unit/api/test_schedules_authz.py -q` (`84 passed`)
- `uv run ruff check agentex/src/utils/visibility_authorization.py agentex/src/utils/authorization_shortcuts.py agentex/src/utils/task_authorization.py agentex/src/utils/agent_api_key_authorization.py agentex/src/utils/schedule_authorization.py tests/unit/api/test_agents_authz.py tests/unit/api/test_tasks_authz.py tests/unit/api/test_agent_api_keys_authz.py tests/unit/api/test_schedules_authz.py`
- `uv run ruff format --check agentex/src/utils/visibility_authorization.py agentex/src/utils/authorization_shortcuts.py agentex/src/utils/task_authorization.py agentex/src/utils/agent_api_key_authorization.py agentex/src/utils/schedule_authorization.py tests/unit/api/test_agents_authz.py tests/unit/api/test_tasks_authz.py tests/unit/api/test_agent_api_keys_authz.py tests/unit/api/test_schedules_authz.py`
- `uv run ruff check tests/integration/api/states/test_states_authz_api.py`
- `uv run ruff format --check tests/integration/api/states/test_states_authz_api.py`
- `git diff --check`

Not run locally: `uv run --group test pytest tests/integration/api/states/test_states_authz_api.py -q` because local Docker/testcontainers could not connect to the Docker socket.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `check_resource_or_collapse_unreadable_to_404` helper in `visibility_authorization.py` that enables a 403/404 split based on whether the caller can read the resource. All four resource-authorization helpers (agent, task, api_key, schedule) now delegate to this utility, and `DAuthorizedBodyId` gains explicit branches for agent, api_key, and schedule resources that previously fell through to a plain `authorization.check()` (always 403 on denial).

- **New behavior**: denied non-read operation + caller can read the resource → 403; denied non-read + read also denied → 404; denied read → always 404.
- **Integration tests** (`test_states_authz_api.py`) are updated from expected 404 to 403 for readable tasks, and unit test suites are expanded across all four resource types to cover the three new behavioral branches.
- **`DAuthorizedBodyId`** now routes `agent`, `api_key`, and `schedule` through the visibility helper; previously these fell to the `else` branch and would raise `AuthorizationError` (403) on any denial, leaking cross-tenant existence.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the two-call authorization pattern is logically correct, all four resource helpers consistently delegate to the shared utility, and the expanded test suite covers all three new behavioral branches.

The core helper correctly gates the 403-vs-404 decision on a follow-up read check, exception-chaining is handled properly (raise exc vs raise ItemDoesNotExist from None), and every changed helper has matching unit tests for all three denial paths. Integration tests are updated in lockstep.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/utils/visibility_authorization.py | New shared helper implementing the 403/404 split via a two-call authorization pattern; logic is correct and well-structured. |
| agentex/src/utils/authorization_shortcuts.py | Refactored to delegate agent/api_key/schedule/task checks through visibility-aware helpers; DAuthorizedBodyId gains new branches for agent, api_key, and schedule — previously these fell to plain authorization.check (always 403). |
| agentex/src/utils/task_authorization.py | Simplified by delegating to check_resource_or_collapse_unreadable_to_404; old TODO about tenant scope removed as part of this fix. |
| agentex/src/utils/schedule_authorization.py | Simplified wrapper; long explanatory comment about cross-tenant schedule-name probing removed as the concern is now addressed by the visibility helper's read-check gate. |
| agentex/src/utils/agent_api_key_authorization.py | Simplified to delegate to shared helper; TODO about api_key tenant scope removed. |
| agentex/tests/unit/api/test_agents_authz.py | Expanded with three new behavioral branches for agent, DAuthorizedId, and DAuthorizedName. |
| agentex/tests/unit/api/test_tasks_authz.py | Updated to expect two auth-check calls on denial; new tests for the 403-when-readable path. |
| agentex/tests/unit/api/test_schedules_authz.py | New denial-path tests added for schedule helper and DAuthorizedScheduleId. |
| agentex/tests/unit/api/test_agent_api_keys_authz.py | New 403-when-readable tests for api_key helper, DAuthorizedId, and the delete-by-name route handler. |
| agentex/tests/integration/api/states/test_states_authz_api.py | Integration test expectations updated from 404 to 403 for denied update/delete on readable tasks. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Route dependency invoked] --> B{Resource type}
    B -->|task| C[check_task_or_collapse_to_404]
    B -->|agent| D[_check_agent_or_collapse_to_404]
    B -->|api_key| E[_check_api_key_or_collapse_to_404]
    B -->|schedule| F[_check_schedule_or_collapse_to_404]
    C & D & E & F --> G[check_resource_or_collapse_unreadable_to_404]
    G --> H{authorization.check operation check}
    H -->|allowed| I[return - request proceeds]
    H -->|AuthorizationError| J{operation == read?}
    J -->|yes| K[raise ItemDoesNotExist 404]
    J -->|no| L{authorization.check follow-up read check}
    L -->|allowed| M[re-raise original AuthorizationError 403]
    L -->|AuthorizationError| K
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(authz): expect 403 for readable sta..."](https://github.com/scaleapi/scale-agentex/commit/67ef0a30d82fbef247110d1bd6d20e2e700b7284) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36778070)</sub>

<!-- /greptile_comment -->