### PR TITLE
docs: specify the AGENTEX_AUTH_URL auth provider HTTP contract

### DIFF
--- a/agentex/docs/docs/development_guides/auth_provider_contract.md
+++ b/agentex/docs/docs/development_guides/auth_provider_contract.md
@@ -1,0 +1,369 @@
+# Auth Provider Contract (`AGENTEX_AUTH_URL`)
+
+Agentex delegates **authentication** (who is calling?) and **authorization** (are
+they allowed to do this?) to an external HTTP service. You point Agentex at that
+service with a single environment variable:
+
+```bash
+AGENTEX_AUTH_URL=https://my-auth-provider.internal
+```
+
+This document specifies the HTTP contract that service must satisfy. Anyone can
+implement it — there is no dependency on Scale's internal `agentex-auth`
+service. This makes the auth provider a **documented extension point**: a naive
+single-account implementation is a few dozen lines, while a full multi-tenant
+implementation can layer in fine-grained access control behind the same wire
+format.
+
+> **Scope.** This contract covers the endpoints a self-hosted / open-source
+> deployment needs: `/v1/authn` plus the authorization endpoints `grant`,
+> `revoke`, `check`, `search`, `register`, and `deregister`. Fine-grained access
+> control (FGAC), per-account routing, and dual-write rollouts are Scale-internal
+> concerns and are **not** part of this contract.
+
+---
+
+## How Agentex calls the provider
+
+- **Disabled by default.** If `AGENTEX_AUTH_URL` is unset or empty, the auth
+  middleware is disabled: all authentication is skipped and all authorization
+  checks are bypassed (every request is treated as fully authorized). This is the
+  default local-development behavior — you only run an auth provider when you set
+  the variable.
+- **Authentication is middleware.** On every non-whitelisted request, Agentex
+  forwards the incoming request headers to `POST {AGENTEX_AUTH_URL}/v1/authn`. A
+  `200` returns a **principal context** that Agentex attaches to the request; any
+  failure becomes a `401` to the original caller.
+- **Authorization is inline.** When handling a request, Agentex calls the
+  `/v1/authz/*` endpoints, passing back the exact principal context it received
+  from `/v1/authn`.
+- **Responses are cached.** Agentex caches successful `/v1/authn` results keyed on
+  the forwarded headers. Provider responses should therefore be a pure function of
+  the request headers.
+
+### Whitelisted (unauthenticated) routes
+
+These routes bypass the provider entirely and are never sent to `/v1/authn`:
+
+```
+/agents/register   /agents/forward   /docs   /api   /openapi.json   /redoc
+/favicon.ico   /health   /healthcheck   /healthz   /readyz   /ping   /echo
+```
+
+(plus any sub-path under them, and all `OPTIONS` preflight requests).
+
+---
+
+## Conventions
+
+| Aspect | Value |
+| --- | --- |
+| Transport | HTTP/1.1, JSON request and response bodies (`Content-Type: application/json`) |
+| Method | All endpoints are `POST` |
+| Base path | `AGENTEX_AUTH_URL` is the origin; paths below are appended verbatim |
+| Auth of the provider itself | Out of scope — secure the network path (mTLS / private network / shared secret) as you see fit |
+
+### Status code semantics
+
+The Agentex client interprets the HTTP **status code**, not the response body, to
+decide what happened. The body matters only where noted (`/v1/authn` principal,
+`search` items).
+
+| Status | Meaning to Agentex | Resulting behavior |
+| --- | --- | --- |
+| `200` | Success | Proceed. For `check`, the principal is authorized. For `search`, read `items`. |
+| `401` | Unauthenticated — missing/invalid credentials | Request rejected as `401 Unauthorized` |
+| `403` | Authenticated but not permitted | Treated as a permission denial (e.g. `check` failed) |
+| `502` | Provider acted as a bad gateway | Surfaced as a gateway error |
+| `503` | Provider temporarily unavailable | Surfaced as service-unavailable |
+| other `5xx` | Provider internal error | Surfaced as a service error |
+| other non-`200` | Unexpected | Surfaced as a service error |
+
+A network/timeout failure reaching the provider is treated as service-unavailable.
+
+### The principal context (opaque round-trip)
+
+The **principal context** is a JSON object returned by `/v1/authn`. Agentex treats
+it as **opaque** — it does not inspect or validate its shape. It caches the object,
+attaches it to the request, and passes it back **verbatim** as the `principal`
+field of every subsequent authorization call.
+
+The practical consequence: **the provider owns its own identity shape end to
+end.** You can return whatever JSON your authz logic needs (a user id, an account
+id, claims from a JWT, etc.) and it will be handed straight back to you on
+`grant` / `revoke` / `check` / `search` / `register` / `deregister`. Agentex is
+just a courier.
+
+Example (the shape Scale's reference provider happens to use — yours can differ):
+
+```json
+{
+  "user_id": "user_123",
+  "account_id": "acct_456",
+  "service_account_id": null,
+  "metadata": {}
+}
+```
+
+### Shared request types
+
+Authorization requests share a small vocabulary.
+
+**Resource** — the object being acted on:
+
+```json
+{ "type": "agent", "selector": "agent_abc123" }
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `type` | enum string | One of `agent`, `task`, `api_key`, `schedule` |
+| `selector` | string | The resource id |
+
+**Operation** — one of: `create`, `read`, `update`, `delete`, `execute`, `cancel`.
+
+---
+
+## Authentication
+
+### `POST /v1/authn`
+
+Verify the caller's credentials and return their principal context.
+
+**Request.** Agentex forwards the incoming request's headers (lowercased) as the
+outbound request headers. It strips hop-by-hop headers (`content-length`, `host`,
+`connection`, `transfer-encoding`, `expect`). The request body is empty — **all
+input is in the headers.** The provider reads whatever credential headers it
+cares about, for example:
+
+- `authorization: Bearer <token>` (e.g. an OIDC / Entra ID access token)
+- `x-api-key: <key>`
+- `cookie: <session>`
+
+**Response — `200`:** the principal context (any JSON object). This becomes the
+`principal` for all later authz calls.
+
+```json
+{ "user_id": "user_123", "account_id": "acct_456", "metadata": {} }
+```
+
+**Response — `401`:** credentials missing or invalid. Agentex rejects the original
+request with `401 Unauthorized`.
+
+---
+
+## Authorization
+
+All authorization endpoints receive the principal context (exactly as returned by
+`/v1/authn`) under the `principal` key.
+
+> **Agent-to-agent calls.** Requests bearing a valid internal agent API key
+> (`x-agent-api-key`) are authenticated by Agentex directly against its own
+> database and **do not** hit the provider. The provider only sees end-user /
+> service-account traffic.
+
+### `POST /v1/authz/check`
+
+The core read gate. Determine whether the principal may perform `operation` on
+`resource`.
+
+**Request:**
+
+```json
+{
+  "principal": { "user_id": "user_123", "account_id": "acct_456" },
+  "resource": { "type": "task", "selector": "task_789" },
+  "operation": "read"
+}
+```
+
+**Response:**
+
+- `200` → **allowed**. Body: `{ "success": true }` (body is not otherwise read).
+- `403` → **denied**.
+
+### `POST /v1/authz/search`
+
+List the resource ids of a given type that the principal may access. Agentex uses
+the returned `items` to **scope list endpoints** — effectively a
+`WHERE id IN (items)` filter over the resources of that type.
+
+**Request:**
+
+```json
+{
+  "principal": { "user_id": "user_123", "account_id": "acct_456" },
+  "filter_resource": "task",
+  "filter_operation": "read"
+}
+```
+
+**Response — `200`:**
+
+```json
+{ "items": ["task_1", "task_2", "task_3"], "success": true }
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `items` | `string[]` | Resource ids the principal may access. **Required.** |
+
+> ⚠️ **`items` is an inclusion filter, not a hint.** Returning `[]` hides *every*
+> resource of that type from the principal. There is no "all resources" sentinel
+> in the base contract — see [Allowing everything](#authorization-allow-everything)
+> for how a permissive provider should handle this.
+
+### `POST /v1/authz/grant`
+
+Grant `operation` on `resource` to the principal (explicit sharing).
+
+**Request:** same shape as `check`. **Response:** `200` with `{ "success": true }`.
+
+### `POST /v1/authz/revoke`
+
+Revoke a previously granted `(principal, resource, operation)` edge.
+
+**Request:** same shape as `check`. **Response:** `200` with `{ "success": true }`.
+
+### `POST /v1/authz/register`
+
+Called by Agentex when a resource is **created** (agents, tasks, api keys,
+schedules). Registers the new resource with the principal as its owner, optionally
+linking it to a parent resource so that permission checks can cascade.
+
+**Request:**
+
+```json
+{
+  "principal": { "user_id": "user_123", "account_id": "acct_456" },
+  "resource": { "type": "task", "selector": "task_789" },
+  "parent": { "type": "agent", "selector": "agent_abc123" }
+}
+```
+
+`parent` may be `null`. **Response:** `200` with `{ "success": true }`.
+
+### `POST /v1/authz/deregister`
+
+Called by Agentex when a resource is **deleted**. Removes the resource and all of
+its relationships.
+
+**Request:**
+
+```json
+{
+  "principal": { "user_id": "user_123", "account_id": "acct_456" },
+  "resource": { "type": "task", "selector": "task_789" }
+}
+```
+
+**Response:** `200` with `{ "success": true }`.
+
+> **`register`/`deregister` are not optional to *implement*, even though their
+> behavior can be trivial.** Agentex calls them on every create/delete whenever a
+> provider is configured. A provider that omits them (returning `404`) will turn
+> every resource create into a `500`. A permissive provider should return `200`
+> from both (see below).
+
+### Endpoint summary
+
+| Endpoint | Purpose | Success | Denial |
+| --- | --- | --- | --- |
+| `POST /v1/authn` | Authenticate, return principal | `200` + principal | `401` |
+| `POST /v1/authz/check` | Read gate | `200` | `403` |
+| `POST /v1/authz/search` | List accessible ids | `200` + `{items}` | `200` + `{items: []}` |
+| `POST /v1/authz/grant` | Share a resource | `200` | `403` |
+| `POST /v1/authz/revoke` | Un-share a resource | `200` | `403` |
+| `POST /v1/authz/register` | Register created resource | `200` | `403` |
+| `POST /v1/authz/deregister` | Remove deleted resource | `200` | `403` |
+
+---
+
+## Implementation notes
+
+The contract above is provider-agnostic. This section sketches two concrete
+implementations: authenticating against **Microsoft Entra ID**, and an
+**"allow everything"** authorization model for single-account deployments.
+
+### Authentication against Entra ID
+
+For a single-account deployment, `/v1/authn` can be as simple as: *take the
+caller's bearer token, validate it against Entra ID, and return a principal.*
+
+1. **Read the token.** Pull the access token from the `authorization: Bearer
+   <token>` header that Agentex forwarded.
+2. **Validate it.** Verify the JWT against your Entra ID tenant:
+   - Fetch the tenant's signing keys (JWKS) from the OIDC discovery document:
+     `https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration`
+     → `jwks_uri`. Cache the keys.
+   - Verify the signature, and validate `iss`, `aud` (your app/API client id),
+     and `exp`.
+3. **Build the principal.** Map standard claims into your principal shape, e.g.
+   `oid` (the stable user object id) → `user_id`, `tid` (tenant) → `account_id`.
+   Return it as the `200` body.
+4. **Reject on failure.** Any missing/expired/invalid token → `401`.
+
+```jsonc
+// 200 response from /v1/authn after validating an Entra ID token
+{
+  "user_id": "<oid claim>",
+  "account_id": "<tid claim>",
+  "metadata": { "upn": "<preferred_username claim>" }
+}
+```
+
+Because the principal is opaque to Agentex, you are free to carry whatever claims
+your authorization logic needs — they round-trip back to you on every authz call.
+
+> **Service accounts / agents.** If non-interactive callers use the OAuth2 client
+> credentials flow, the token will have no user `oid`. Detect that (e.g. an `idtyp`
+> / `app`-style claim) and populate a service-account identity instead of a user
+> identity.
+
+<a id="authorization-allow-everything"></a>
+### Authorization: "allow everything" (single account)
+
+If you assume a single account/tenant and don't need per-resource permissions,
+authorization collapses to "yes" almost everywhere. The endpoints split into two
+groups:
+
+**Endpoints you can no-op** — anything keyed on a status code can simply return
+`200`:
+
+| Endpoint | "Allow everything" behavior |
+| --- | --- |
+| `POST /v1/authz/check` | Always return `200` (never `403`) |
+| `POST /v1/authz/grant` | Return `200` (nothing to persist) |
+| `POST /v1/authz/revoke` | Return `200` (nothing to persist) |
+| `POST /v1/authz/register` | Return `200` (no ownership graph to maintain) |
+| `POST /v1/authz/deregister` | Return `200` (nothing to clean up) |
+
+**The one endpoint you can't no-op: `search`.** Its `items` array is applied as an
+inclusion filter, so it must reflect "everything." Returning `[]` would hide all
+resources — the opposite of "allow everything." You have three options:
+
+1. **Recommended — add a wildcard sentinel to the contract.** Have `search` signal
+   "no filter / everything" rather than enumerate. Agentex already has an internal
+   "no scoping" path: when authorization is disabled it represents "all resources"
+   as *no filter at all* rather than an explicit id list. The clean fix is to
+   surface that over the wire — e.g. `search` returns `{ "items": null }` (or an
+   explicit `{ "unscoped": true }`), and the Agentex authorization proxy maps that
+   sentinel to "no filter," reusing the existing unscoped code path instead of
+   building an `id IN (...)` clause. This keeps the permissive provider truly
+   stateless. *(This requires a small change in the Agentex proxy to recognize the
+   sentinel — it is not yet part of the shipped contract, but it is the
+   lowest-friction way to support permissive providers and is the recommended
+   addition.)*
+
+2. **Enumerate from Agentex's own data.** Have the provider (or a thin sidecar)
+   query Agentex's database / API for all resource ids of `filter_resource` in the
+   account and return them. Correct with no Agentex change, but couples the
+   provider to Agentex's storage and scales poorly on large accounts.
+
+3. **Don't use list endpoints.** If the deployment never relies on the scoped list
+   routes, the `items` filter is moot. Fragile — easy to regress — so only viable
+   for narrow, controlled deployments.
+
+Option 1 is the right long-term shape: it makes "allow everything" a genuinely
+stateless provider and formalizes a wildcard in the contract that any provider can
+use.

--- a/agentex/docs/docs/development_guides/auth_provider_contract.md
+++ b/agentex/docs/docs/development_guides/auth_provider_contract.md
@@ -80,6 +80,14 @@ decide what happened. The body matters only where noted (`/v1/authn` principal,
 
 A network/timeout failure reaching the provider is treated as service-unavailable.
 
+> **`/v1/authn` collapses every failure to `401`.** The status-code distinctions
+> above (`502`/`503`/`5xx`) are preserved only for the **authz** endpoints, which
+> are called inside request handlers. Authentication runs in middleware that
+> catches *any* non-`200` from the provider — including `5xx` — and returns a flat
+> `401 Unauthorized` to the original caller. A `503` from your authn endpoint
+> during an outage will therefore reach clients as `401`, not as a retryable
+> service-unavailable error.
+
 ### The principal context (opaque round-trip)
 
 The **principal context** is a JSON object returned by `/v1/authn`. Agentex treats

--- a/agentex/docs/docs/development_guides/auth_provider_contract.md
+++ b/agentex/docs/docs/development_guides/auth_provider_contract.md
@@ -29,7 +29,7 @@ behind the same wire format.
   checks are bypassed (every request is treated as fully authorized). This is the
   default local-development behavior — you only run an auth provider when you set
   the variable.
-- **Authentication is middleware.** On every non-whitelisted request, Agentex
+- **Authentication is middleware.** On every non-allowlisted request, Agentex
   forwards the incoming request headers to `POST {AGENTEX_AUTH_URL}/v1/authn`. A
   `200` returns a **principal context** that Agentex attaches to the request; any
   failure becomes a `401` to the original caller.
@@ -40,7 +40,7 @@ behind the same wire format.
   the forwarded headers. Provider responses should therefore be a pure function of
   the request headers.
 
-### Whitelisted (unauthenticated) routes
+### Allowlisted (unauthenticated) routes
 
 These routes bypass the provider entirely and are never sent to `/v1/authn`:
 

--- a/agentex/docs/docs/development_guides/auth_provider_contract.md
+++ b/agentex/docs/docs/development_guides/auth_provider_contract.md
@@ -209,8 +209,8 @@ the returned `items` to **scope list endpoints** — effectively a
 
 > ⚠️ **`items` is an inclusion filter, not a hint.** Returning `[]` hides *every*
 > resource of that type from the principal. There is no "all resources" sentinel
-> in the base contract — see [Allowing everything](#authorization-allow-everything)
-> for how a permissive provider should handle this.
+> in the base contract, so a provider that intends to grant broad access must
+> return the actual set of accessible ids.
 
 ### `POST /v1/authz/grant`
 
@@ -275,94 +275,3 @@ its relationships.
 | `POST /v1/authz/revoke` | Un-share a resource | `200` | `403` |
 | `POST /v1/authz/register` | Register created resource | `200` | `403` |
 | `POST /v1/authz/deregister` | Remove deleted resource | `200` | `403` |
-
----
-
-## Implementation notes
-
-The contract above is provider-agnostic. This section sketches two concrete
-implementations: authenticating against **Microsoft Entra ID**, and an
-**"allow everything"** authorization model for single-account deployments.
-
-### Authentication against Entra ID
-
-For a single-account deployment, `/v1/authn` can be as simple as: *take the
-caller's bearer token, validate it against Entra ID, and return a principal.*
-
-1. **Read the token.** Pull the access token from the `authorization: Bearer
-   <token>` header that Agentex forwarded.
-2. **Validate it.** Verify the JWT against your Entra ID tenant:
-   - Fetch the tenant's signing keys (JWKS) from the OIDC discovery document:
-     `https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration`
-     → `jwks_uri`. Cache the keys.
-   - Verify the signature, and validate `iss`, `aud` (your app/API client id),
-     and `exp`.
-3. **Build the principal.** Map standard claims into your principal shape, e.g.
-   `oid` (the stable user object id) → `user_id`, `tid` (tenant) → `account_id`.
-   Return it as the `200` body.
-4. **Reject on failure.** Any missing/expired/invalid token → `401`.
-
-```jsonc
-// 200 response from /v1/authn after validating an Entra ID token
-{
-  "user_id": "<oid claim>",
-  "account_id": "<tid claim>",
-  "metadata": { "upn": "<preferred_username claim>" }
-}
-```
-
-Because the principal is opaque to Agentex, you are free to carry whatever claims
-your authorization logic needs — they round-trip back to you on every authz call.
-
-> **Service accounts / agents.** If non-interactive callers use the OAuth2 client
-> credentials flow, the token will have no user `oid`. Detect that (e.g. an `idtyp`
-> / `app`-style claim) and populate a service-account identity instead of a user
-> identity.
-
-<a id="authorization-allow-everything"></a>
-### Authorization: "allow everything" (single account)
-
-If you assume a single account/tenant and don't need per-resource permissions,
-authorization collapses to "yes" almost everywhere. The endpoints split into two
-groups:
-
-**Endpoints you can no-op** — anything keyed on a status code can simply return
-`200`:
-
-| Endpoint | "Allow everything" behavior |
-| --- | --- |
-| `POST /v1/authz/check` | Always return `200` (never `403`) |
-| `POST /v1/authz/grant` | Return `200` (nothing to persist) |
-| `POST /v1/authz/revoke` | Return `200` (nothing to persist) |
-| `POST /v1/authz/register` | Return `200` (no ownership graph to maintain) |
-| `POST /v1/authz/deregister` | Return `200` (nothing to clean up) |
-
-**The one endpoint you can't no-op: `search`.** Its `items` array is applied as an
-inclusion filter, so it must reflect "everything." Returning `[]` would hide all
-resources — the opposite of "allow everything." You have three options:
-
-1. **Recommended — add a wildcard sentinel to the contract.** Have `search` signal
-   "no filter / everything" rather than enumerate. Agentex already has an internal
-   "no scoping" path: when authorization is disabled it represents "all resources"
-   as *no filter at all* rather than an explicit id list. The clean fix is to
-   surface that over the wire — e.g. `search` returns `{ "items": null }` (or an
-   explicit `{ "unscoped": true }`), and the Agentex authorization proxy maps that
-   sentinel to "no filter," reusing the existing unscoped code path instead of
-   building an `id IN (...)` clause. This keeps the permissive provider truly
-   stateless. *(This requires a small change in the Agentex proxy to recognize the
-   sentinel — it is not yet part of the shipped contract, but it is the
-   lowest-friction way to support permissive providers and is the recommended
-   addition.)*
-
-2. **Enumerate from Agentex's own data.** Have the provider (or a thin sidecar)
-   query Agentex's database / API for all resource ids of `filter_resource` in the
-   account and return them. Correct with no Agentex change, but couples the
-   provider to Agentex's storage and scales poorly on large accounts.
-
-3. **Don't use list endpoints.** If the deployment never relies on the scoped list
-   routes, the `items` filter is moot. Fragile — easy to regress — so only viable
-   for narrow, controlled deployments.
-
-Option 1 is the right long-term shape: it makes "allow everything" a genuinely
-stateless provider and formalizes a wildcard in the contract that any provider can
-use.

--- a/agentex/docs/docs/development_guides/auth_provider_contract.md
+++ b/agentex/docs/docs/development_guides/auth_provider_contract.md
@@ -9,17 +9,16 @@ AGENTEX_AUTH_URL=https://my-auth-provider.internal
 ```
 
 This document specifies the HTTP contract that service must satisfy. Anyone can
-implement it — there is no dependency on Scale's internal `agentex-auth`
-service. This makes the auth provider a **documented extension point**: a naive
-single-account implementation is a few dozen lines, while a full multi-tenant
-implementation can layer in fine-grained access control behind the same wire
-format.
+implement it from this spec alone. This makes the auth provider a **documented
+extension point**: a naive single-account implementation is a few dozen lines,
+while a full multi-tenant implementation can layer in fine-grained access control
+behind the same wire format.
 
 > **Scope.** This contract covers the endpoints a self-hosted / open-source
 > deployment needs: `/v1/authn` plus the authorization endpoints `grant`,
 > `revoke`, `check`, `search`, `register`, and `deregister`. Fine-grained access
-> control (FGAC), per-account routing, and dual-write rollouts are Scale-internal
-> concerns and are **not** part of this contract.
+> control (FGAC), per-account routing, and dual-write rollouts are out of scope
+> and are **not** part of this contract.
 
 ---
 
@@ -94,7 +93,7 @@ id, claims from a JWT, etc.) and it will be handed straight back to you on
 `grant` / `revoke` / `check` / `search` / `register` / `deregister`. Agentex is
 just a courier.
 
-Example (the shape Scale's reference provider happens to use — yours can differ):
+Example (one possible shape — yours can differ):
 
 ```json
 {

--- a/agentex/docs/mkdocs.yml
+++ b/agentex/docs/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - State Machines: development_guides/state_machines.md
       - Agent Task Tracker: development_guides/agent_task_tracker.md
       - Webhooks: development_guides/webhooks.md
+      - Auth Provider Contract: development_guides/auth_provider_contract.md
       - Enterprise Edition: development_guides/enterprise_edition.md
   - Temporal Development:
       - Overview: temporal_development/overview.md


### PR DESCRIPTION
## What

Documents the HTTP contract that a service pointed to by `AGENTEX_AUTH_URL` must implement, so the auth provider becomes a clearly documented extension point. A self-hosted / open-source deployment can implement this contract directly without depending on any Scale-internal auth service.

New doc: `agentex/docs/docs/development_guides/auth_provider_contract.md` (added to the docs nav under **Development Guides**).

## Contract covered

- **`POST /v1/authn`** — authenticate from forwarded request headers, return an opaque principal context.
- **`POST /v1/authz/*`** — `check`, `search`, `grant`, `revoke`, `register`, `deregister`, with request/response shapes and status-code semantics.

The contract was derived from the existing integration on both sides: the consumer-side proxies/middleware in `agentex/src` (which define what gets sent and how status codes are interpreted) and the reference provider's routers/schemas.

### Key points the doc makes explicit

- **The principal is an opaque round-trip object.** Agentex never inspects it — it caches the `/v1/authn` result and passes it back verbatim on every authz call. This is what lets a provider own its own identity shape (and makes OIDC/Entra ID pluggable with no Agentex change).
- **Status code is the API.** `200`=success, `401`=unauthenticated, `403`=denied, `5xx`=service errors. `check` returns no meaningful body.
- **`register`/`deregister` must exist.** Agentex calls them on every resource create/delete when a provider is configured, so omitting them turns creates into 500s. Their behavior can be a trivial `200` no-op.

## Implementation guidance

The doc includes two concrete sketches:

1. **Authenticating against an OIDC provider (e.g. Entra ID)** — validate the bearer JWT against the tenant JWKS, map standard claims into a principal.
2. **An "allow everything" single-account authorization model** — `check`/`grant`/`revoke`/`register`/`deregister` collapse to `200`, but **`search` cannot be a no-op** because its `items` list is consumed as an inclusion filter (`WHERE id IN (...)`); returning `[]` hides everything.

## Note for reviewers — one follow-up

The recommended "allow everything" approach for `search` is a **wildcard sentinel** (e.g. `{"items": null}`) that the Agentex authorization proxy maps to its existing "no filter" code path. That sentinel is **not yet part of the shipped contract** — supporting a truly stateless permissive provider would need a small proxy change. The doc calls this out explicitly as a recommended addition rather than describing it as current behavior.

## Type of change

Documentation only. No code or runtime behavior changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new reference doc (`agentex/docs/docs/development_guides/auth_provider_contract.md`) that specifies the HTTP contract a service pointed to by `AGENTEX_AUTH_URL` must implement, making the auth provider a documented extension point for self-hosted deployments. The contract was cross-checked against the actual consumer-side code in `adapter_agentex_authn_proxy.py`, `adapter_agentex_authz_proxy.py`, and `middleware_utils.py` and is accurate in all request/response shapes, status-code semantics, allowlist routes, header-stripping, and the caching behavior.

- **New doc** (`auth_provider_contract.md`): covers `POST /v1/authn` and all six `POST /v1/authz/*` endpoints with wire-format examples, status-code semantics, and important behavioral callouts (principal opacity, authn 5xx collapse, `search` as an inclusion filter, `register`/`deregister` being mandatory).
- **`mkdocs.yml`**: single nav entry added under Development Guides, placed between Webhooks and Enterprise Edition.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after resolving the broken forward reference; all documented behavior has been verified against the actual implementation code.

The doc is accurate and well-researched, but line 273 explicitly directs readers to implementation guidance that is not present in the file — a provider author implementing the permissive use case (the most likely open-source scenario) will follow that reference and find nothing.

agentex/docs/docs/development_guides/auth_provider_contract.md — the dangling "(see below)" at line 273 needs either the missing implementation sketches added or the forward reference removed.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/docs/docs/development_guides/auth_provider_contract.md | New reference doc for the AGENTEX_AUTH_URL provider contract; content is accurate and well-structured, but a forward "(see below)" reference at line 273 points to implementation sketches that are absent from the file. |
| agentex/docs/mkdocs.yml | Adds the new auth provider contract page to the Development Guides nav section between Webhooks and Enterprise Edition; no issues. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as Agentex Middleware
    participant Provider as Auth Provider
    participant Handler as Agentex Handler

    Client->>Middleware: HTTP Request (with headers)
    Note over Middleware: Allowlisted route or x-agent-api-key? Skip provider
    Middleware->>Provider: POST /v1/authn (forwarded headers, empty body)
    alt 200 OK
        Provider-->>Middleware: principal context JSON
        Middleware->>Middleware: Cache principal keyed on headers
        Middleware->>Handler: Request + principal_context
        Handler->>Provider: POST /v1/authz/check or search or register etc
        alt 200
            Provider-->>Handler: success body
            Handler-->>Client: Response
        else 403
            Provider-->>Handler: denied
            Handler-->>Client: 403 Forbidden
        else 5xx or network error
            Provider-->>Handler: error
            Handler-->>Client: 5xx propagated
        end
    else any non-200 including 5xx
        Provider-->>Middleware: error
        Middleware-->>Client: 401 Unauthorized
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fdocs%2Fdocs%2Fdevelopment_guides%2Fauth_provider_contract.md%3A273%0A**Dangling%20%22%28see%20below%29%22%20forward%20reference**%0A%0AThe%20callout%20at%20this%20line%20directs%20implementers%20to%20%22see%20below%22%20for%20how%20a%20permissive%20provider%20should%20handle%20%60register%60%2F%60deregister%60%2C%20but%20the%20doc%20ends%20three%20lines%20later%20with%20the%20endpoint%20summary%20table%20%E2%80%94%20there%20is%20no%20%22below%22%20section.%20The%20PR%20description%20mentions%20two%20concrete%20implementation%20sketches%20%28OIDC%20%2F%20Entra%20ID%20and%20an%20%22allow%20everything%22%20model%29%2C%20but%20they%20were%20not%20included%20in%20the%20file.%20A%20provider%20author%20following%20this%20reference%20will%20find%20nothing%2C%20leaving%20the%20most%20common%20open-source%20use%20case%20undocumented.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fdocs%2Fdocs%2Fdevelopment_guides%2Fauth_provider_contract.md%3A189%0A**%60check%60%20200%20body%20must%20be%20valid%20JSON**%0A%0AThe%20note%20%22%28body%20is%20not%20otherwise%20read%29%22%20may%20lead%20a%20provider%20author%20to%20return%20an%20empty%20or%20plain-text%20%60200%60%2C%20but%20%60HttpRequestHandler.post_with_error_handling%60%20always%20calls%20%60response.json%28%29%60%20on%20every%20%60200%60%20response%20and%20raises%20%60ServiceError%60%20if%20parsing%20fails.%20An%20empty%20body%20or%20a%20non-JSON%20string%20like%20%60%22OK%22%60%20would%20cause%20a%20%60ServiceError%60%20on%20every%20%60check%60%20call.%20The%20doc%20already%20shows%20%60%7B%20%22success%22%3A%20true%20%7D%60%20as%20the%20suggested%20shape%2C%20but%20clarifying%20that%20**valid%20JSON%20is%20required**%20%28even%20though%20the%20content%20is%20ignored%29%20would%20prevent%20this%20trap.%0A%0A&pr=300&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fdocs%2Fdocs%2Fdevelopment_guides%2Fauth_provider_contract.md%3A273%0A**Dangling%20%22%28see%20below%29%22%20forward%20reference**%0A%0AThe%20callout%20at%20this%20line%20directs%20implementers%20to%20%22see%20below%22%20for%20how%20a%20permissive%20provider%20should%20handle%20%60register%60%2F%60deregister%60%2C%20but%20the%20doc%20ends%20three%20lines%20later%20with%20the%20endpoint%20summary%20table%20%E2%80%94%20there%20is%20no%20%22below%22%20section.%20The%20PR%20description%20mentions%20two%20concrete%20implementation%20sketches%20%28OIDC%20%2F%20Entra%20ID%20and%20an%20%22allow%20everything%22%20model%29%2C%20but%20they%20were%20not%20included%20in%20the%20file.%20A%20provider%20author%20following%20this%20reference%20will%20find%20nothing%2C%20leaving%20the%20most%20common%20open-source%20use%20case%20undocumented.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fdocs%2Fdocs%2Fdevelopment_guides%2Fauth_provider_contract.md%3A189%0A**%60check%60%20200%20body%20must%20be%20valid%20JSON**%0A%0AThe%20note%20%22%28body%20is%20not%20otherwise%20read%29%22%20may%20lead%20a%20provider%20author%20to%20return%20an%20empty%20or%20plain-text%20%60200%60%2C%20but%20%60HttpRequestHandler.post_with_error_handling%60%20always%20calls%20%60response.json%28%29%60%20on%20every%20%60200%60%20response%20and%20raises%20%60ServiceError%60%20if%20parsing%20fails.%20An%20empty%20body%20or%20a%20non-JSON%20string%20like%20%60%22OK%22%60%20would%20cause%20a%20%60ServiceError%60%20on%20every%20%60check%60%20call.%20The%20doc%20already%20shows%20%60%7B%20%22success%22%3A%20true%20%7D%60%20as%20the%20suggested%20shape%2C%20but%20clarifying%20that%20**valid%20JSON%20is%20required**%20%28even%20though%20the%20content%20is%20ignored%29%20would%20prevent%20this%20trap.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=300&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22docs%2Fauth-provider-contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fauth-provider-contract%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fdocs%2Fdocs%2Fdevelopment_guides%2Fauth_provider_contract.md%3A273%0A**Dangling%20%22%28see%20below%29%22%20forward%20reference**%0A%0AThe%20callout%20at%20this%20line%20directs%20implementers%20to%20%22see%20below%22%20for%20how%20a%20permissive%20provider%20should%20handle%20%60register%60%2F%60deregister%60%2C%20but%20the%20doc%20ends%20three%20lines%20later%20with%20the%20endpoint%20summary%20table%20%E2%80%94%20there%20is%20no%20%22below%22%20section.%20The%20PR%20description%20mentions%20two%20concrete%20implementation%20sketches%20%28OIDC%20%2F%20Entra%20ID%20and%20an%20%22allow%20everything%22%20model%29%2C%20but%20they%20were%20not%20included%20in%20the%20file.%20A%20provider%20author%20following%20this%20reference%20will%20find%20nothing%2C%20leaving%20the%20most%20common%20open-source%20use%20case%20undocumented.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fdocs%2Fdocs%2Fdevelopment_guides%2Fauth_provider_contract.md%3A189%0A**%60check%60%20200%20body%20must%20be%20valid%20JSON**%0A%0AThe%20note%20%22%28body%20is%20not%20otherwise%20read%29%22%20may%20lead%20a%20provider%20author%20to%20return%20an%20empty%20or%20plain-text%20%60200%60%2C%20but%20%60HttpRequestHandler.post_with_error_handling%60%20always%20calls%20%60response.json%28%29%60%20on%20every%20%60200%60%20response%20and%20raises%20%60ServiceError%60%20if%20parsing%20fails.%20An%20empty%20body%20or%20a%20non-JSON%20string%20like%20%60%22OK%22%60%20would%20cause%20a%20%60ServiceError%60%20on%20every%20%60check%60%20call.%20The%20doc%20already%20shows%20%60%7B%20%22success%22%3A%20true%20%7D%60%20as%20the%20suggested%20shape%2C%20but%20clarifying%20that%20**valid%20JSON%20is%20required**%20%28even%20though%20the%20content%20is%20ignored%29%20would%20prevent%20this%20trap.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=300&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
agentex/docs/docs/development_guides/auth_provider_contract.md:273
**Dangling "(see below)" forward reference**

The callout at this line directs implementers to "see below" for how a permissive provider should handle `register`/`deregister`, but the doc ends three lines later with the endpoint summary table — there is no "below" section. The PR description mentions two concrete implementation sketches (OIDC / Entra ID and an "allow everything" model), but they were not included in the file. A provider author following this reference will find nothing, leaving the most common open-source use case undocumented.

### Issue 2 of 2
agentex/docs/docs/development_guides/auth_provider_contract.md:189
**`check` 200 body must be valid JSON**

The note "(body is not otherwise read)" may lead a provider author to return an empty or plain-text `200`, but `HttpRequestHandler.post_with_error_handling` always calls `response.json()` on every `200` response and raises `ServiceError` if parsing fails. An empty body or a non-JSON string like `"OK"` would cause a `ServiceError` on every `check` call. The doc already shows `{ "success": true }` as the suggested shape, but clarifying that **valid JSON is required** (even though the content is ignored) would prevent this trap.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into docs/auth-provi..."](https://github.com/scaleapi/scale-agentex/commit/19b242b7d7fdf2c112302c1636135b82dcd7ceef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36789156)</sub>

<!-- /greptile_comment -->