### PR TITLE
fix(authz): hide unreadable agents on api key create

### DIFF
--- a/agentex/src/api/routes/agent_api_keys.py
+++ b/agentex/src/api/routes/agent_api_keys.py
@@ -9,7 +9,6 @@ from src.api.schemas.agent_api_keys import (
     CreateAPIKeyResponse,
 )
 from src.api.schemas.authorization_types import (
-    AgentexResource,
     AgentexResourceType,
     AuthorizedOperationType,
 )
@@ -24,6 +23,7 @@ from src.utils.agent_api_key_authorization import (
 from src.utils.authorization_shortcuts import (
     DAuthorizedId,
     DAuthorizedResourceIds,
+    _check_agent_or_collapse_to_404,
 )
 from src.utils.logging import make_logger
 
@@ -57,11 +57,12 @@ async def create_api_key(
         )
     agent = await agent_use_case.get(id=request.agent_id, name=request.agent_name)
 
-    # No api_key resource exists yet, so the authorization service can't gate
-    # transitively — gate on parent ``agent.update`` directly.
-    await authorization_service.check(
-        resource=AgentexResource.agent(agent.id),
-        operation=AuthorizedOperationType.update,
+    # No api_key resource exists yet, so gate on the parent agent while keeping
+    # hidden-vs-visible denied semantics consistent with other agent checks.
+    await _check_agent_or_collapse_to_404(
+        authorization_service,
+        agent.id,
+        AuthorizedOperationType.update,
     )
 
     # Check if external agent API key already exists for this name and agent ID

--- a/agentex/tests/unit/api/test_agent_api_keys_authz.py
+++ b/agentex/tests/unit/api/test_agent_api_keys_authz.py
@@ -435,8 +435,7 @@ class TestCreateParentAgentCheck:
         assert called_kwargs["resource"] == AgentexResource.agent("agent-1")
         assert called_kwargs["operation"] == AuthorizedOperationType.update
 
-    async def test_create_denied_on_parent_agent_propagates_403(self):
-        """Create denial surfaces as 403 — no api_key exists yet, no leak possible."""
+    async def test_create_denied_on_parent_agent_collapses_when_read_denied(self):
         from src.api.routes.agent_api_keys import create_api_key
         from src.api.schemas.agent_api_keys import CreateAPIKeyRequest
         from src.domain.entities.agent_api_keys import AgentAPIKeyType
@@ -444,9 +443,15 @@ class TestCreateParentAgentCheck:
         agent_use_case = MagicMock()
         agent_use_case.get = AsyncMock(return_value=MagicMock(id="agent-1"))
         api_key_use_case = MagicMock()
+        api_key_use_case.get_by_agent_id_and_name = AsyncMock()
         api_key_use_case.create = AsyncMock()
         authorization = MagicMock()
-        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+        authorization.check = AsyncMock(
+            side_effect=[
+                AuthorizationError("update denied"),
+                AuthorizationError("read denied"),
+            ]
+        )
 
         request = CreateAPIKeyRequest(
             agent_id="agent-1",
@@ -456,12 +461,53 @@ class TestCreateParentAgentCheck:
             api_key="x",
         )
 
-        with pytest.raises(AuthorizationError):
+        with pytest.raises(ItemDoesNotExist):
             await create_api_key(
                 request=request,
                 agent_api_key_use_case=api_key_use_case,
                 agent_use_case=agent_use_case,
                 authorization_service=authorization,
             )
-        # Create is NOT invoked when parent check fails.
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.update
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+        api_key_use_case.get_by_agent_id_and_name.assert_not_called()
+        api_key_use_case.create.assert_not_called()
+
+    async def test_create_denied_on_readable_parent_agent_propagates_403(self):
+        from src.api.routes.agent_api_keys import create_api_key
+        from src.api.schemas.agent_api_keys import CreateAPIKeyRequest
+        from src.domain.entities.agent_api_keys import AgentAPIKeyType
+
+        agent_use_case = MagicMock()
+        agent_use_case.get = AsyncMock(return_value=MagicMock(id="agent-1"))
+        api_key_use_case = MagicMock()
+        api_key_use_case.get_by_agent_id_and_name = AsyncMock()
+        api_key_use_case.create = AsyncMock()
+        authorization = MagicMock()
+        operation_denied = AuthorizationError("update denied")
+        authorization.check = AsyncMock(side_effect=[operation_denied, True])
+
+        request = CreateAPIKeyRequest(
+            agent_id="agent-1",
+            agent_name=None,
+            name="prod-key",
+            api_key_type=AgentAPIKeyType.EXTERNAL,
+            api_key="x",
+        )
+
+        with pytest.raises(AuthorizationError) as exc_info:
+            await create_api_key(
+                request=request,
+                agent_api_key_use_case=api_key_use_case,
+                agent_use_case=agent_use_case,
+                authorization_service=authorization,
+            )
+        assert exc_info.value is operation_denied
+        assert authorization.check.await_count == 2
+        first_call, second_call = authorization.check.await_args_list
+        assert first_call.kwargs["operation"] == AuthorizedOperationType.update
+        assert second_call.kwargs["operation"] == AuthorizedOperationType.read
+        api_key_use_case.get_by_agent_id_and_name.assert_not_called()
         api_key_use_case.create.assert_not_called()


### PR DESCRIPTION
## Summary

Routes `create_api_key` parent-agent authorization through the same visibility-aware helper used by the other agent resource checks.

This fixes the remaining old behavior where an existing-but-unreadable parent agent returned 403 from a plain `agent.update` check, while an absent parent agent returned 404 from lookup.

With this change:
- parent `agent.update` denied + parent `agent.read` denied returns 404
- parent `agent.update` denied + parent `agent.read` allowed returns 403

## Validation

- `uv run --group test pytest tests/unit/api/test_agent_api_keys_authz.py -q` (`18 passed`)
- `uv run ruff check src/api/routes/agent_api_keys.py tests/unit/api/test_agent_api_keys_authz.py`
- `uv run ruff format --check src/api/routes/agent_api_keys.py tests/unit/api/test_agent_api_keys_authz.py`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes the `create_api_key` parent-agent authorization through the shared `_check_agent_or_collapse_to_404` helper, bringing it in line with every other agent-resource check in the codebase. Previously, a denied `agent.update` on an unreadable agent returned 403 (leaking existence), while a truly absent agent returned 404.

- **`agent_api_keys.py`**: Replaces the direct `authorization_service.check(resource=AgentexResource.agent(...), operation=update)` call with `_check_agent_or_collapse_to_404(...)`, delegating 403-vs-404 disambiguation to `check_resource_or_collapse_unreadable_to_404`.
- **`test_agent_api_keys_authz.py`**: The single old 403-propagation test is replaced by two new tests that independently cover both the collapse-to-404 path (update denied + read denied) and the surface-403 path (update denied + read allowed), plus adds `get_by_agent_id_and_name.assert_not_called()` guards to verify the mutation path is never reached when auth fails.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted one-line swap that brings `create_api_key` in line with all other agent-resource checks already using the same helper.

The route change is small and surgical: one call replaced with a well-tested shared helper that is already used in multiple other paths. The new tests cover both outcome branches (collapse to 404 and surface 403), include mutation-guard assertions, and the happy-path test confirms only a single auth check occurs on success. No regressions are visible in adjacent routes.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/api/routes/agent_api_keys.py | Replaces direct `authorization_service.check` call with `_check_agent_or_collapse_to_404` for consistent 403/404 visibility semantics on `create_api_key`; also removes now-unused `AgentexResource` import. |
| agentex/tests/unit/api/test_agent_api_keys_authz.py | Expands the single old 403-propagation test into two precise tests covering collapse-to-404 and surface-403 paths, with added mutation-guard assertions. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Route as create_api_key
    participant AgentUC as AgentUseCase
    participant Helper as _check_agent_or_collapse_to_404
    participant AuthSvc as AuthorizationService
    participant KeyUC as APIKeyUseCase

    Client->>Route: POST /agent_api_keys
    Route->>AgentUC: get(id/name)
    AgentUC-->>Route: agent (or 404 if absent)

    Route->>Helper: (authz, agent.id, update)
    Helper->>AuthSvc: check(agent, update)

    alt update allowed
        AuthSvc-->>Helper: OK
        Helper-->>Route: OK
        Route->>KeyUC: get_by_agent_id_and_name(...)
        Route->>KeyUC: create(...)
        KeyUC-->>Route: new key
        Route-->>Client: 200 CreateAPIKeyResponse
    else update denied + read denied
        AuthSvc-->>Helper: AuthorizationError
        Helper->>AuthSvc: check(agent, read)
        AuthSvc-->>Helper: AuthorizationError
        Helper-->>Route: ItemDoesNotExist (404)
        Route-->>Client: 404
    else update denied + read allowed
        AuthSvc-->>Helper: AuthorizationError
        Helper->>AuthSvc: check(agent, read)
        AuthSvc-->>Helper: OK
        Helper-->>Route: AuthorizationError (403)
        Route-->>Client: 403
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(authz): hide unreadable agents on ap..."](https://github.com/scaleapi/scale-agentex/commit/f9eb55cce610b7e250919842d6fc5b0c75a11294) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36794484)</sub>

<!-- /greptile_comment -->