### PR TITLE
feat(test-seeding): add gated POST /test/seed for e2e test resource seeding

### DIFF
--- a/agentex/src/api/app.py
+++ b/agentex/src/api/app.py
@@ -195,14 +195,21 @@ fastapi_app.include_router(schedules.router)
 fastapi_app.include_router(checkpoints.router)
 fastapi_app.include_router(task_retention.router)
 
-# Test-only seeding endpoint. Gated by env (must opt in AND not be prod) so
-# this code path is unreachable in production deployments by construction --
-# the router is not even mounted. Both conditions are required.
+# Test-only seeding endpoint. Gated by env (must opt in AND be on a known
+# non-prod environment) so this code path is unreachable in production
+# deployments by construction -- the router is not even mounted.
+#
+# Allow-list rather than deny-list: ENVIRONMENT is typed `str | None` and
+# populated raw from os.environ with no enum coercion, so a deny-list against
+# Environment.PROD would fail OPEN on unset, "prod", "Production", typos, or
+# any new environment name. Mount only when ENVIRONMENT is an explicitly
+# known non-prod value.
+_TEST_SEEDING_ALLOWED_ENVS = {Environment.DEV, Environment.STAGING}
 _test_seeding_env_vars = EnvironmentVariables.refresh()
 if (
     _test_seeding_env_vars is not None
     and _test_seeding_env_vars.ENABLE_TEST_SEEDING
-    and _test_seeding_env_vars.ENVIRONMENT != Environment.PROD
+    and _test_seeding_env_vars.ENVIRONMENT in _TEST_SEEDING_ALLOWED_ENVS
 ):
     from src.api.routes import test_seeding
 

--- a/agentex/src/api/app.py
+++ b/agentex/src/api/app.py
@@ -35,7 +35,7 @@ from src.config.dependencies import (
     GlobalDependencies,
     resolve_environment_variable_dependency,
 )
-from src.config.environment_variables import EnvVarKeys
+from src.config.environment_variables import EnvironmentVariables, EnvVarKeys, Environment
 from src.domain.exceptions import GenericException
 from src.utils.logging import make_logger
 from src.utils.otel_metrics import init_otel_metrics, shutdown_otel_metrics
@@ -194,6 +194,24 @@ fastapi_app.include_router(deployments.router)
 fastapi_app.include_router(schedules.router)
 fastapi_app.include_router(checkpoints.router)
 fastapi_app.include_router(task_retention.router)
+
+# Test-only seeding endpoint. Gated by env (must opt in AND not be prod) so
+# this code path is unreachable in production deployments by construction --
+# the router is not even mounted. Both conditions are required.
+_test_seeding_env_vars = EnvironmentVariables.refresh()
+if (
+    _test_seeding_env_vars is not None
+    and _test_seeding_env_vars.ENABLE_TEST_SEEDING
+    and _test_seeding_env_vars.ENVIRONMENT != Environment.PROD
+):
+    from src.api.routes import test_seeding
+
+    fastapi_app.include_router(test_seeding.router)
+    logger.warning(
+        "Test seeding endpoint /test/seed is MOUNTED. "
+        "This must never happen in production.",
+        extra={"environment": _test_seeding_env_vars.ENVIRONMENT},
+    )
 
 # Wrap FastAPI app with health check interceptor for sub-millisecond K8s probe responses.
 # This must be the outermost layer to bypass all middleware.

--- a/agentex/src/api/routes/test_seeding.py
+++ b/agentex/src/api/routes/test_seeding.py
@@ -1,0 +1,170 @@
+"""Test-only seeding endpoint.
+
+POST /test/seed lets e2e tests insert resource rows directly, bypassing the ACP
+runtime. The router is only mounted in app.py when both:
+  - env_vars.ENABLE_TEST_SEEDING is true
+  - env_vars.ENVIRONMENT != Environment.PROD
+
+Per-request the endpoint also requires the X-Test-Seed-Token header to match
+env_vars.TEST_SEED_TOKEN (compared with hmac.compare_digest).
+
+All gate failures return 404 (not 401/403) to avoid advertising the route's
+existence on misconfigured deployments. This file + the use case + the env
+config + the mount check in app.py are the four removal points if test seeding
+ever moves to a separate test-utilities image.
+"""
+
+from __future__ import annotations
+
+import hmac
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from pydantic import Field
+
+from src.api.schemas.events import Event
+from src.config.dependencies import GlobalDependencies
+from src.config.environment_variables import Environment, EnvironmentVariables
+from src.domain.use_cases.test_seeding_use_case import DTestSeedingUseCase
+from src.utils.logging import make_logger
+from src.utils.model_utils import BaseModel
+
+
+def get_seeding_env_vars() -> EnvironmentVariables:
+    """Named dependency callable for the seeding gate.
+
+    Defined as a named function (not an inline lambda) so tests can override it
+    via ``fastapi_app.dependency_overrides[get_seeding_env_vars] = ...``. The
+    process-wide ``DEnvironmentVariables`` alias uses an inline lambda which
+    cannot be keyed in dependency_overrides.
+    """
+    return GlobalDependencies().environment_variables
+
+logger = make_logger(__name__)
+
+router = APIRouter(prefix="/test", tags=["TestSeeding"])
+
+
+# -- request payload schemas ---------------------------------------------------
+
+
+class _EventSeedPayload(BaseModel):
+    """Payload for seeding a single event row."""
+
+    task_id: UUID = Field(..., description="Parent task UUID. Must already exist.")
+    agent_id: UUID = Field(..., description="Parent agent UUID. Must already exist.")
+    content: dict[str, Any] | None = Field(
+        None,
+        description=(
+            "Optional event content. Will be wrapped in a DataContentEntity and "
+            "have audit-marker keys ('seeded', 'seeded_at') added before persist."
+        ),
+    )
+    id: UUID | None = Field(
+        None,
+        description="Optional event UUID override. Auto-generated if omitted.",
+    )
+
+
+class SeedEventRequest(BaseModel):
+    """Discriminated request for seeding an event.
+
+    To add a new seedable resource (task, api_key, schedule, ...), add a sibling
+    `SeedXxxRequest` class with `resource_type: Literal["xxx"]`, then add it to
+    the `SeedRequest` union below and dispatch in the route handler.
+    """
+
+    resource_type: Literal["event"]
+    payload: _EventSeedPayload
+
+
+# When adding a second resource type, change this to:
+#   SeedRequest = Annotated[
+#       SeedEventRequest | SeedTaskRequest | ...,
+#       Field(discriminator="resource_type"),
+#   ]
+# For now there is a single variant; we keep the discriminated shape so the
+# eventual extension is mechanical.
+SeedRequest = SeedEventRequest
+
+
+# -- gate ----------------------------------------------------------------------
+
+
+def _require_test_seeding_enabled(
+    env_vars: Annotated[EnvironmentVariables, Depends(get_seeding_env_vars)],
+    x_test_seed_token: Annotated[str | None, Header(alias="X-Test-Seed-Token")] = None,
+) -> None:
+    """Fail-closed gate for the seeding endpoint.
+
+    All failure modes return 404 (not 401/403) so we don't advertise that the
+    route exists on misconfigured deployments. Token comparison is constant-time.
+    """
+    not_found = HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND, detail="Not Found"
+    )
+
+    # Hard env gate, regardless of flag. Paranoia: prevents a flag-flip in prod
+    # from exposing seeding even momentarily.
+    if env_vars.ENVIRONMENT == Environment.PROD:
+        raise not_found
+
+    if not env_vars.ENABLE_TEST_SEEDING:
+        raise not_found
+
+    expected = env_vars.TEST_SEED_TOKEN
+    if not expected:
+        # No token configured -> endpoint is unusable even with the flag on.
+        raise not_found
+
+    if not x_test_seed_token:
+        raise not_found
+
+    if not hmac.compare_digest(x_test_seed_token, expected):
+        raise not_found
+
+
+# -- route ---------------------------------------------------------------------
+
+
+@router.post(
+    "/seed",
+    response_model=Event,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_require_test_seeding_enabled)],
+)
+async def seed_resource(
+    body: SeedRequest,
+    request: Request,
+    use_case: DTestSeedingUseCase,
+) -> Event:
+    """Test-only direct insert. Returns the persisted resource entity.
+
+    Extension point: when SeedRequest becomes a true union, dispatch on
+    body.resource_type here. Each branch should call into its matching
+    `use_case.seed_<resource>(...)` method.
+    """
+    principal_id: str | None = None
+    principal_ctx = getattr(request.state, "principal_context", None)
+    if isinstance(principal_ctx, dict):
+        principal_id = principal_ctx.get("user_id") or principal_ctx.get(
+            "service_account_id"
+        )
+
+    if body.resource_type == "event":
+        payload = body.payload
+        event_entity = await use_case.seed_event(
+            task_id=str(payload.task_id),
+            agent_id=str(payload.agent_id),
+            content=payload.content,
+            id_override=str(payload.id) if payload.id is not None else None,
+            principal_id=principal_id,
+        )
+        return Event.model_validate(event_entity)
+
+    # Defensive: the discriminator should make this unreachable.
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"Unsupported resource_type: {body.resource_type!r}",
+    )

--- a/agentex/src/api/routes/test_seeding.py
+++ b/agentex/src/api/routes/test_seeding.py
@@ -3,7 +3,10 @@
 POST /test/seed lets e2e tests insert resource rows directly, bypassing the ACP
 runtime. The router is only mounted in app.py when both:
   - env_vars.ENABLE_TEST_SEEDING is true
-  - env_vars.ENVIRONMENT != Environment.PROD
+  - env_vars.ENVIRONMENT is an explicitly-allowed non-prod value
+    (Environment.DEV or Environment.STAGING). Unknown / typo'd / unset
+    environments fail closed because ENVIRONMENT is typed `str | None`
+    with no enum coercion.
 
 Per-request the endpoint also requires the X-Test-Seed-Token header to match
 env_vars.TEST_SEED_TOKEN (compared with hmac.compare_digest).
@@ -29,6 +32,11 @@ from src.config.environment_variables import Environment, EnvironmentVariables
 from src.domain.use_cases.test_seeding_use_case import DTestSeedingUseCase
 from src.utils.logging import make_logger
 from src.utils.model_utils import BaseModel
+
+# Allow-list of non-prod environment names for the seeding gate. Kept in sync
+# with the mount-time check in src/api/app.py — any new non-prod environment
+# must be added in both places.
+_ALLOWED_ENVS: frozenset[str] = frozenset({Environment.DEV, Environment.STAGING})
 
 
 def get_seeding_env_vars() -> EnvironmentVariables:
@@ -105,9 +113,12 @@ def _require_test_seeding_enabled(
         status_code=status.HTTP_404_NOT_FOUND, detail="Not Found"
     )
 
-    # Hard env gate, regardless of flag. Paranoia: prevents a flag-flip in prod
-    # from exposing seeding even momentarily.
-    if env_vars.ENVIRONMENT == Environment.PROD:
+    # Hard env gate, regardless of flag. Allow-list rather than deny-list:
+    # ENVIRONMENT is raw os.environ with no enum coercion, so a deny-list
+    # against PROD would fail OPEN on unset / "prod" / "Production" / typos /
+    # new env names. Fail closed on anything we don't explicitly recognize as
+    # non-prod.
+    if env_vars.ENVIRONMENT not in _ALLOWED_ENVS:
         raise not_found
 
     if not env_vars.ENABLE_TEST_SEEDING:

--- a/agentex/src/config/environment_variables.py
+++ b/agentex/src/config/environment_variables.py
@@ -65,6 +65,8 @@ class EnvVarKeys(str, Enum):
     RETENTION_CLEANUP_PAGE_SIZE = "RETENTION_CLEANUP_PAGE_SIZE"
     RETENTION_CLEANUP_MAX_IN_FLIGHT = "RETENTION_CLEANUP_MAX_IN_FLIGHT"
     RETENTION_CLEANUP_DRY_RUN = "RETENTION_CLEANUP_DRY_RUN"
+    ENABLE_TEST_SEEDING = "ENABLE_TEST_SEEDING"
+    TEST_SEED_TOKEN = "TEST_SEED_TOKEN"
 
 
 class Environment(str, Enum):
@@ -128,6 +130,11 @@ class EnvironmentVariables(BaseModel):
     RETENTION_CLEANUP_PAGE_SIZE: int = 200
     RETENTION_CLEANUP_MAX_IN_FLIGHT: int = 20
     RETENTION_CLEANUP_DRY_RUN: bool = True
+    # Test-only seeding gate. Both must be set for the /test/seed endpoint to be
+    # mounted. Defaults are fail-closed: endpoint is unreachable in any env that
+    # doesn't explicitly opt in. Hard-gated off in production regardless of flag.
+    ENABLE_TEST_SEEDING: bool = False
+    TEST_SEED_TOKEN: str | None = None
 
     @classmethod
     def refresh(cls, force_refresh: bool = False) -> EnvironmentVariables | None:
@@ -242,6 +249,10 @@ class EnvironmentVariables(BaseModel):
             RETENTION_CLEANUP_DRY_RUN=(
                 os.environ.get(EnvVarKeys.RETENTION_CLEANUP_DRY_RUN, "true") == "true"
             ),
+            ENABLE_TEST_SEEDING=(
+                os.environ.get(EnvVarKeys.ENABLE_TEST_SEEDING, "false") == "true"
+            ),
+            TEST_SEED_TOKEN=os.environ.get(EnvVarKeys.TEST_SEED_TOKEN),
         )
         refreshed_environment_variables = environment_variables
         return refreshed_environment_variables

--- a/agentex/src/domain/use_cases/test_seeding_use_case.py
+++ b/agentex/src/domain/use_cases/test_seeding_use_case.py
@@ -32,7 +32,6 @@ logger = make_logger(__name__)
 
 
 class TestSeedingUseCase:  # noqa: PT001 — not a pytest class; "Test" prefix is the use-case domain name
-    __test__ = False  # tell pytest not to collect this as a test class
     """Test-only resource seeding.
 
     Each `seed_<resource>` method writes a row directly via the matching
@@ -46,6 +45,11 @@ class TestSeedingUseCase:  # noqa: PT001 — not a pytest class; "Test" prefix i
     also call authorization_service.register_resource(...) before persisting,
     mirroring the pattern in agent_api_keys_use_case._register_api_key_in_auth.
     """
+
+    # Tell pytest not to collect this as a test class. Must come AFTER the
+    # docstring — Python only treats a string literal as __doc__ when it's
+    # the FIRST statement in the class body.
+    __test__ = False
 
     def __init__(self, event_repository: DEventRepository) -> None:
         self.event_repository = event_repository

--- a/agentex/src/domain/use_cases/test_seeding_use_case.py
+++ b/agentex/src/domain/use_cases/test_seeding_use_case.py
@@ -1,0 +1,120 @@
+"""Test-only seeding use case.
+
+Inserts resource rows directly into the repositories without going through the
+ACP runtime. Mounted only when ENABLE_TEST_SEEDING is true AND
+ENVIRONMENT != production. The endpoint that calls into this use case is gated
+to the same conditions plus a shared-secret header. See
+src/api/routes/test_seeding.py.
+
+This module is deliberately isolated so it can be deleted in one surgical
+removal when/if test seeding moves into a separate test-utilities image.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from fastapi import Depends
+
+from src.domain.entities.events import EventEntity
+from src.domain.entities.task_messages import (
+    DataContentEntity,
+    MessageAuthor,
+    TaskMessageContentEntity,
+    TaskMessageContentType,
+)
+from src.domain.repositories.event_repository import DEventRepository
+from src.utils.ids import orm_id
+from src.utils.logging import make_logger
+
+logger = make_logger(__name__)
+
+
+class TestSeedingUseCase:  # noqa: PT001 — not a pytest class; "Test" prefix is the use-case domain name
+    __test__ = False  # tell pytest not to collect this as a test class
+    """Test-only resource seeding.
+
+    Each `seed_<resource>` method writes a row directly via the matching
+    repository, mirroring the persistence half of the natural-flow write path
+    but skipping any downstream side effects (ACP forwards, etc.).
+
+    NOTE on FGAC: events are not a first-class FGAC resource
+    (AgentexResourceType has only agent/task/api_key/schedule). Event authz
+    delegates to the parent agent. When seeding future FGAC-registered
+    resources (task, api_key, schedule), the corresponding seed_* method MUST
+    also call authorization_service.register_resource(...) before persisting,
+    mirroring the pattern in agent_api_keys_use_case._register_api_key_in_auth.
+    """
+
+    def __init__(self, event_repository: DEventRepository) -> None:
+        self.event_repository = event_repository
+
+    async def seed_event(
+        self,
+        *,
+        task_id: str,
+        agent_id: str,
+        content: dict[str, Any] | None = None,
+        id_override: str | None = None,
+        principal_id: str | None = None,
+    ) -> EventEntity:
+        """Seed a single event row.
+
+        Injects an audit marker `{"seeded": true, "seeded_at": <iso8601>}` into
+        the persisted content so downstream tests can filter for seeded rows.
+        """
+        event_id = id_override or orm_id()
+        seeded_at = datetime.now(timezone.utc).isoformat()
+
+        # Build the persisted content: start with any caller-supplied dict, then
+        # overlay the audit marker. If no content was supplied, persist just the
+        # marker as a DataContentEntity (events.content is nullable but we want
+        # the marker to always be present, and DATA is the only content type
+        # that accepts an arbitrary dict).
+        merged: dict[str, Any] = dict(content) if content else {}
+        merged["seeded"] = True
+        merged["seeded_at"] = seeded_at
+
+        # Seeded events are synthetic; mark them as agent-authored. The author
+        # field is required by BaseTaskMessageContentEntity but has no
+        # semantic meaning for seeded rows -- the {"seeded": true} audit
+        # marker in `data` is the actual signal for downstream filtering.
+        content_entity: TaskMessageContentEntity = DataContentEntity(
+            type=TaskMessageContentType.DATA,
+            author=MessageAuthor.AGENT,
+            data=merged,
+        )
+
+        event = await self.event_repository.create(
+            id=event_id,
+            task_id=task_id,
+            agent_id=agent_id,
+            content=content_entity,
+        )
+
+        logger.info(
+            "test seeding wrote resource",
+            extra={
+                "resource_type": "event",
+                "resource_id": event.id,
+                "principal_id": principal_id,
+                "task_id": task_id,
+                "agent_id": agent_id,
+            },
+        )
+
+        # TODO when adding seed_task / seed_api_key / seed_schedule:
+        # FGAC-registered resources MUST also call
+        # authorization_service.register_resource(
+        #     resource=AgentexResource.<type>(<id>),
+        #     parent=AgentexResource.agent(<agent_id>),
+        # )
+        # BEFORE persisting, mirroring agent_api_keys_use_case._register_api_key_in_auth.
+        # Events are exempt from this because event authz delegates to the parent
+        # agent (which must already exist & already be registered).
+
+        return event
+
+
+DTestSeedingUseCase = Annotated[TestSeedingUseCase, Depends(TestSeedingUseCase)]

--- a/agentex/tests/integration/api/test_test_seeding_api.py
+++ b/agentex/tests/integration/api/test_test_seeding_api.py
@@ -1,0 +1,301 @@
+"""Integration tests for the test-only /test/seed endpoint.
+
+Covers:
+  - Gate behavior (flag off, prod env, missing/wrong token) -> 404
+  - Happy path: event row is persisted and returned
+  - Audit marker injected into content
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from src.api.app import fastapi_app
+from src.api.routes import test_seeding as test_seeding_route
+from src.api.routes.test_seeding import get_seeding_env_vars
+from src.config.environment_variables import Environment
+from src.domain.entities.agents import ACPType, AgentEntity
+from src.domain.entities.tasks import TaskEntity, TaskStatus
+from src.domain.use_cases.test_seeding_use_case import TestSeedingUseCase
+from src.utils.ids import orm_id
+
+VALID_TOKEN = "test-seed-token-abc123"
+
+
+class _FakeEnvVars:
+    """Minimal stand-in for EnvironmentVariables; only the attrs the gate reads."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool = True,
+        environment: str = Environment.DEV,
+        token: str | None = VALID_TOKEN,
+    ) -> None:
+        self.ENABLE_TEST_SEEDING = enabled
+        self.ENVIRONMENT = environment
+        self.TEST_SEED_TOKEN = token
+
+
+@pytest_asyncio.fixture
+async def seeded_agent_and_task(isolated_repositories):
+    """Create an agent + task so seeded events have valid FKs."""
+    agent = await isolated_repositories["agent_repository"].create(
+        AgentEntity(
+            id=orm_id(),
+            name="seed-test-agent",
+            description="seed",
+            acp_url="http://acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+    )
+    task = await isolated_repositories["task_repository"].create(
+        agent_id=agent.id,
+        task=TaskEntity(
+            id=orm_id(),
+            name="seed-test-task",
+            status=TaskStatus.RUNNING,
+            status_reason="seed",
+        ),
+    )
+    return {"agent": agent, "task": task}
+
+
+@pytest_asyncio.fixture
+async def seeding_client(isolated_integration_app, isolated_repositories):
+    """Provide an httpx client with the seeding router mounted + gate overridden.
+
+    The seeding router is normally only mounted when ENABLE_TEST_SEEDING=true at
+    process start. In tests we register the router on fastapi_app manually and
+    override DEnvironmentVariables to control the gate per test.
+    """
+    # Mount the router (idempotent - FastAPI tolerates re-includes only via
+    # checking existing routes; safer to add once and rely on dependency
+    # overrides for gate behavior).
+    already_mounted = any(
+        getattr(r, "path", None) == "/test/seed" for r in fastapi_app.routes
+    )
+    if not already_mounted:
+        fastapi_app.include_router(test_seeding_route.router)
+
+    # Wire the use case to the isolated event repository.
+    def _make_use_case():
+        return TestSeedingUseCase(
+            event_repository=isolated_repositories["event_repository"]
+        )
+
+    fastapi_app.dependency_overrides[TestSeedingUseCase] = _make_use_case
+
+    # Default to enabled + dev env + valid token.
+    fastapi_app.dependency_overrides[get_seeding_env_vars] = lambda: _FakeEnvVars()
+
+    from src.api.app import app as wrapped_app
+
+    async with AsyncClient(
+        transport=ASGITransport(app=wrapped_app), base_url="http://test"
+    ) as client:
+        yield client, isolated_repositories
+
+
+def _override_env(env_vars: _FakeEnvVars) -> None:
+    fastapi_app.dependency_overrides[get_seeding_env_vars] = lambda: env_vars
+
+
+@pytest.mark.integration
+class TestTestSeedingGate:
+    @pytest.mark.asyncio
+    async def test_flag_off_returns_404(self, seeding_client, seeded_agent_and_task):
+        client, _ = seeding_client
+        _override_env(_FakeEnvVars(enabled=False))
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                },
+            },
+            headers={"X-Test-Seed-Token": VALID_TOKEN},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_prod_env_returns_404_even_with_flag_on(
+        self, seeding_client, seeded_agent_and_task
+    ):
+        client, _ = seeding_client
+        _override_env(_FakeEnvVars(enabled=True, environment=Environment.PROD))
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                },
+            },
+            headers={"X-Test-Seed-Token": VALID_TOKEN},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_returns_404(
+        self, seeding_client, seeded_agent_and_task
+    ):
+        client, _ = seeding_client
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                },
+            },
+            headers={"X-Test-Seed-Token": "wrong-token"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_missing_token_returns_404(
+        self, seeding_client, seeded_agent_and_task
+    ):
+        client, _ = seeding_client
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                },
+            },
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_token_not_configured_returns_404(
+        self, seeding_client, seeded_agent_and_task
+    ):
+        client, _ = seeding_client
+        _override_env(_FakeEnvVars(enabled=True, token=None))
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                },
+            },
+            headers={"X-Test-Seed-Token": "anything"},
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.integration
+class TestTestSeedingEvent:
+    @pytest.mark.asyncio
+    async def test_seed_event_happy_path(
+        self, seeding_client, seeded_agent_and_task
+    ):
+        client, repos = seeding_client
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                    "content": {"hello": "world"},
+                },
+            },
+            headers={"X-Test-Seed-Token": VALID_TOKEN},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["task_id"] == seeded_agent_and_task["task"].id
+        assert body["agent_id"] == seeded_agent_and_task["agent"].id
+        assert body["id"]
+        assert isinstance(body["sequence_id"], int)
+
+        # Verify the row is in the repo
+        listed = await repos["event_repository"].list_events_after_last_processed(
+            task_id=seeded_agent_and_task["task"].id,
+            agent_id=seeded_agent_and_task["agent"].id,
+        )
+        assert len(listed) == 1
+        assert listed[0].id == body["id"]
+
+    @pytest.mark.asyncio
+    async def test_seed_event_audit_marker_present(
+        self, seeding_client, seeded_agent_and_task
+    ):
+        client, repos = seeding_client
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                    "content": {"foo": "bar"},
+                },
+            },
+            headers={"X-Test-Seed-Token": VALID_TOKEN},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        # Response uses TaskMessageContent (api schema). The DataContentEntity
+        # round-trips through the API as {"type": "data", "data": {...}}.
+        content = body["content"]
+        assert content is not None
+        assert content["type"] == "data"
+        data = content["data"]
+        assert data.get("seeded") is True
+        assert "seeded_at" in data and isinstance(data["seeded_at"], str)
+        # Caller-provided keys preserved alongside the marker.
+        assert data.get("foo") == "bar"
+
+    @pytest.mark.asyncio
+    async def test_seed_event_audit_marker_when_no_content(
+        self, seeding_client, seeded_agent_and_task
+    ):
+        client, _ = seeding_client
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                },
+            },
+            headers={"X-Test-Seed-Token": VALID_TOKEN},
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()["content"]["data"]
+        assert data == {"seeded": True, "seeded_at": data["seeded_at"]}
+
+    @pytest.mark.asyncio
+    async def test_seed_event_id_override(
+        self, seeding_client, seeded_agent_and_task
+    ):
+        client, _ = seeding_client
+        override_id = orm_id()
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                    "id": override_id,
+                },
+            },
+            headers={"X-Test-Seed-Token": VALID_TOKEN},
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["id"] == override_id

--- a/agentex/tests/integration/api/test_test_seeding_api.py
+++ b/agentex/tests/integration/api/test_test_seeding_api.py
@@ -85,6 +85,12 @@ async def seeding_client(isolated_integration_app, isolated_repositories):
             event_repository=isolated_repositories["event_repository"]
         )
 
+    # Snapshot overrides so teardown can restore — covers both the fixture's
+    # own injections AND any mid-test mutations from `_override_env`. Without
+    # this, entries leak into fastapi_app's global state and can bleed into
+    # other test modules sharing the same app instance.
+    original_overrides = fastapi_app.dependency_overrides.copy()
+
     fastapi_app.dependency_overrides[TestSeedingUseCase] = _make_use_case
 
     # Default to enabled + dev env + valid token.
@@ -92,10 +98,13 @@ async def seeding_client(isolated_integration_app, isolated_repositories):
 
     from src.api.app import app as wrapped_app
 
-    async with AsyncClient(
-        transport=ASGITransport(app=wrapped_app), base_url="http://test"
-    ) as client:
-        yield client, isolated_repositories
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=wrapped_app), base_url="http://test"
+        ) as client:
+            yield client, isolated_repositories
+    finally:
+        fastapi_app.dependency_overrides = original_overrides
 
 
 def _override_env(env_vars: _FakeEnvVars) -> None:

--- a/agentex/tests/integration/api/test_test_seeding_api.py
+++ b/agentex/tests/integration/api/test_test_seeding_api.py
@@ -30,7 +30,7 @@ class _FakeEnvVars:
         self,
         *,
         enabled: bool = True,
-        environment: str = Environment.DEV,
+        environment: str | None = Environment.DEV,
         token: str | None = VALID_TOKEN,
     ) -> None:
         self.ENABLE_TEST_SEEDING = enabled
@@ -148,6 +148,42 @@ class TestTestSeedingGate:
             headers={"X-Test-Seed-Token": VALID_TOKEN},
         )
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_env",
+        [
+            None,           # unset env var
+            "",             # empty string
+            "prod",         # short form (not Environment.PROD's "production")
+            "Production",   # case variant
+            "dev",          # short form (not Environment.DEV's "development")
+            "qa",           # unknown environment name
+        ],
+        ids=["unset", "empty", "prod_short", "prod_titlecase", "dev_short", "unknown"],
+    )
+    async def test_unknown_environment_returns_404(
+        self, seeding_client, seeded_agent_and_task, bad_env
+    ):
+        """Allow-list, not deny-list: ENVIRONMENT is raw os.environ with no enum
+        coercion, so any value the gate doesn't explicitly recognize as non-prod
+        must fail closed."""
+        client, _ = seeding_client
+        _override_env(_FakeEnvVars(enabled=True, environment=bad_env))
+        resp = await client.post(
+            "/test/seed",
+            json={
+                "resource_type": "event",
+                "payload": {
+                    "task_id": seeded_agent_and_task["task"].id,
+                    "agent_id": seeded_agent_and_task["agent"].id,
+                },
+            },
+            headers={"X-Test-Seed-Token": VALID_TOKEN},
+        )
+        assert resp.status_code == 404, (
+            f"environment={bad_env!r} should fail closed, got {resp.status_code}"
+        )
 
     @pytest.mark.asyncio
     async def test_wrong_token_returns_404(


### PR DESCRIPTION
## Summary

Adds a test-only seeding endpoint at \`POST /test/seed\` so the e2e suite (scaleapi/agentex#378) can directly insert resource rows for FGAC assertions, bypassing the natural-flow side effects (ACP forward, worker pickup, etc.).

The endpoint writes via the existing repository layer — same path the natural flow takes — so seeded rows are indistinguishable from real ones to downstream consumers, except for an audit marker (below).

## Why

E2E tests for FGAC need to assert authz outcomes (e.g. denied-get → 404) against real resource rows. A 404 on a *missing* row doesn't prove the same code path as a 404 on a *denied* row. Black-box seeding via the natural flow requires a healthy running agent for events, which is heavy/flaky for an e2e suite.

For events specifically, scaleapi/agentex#378 ships a workaround that exploits a quirk of \`task_service.create_event_and_forward_to_acp\` (writes row before forward). That works for events but isn't a general solution — this endpoint is.

## Gate (defense in depth)

| Layer | Behavior |
|---|---|
| \`ENABLE_TEST_SEEDING\` env flag (default \`False\`) | Router not mounted |
| \`ENVIRONMENT != production\` hard-check in \`app.py\` | Prod never has the route, regardless of flag |
| \`X-Test-Seed-Token\` header (\`hmac.compare_digest\`) | Auth missing/wrong → 404 |

All gate failures return **404, not 401/403** — the route's existence isn't advertised.

## Audit

- Every seeded event has \`{"seeded": true, "seeded_at": <iso8601>}\` injected into its \`content\` payload — downstream filterable.
- Structured \`logger.info("test seeding wrote resource", extra={...})\` log on every seed call.

## Scope today, extension later

Ships event seeding only. The use case is structured so adding \`seed_task\` / \`seed_api_key\` / \`seed_schedule\` is mechanical — each new type wraps its own branch and (for FGAC-registered types) mirrors the natural flow's \`register_resource\` call. A \`TODO\` comment marks that integration point for the next contributor.

Events are intentionally NOT registered as a top-level FGAC resource here — they delegate read authz to the parent agent, matching the natural flow. Verified against \`AgentexResourceType\` and \`routes/events.py\`.

## Test plan

- [x] 9 new integration tests in \`tests/integration/api/test_test_seeding_api.py\`: gate-flag-off, prod-env hard-gate, wrong/missing/unconfigured token, happy path with + without content, audit-marker presence, id override.
- [x] Full integration API suite (243 tests) green — no regressions.

## Files

- \`src/config/environment_variables.py\` — \`ENABLE_TEST_SEEDING\` + \`TEST_SEED_TOKEN\` config.
- \`src/api/routes/test_seeding.py\` — route + discriminated request schema + gate dependency.
- \`src/domain/use_cases/test_seeding_use_case.py\` — \`TestSeedingUseCase\` (event-only today, extensible).
- \`src/api/app.py\` — conditional router mount with prod hard-gate.
- \`tests/integration/api/test_test_seeding_api.py\` — gate + happy-path coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a gated `POST /test/seed` endpoint so the e2e suite can insert resource rows directly — bypassing ACP, worker pickup, and other natural-flow side effects — for FGAC assertion testing. The endpoint is protected by three independent layers: an opt-in env flag, an allow-list environment check that fails closed on prod/unknown environments, and a constant-time shared-secret header check; all failures return 404 to avoid advertising the route.

- **`src/api/routes/test_seeding.py`** — new router with a discriminated request schema (`SeedEventRequest`) and a `_require_test_seeding_enabled` dependency that enforces all three gate layers per request.
- **`src/domain/use_cases/test_seeding_use_case.py`** — `TestSeedingUseCase.seed_event` writes directly via the event repository and injects a `{\"seeded\": true, \"seeded_at\": ...}` audit marker into every persisted row.
- **`src/api/app.py`** — conditionally mounts the router at startup using the same allow-list check; emits a `logger.warning` if it mounts so the state is visible in logs.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The three-layer gate (env flag + allow-list environment check + constant-time token) is well-designed and fails closed; the router is never mounted in production by construction.

The gating logic is careful and consistent between mount-time (app.py) and per-request (test_seeding.py) checks. The test suite covers all gate failure paths and the happy path with audit-marker validation. The two findings are minor edge cases that do not affect the core security properties of the implementation.

No files require special attention. The _ALLOWED_ENVS set is defined in both app.py and test_seeding.py — the in-code comment calls this out — so reviewers should ensure both are updated together if a new non-prod environment is ever added.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/api/routes/test_seeding.py | New gated POST /test/seed endpoint with discriminated request schema; gate uses allow-list env check + constant-time token comparison; all failure modes return 404. |
| agentex/src/domain/use_cases/test_seeding_use_case.py | New use case that writes event rows directly via the event repository, injects a seeded/seeded_at audit marker, and logs structured metadata. TODO comment is missing a ticket number. |
| agentex/src/api/app.py | Conditionally mounts the test-seeding router using an allow-list environment check at process start; logs a warning if the router is mounted. Straightforward and safe. |
| agentex/src/config/environment_variables.py | Adds ENABLE_TEST_SEEDING (bool, default False) and TEST_SEED_TOKEN (str | None, default None) env vars; both default to the safest off/unset state. |
| agentex/tests/integration/api/test_test_seeding_api.py | Nine integration tests covering all gate failure modes plus happy-path and audit-marker assertions; fixture now snapshots and restores dependency_overrides to avoid bleed into other test modules. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant E2E as E2E Test Client
    participant App as FastAPI app.py (startup)
    participant Gate as _require_test_seeding_enabled
    participant Route as POST /test/seed
    participant UC as TestSeedingUseCase
    participant Repo as EventRepository

    App->>App: EnvironmentVariables.refresh()
    alt "ENABLE_TEST_SEEDING AND ENVIRONMENT in {DEV, STAGING}"
        App->>App: include_router(test_seeding.router) + logger.warning
    else
        App->>App: router not mounted
    end

    E2E->>Route: POST /test/seed + X-Test-Seed-Token header
    Route->>Gate: Depends(_require_test_seeding_enabled)
    Gate->>Gate: check ENVIRONMENT in allow-list
    Gate->>Gate: check ENABLE_TEST_SEEDING flag
    Gate->>Gate: check TEST_SEED_TOKEN configured
    Gate->>Gate: hmac.compare_digest(header, expected)
    alt any check fails
        Gate-->>E2E: 404 Not Found
    else all checks pass
        Gate-->>Route: proceed
        Route->>UC: seed_event(task_id, agent_id, content, ...)
        UC->>UC: merge content + inject seeded/seeded_at marker
        UC->>Repo: create(id, task_id, agent_id, content_entity)
        Repo-->>UC: EventEntity
        UC->>UC: logger.info(test seeding wrote resource)
        UC-->>Route: EventEntity
        Route-->>E2E: 201 Created (Event schema)
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Ftest_seeding_use_case.py%3A111-119%0A**TODO%20missing%20a%20linked%20ticket%20number**%0A%0AThe%20comment%20block%20starting%20at%20this%20line%20is%20a%20multi-step%20future%20obligation%20%28FGAC%20%60register_resource%60%20wiring%20for%20tasks%2C%20api%20keys%2C%20and%20schedules%29.%20Per%20the%20team's%20convention%2C%20TODO%20comments%20should%20include%20a%20ticket%20number%20so%20future%20contributors%20can%20discover%2C%20prioritise%2C%20and%20track%20the%20work.%20Without%20one%2C%20this%20is%20a%20bookmark%20that%20is%20easy%20to%20overlook%20or%20lose%20in%20a%20later%20search.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fsrc%2Fapi%2Froutes%2Ftest_seeding.py%3A135%0A**%60hmac.compare_digest%60%20raises%20%60ValueError%60%20for%20non-ASCII%20token%20strings**%0A%0APython's%20%60hmac.compare_digest%60%20only%20accepts%20ASCII-only%20%60str%60%20arguments%3B%20any%20non-ASCII%20character%20raises%20%60ValueError%3A%20strings%20can%20only%20contain%20ASCII%20characters%60%20rather%20than%20returning%20%60False%60.%20If%20%60TEST_SEED_TOKEN%60%20is%20set%20to%20a%20value%20that%20contains%20non-ASCII%20bytes%20%28e.g.%2C%20a%20raw%20binary%20secret%20pasted%20from%20a%20password%20manager%29%2C%20the%20call%20throws%20an%20unhandled%20exception%20that%20propagates%20as%20a%20500%2C%20revealing%20that%20the%20route%20exists%20%E2%80%94%20the%20opposite%20of%20the%20intended%20%22fail%20silently%20with%20404%22%20behaviour.%20Encoding%20both%20sides%20to%20bytes%20before%20comparison%20eliminates%20this%20class%20of%20error%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20not%20hmac.compare_digest%28x_test_seed_token.encode%28%29%2C%20expected.encode%28%29%29%3A%0A%60%60%60%0A%0A&pr=301&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Ftest_seeding_use_case.py%3A111-119%0A**TODO%20missing%20a%20linked%20ticket%20number**%0A%0AThe%20comment%20block%20starting%20at%20this%20line%20is%20a%20multi-step%20future%20obligation%20%28FGAC%20%60register_resource%60%20wiring%20for%20tasks%2C%20api%20keys%2C%20and%20schedules%29.%20Per%20the%20team's%20convention%2C%20TODO%20comments%20should%20include%20a%20ticket%20number%20so%20future%20contributors%20can%20discover%2C%20prioritise%2C%20and%20track%20the%20work.%20Without%20one%2C%20this%20is%20a%20bookmark%20that%20is%20easy%20to%20overlook%20or%20lose%20in%20a%20later%20search.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fsrc%2Fapi%2Froutes%2Ftest_seeding.py%3A135%0A**%60hmac.compare_digest%60%20raises%20%60ValueError%60%20for%20non-ASCII%20token%20strings**%0A%0APython's%20%60hmac.compare_digest%60%20only%20accepts%20ASCII-only%20%60str%60%20arguments%3B%20any%20non-ASCII%20character%20raises%20%60ValueError%3A%20strings%20can%20only%20contain%20ASCII%20characters%60%20rather%20than%20returning%20%60False%60.%20If%20%60TEST_SEED_TOKEN%60%20is%20set%20to%20a%20value%20that%20contains%20non-ASCII%20bytes%20%28e.g.%2C%20a%20raw%20binary%20secret%20pasted%20from%20a%20password%20manager%29%2C%20the%20call%20throws%20an%20unhandled%20exception%20that%20propagates%20as%20a%20500%2C%20revealing%20that%20the%20route%20exists%20%E2%80%94%20the%20opposite%20of%20the%20intended%20%22fail%20silently%20with%20404%22%20behaviour.%20Encoding%20both%20sides%20to%20bytes%20before%20comparison%20eliminates%20this%20class%20of%20error%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20not%20hmac.compare_digest%28x_test_seed_token.encode%28%29%2C%20expected.encode%28%29%29%3A%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=301&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22dhruv%2Ftest-seeding-endpoint%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dhruv%2Ftest-seeding-endpoint%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Ftest_seeding_use_case.py%3A111-119%0A**TODO%20missing%20a%20linked%20ticket%20number**%0A%0AThe%20comment%20block%20starting%20at%20this%20line%20is%20a%20multi-step%20future%20obligation%20%28FGAC%20%60register_resource%60%20wiring%20for%20tasks%2C%20api%20keys%2C%20and%20schedules%29.%20Per%20the%20team's%20convention%2C%20TODO%20comments%20should%20include%20a%20ticket%20number%20so%20future%20contributors%20can%20discover%2C%20prioritise%2C%20and%20track%20the%20work.%20Without%20one%2C%20this%20is%20a%20bookmark%20that%20is%20easy%20to%20overlook%20or%20lose%20in%20a%20later%20search.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fsrc%2Fapi%2Froutes%2Ftest_seeding.py%3A135%0A**%60hmac.compare_digest%60%20raises%20%60ValueError%60%20for%20non-ASCII%20token%20strings**%0A%0APython's%20%60hmac.compare_digest%60%20only%20accepts%20ASCII-only%20%60str%60%20arguments%3B%20any%20non-ASCII%20character%20raises%20%60ValueError%3A%20strings%20can%20only%20contain%20ASCII%20characters%60%20rather%20than%20returning%20%60False%60.%20If%20%60TEST_SEED_TOKEN%60%20is%20set%20to%20a%20value%20that%20contains%20non-ASCII%20bytes%20%28e.g.%2C%20a%20raw%20binary%20secret%20pasted%20from%20a%20password%20manager%29%2C%20the%20call%20throws%20an%20unhandled%20exception%20that%20propagates%20as%20a%20500%2C%20revealing%20that%20the%20route%20exists%20%E2%80%94%20the%20opposite%20of%20the%20intended%20%22fail%20silently%20with%20404%22%20behaviour.%20Encoding%20both%20sides%20to%20bytes%20before%20comparison%20eliminates%20this%20class%20of%20error%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20not%20hmac.compare_digest%28x_test_seed_token.encode%28%29%2C%20expected.encode%28%29%29%3A%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=301&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
agentex/src/domain/use_cases/test_seeding_use_case.py:111-119
**TODO missing a linked ticket number**

The comment block starting at this line is a multi-step future obligation (FGAC `register_resource` wiring for tasks, api keys, and schedules). Per the team's convention, TODO comments should include a ticket number so future contributors can discover, prioritise, and track the work. Without one, this is a bookmark that is easy to overlook or lose in a later search.

### Issue 2 of 2
agentex/src/api/routes/test_seeding.py:135
**`hmac.compare_digest` raises `ValueError` for non-ASCII token strings**

Python's `hmac.compare_digest` only accepts ASCII-only `str` arguments; any non-ASCII character raises `ValueError: strings can only contain ASCII characters` rather than returning `False`. If `TEST_SEED_TOKEN` is set to a value that contains non-ASCII bytes (e.g., a raw binary secret pasted from a password manager), the call throws an unhandled exception that propagates as a 500, revealing that the route exists — the opposite of the intended "fail silently with 404" behaviour. Encoding both sides to bytes before comparison eliminates this class of error entirely.

```suggestion
    if not hmac.compare_digest(x_test_seed_token.encode(), expected.encode()):
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(test-seeding): allow-list non-prod e..."](https://github.com/scaleapi/scale-agentex/commit/49bf903c0c2aa38a94294e9d90f98c99b8993f86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36793258)</sub>

**Context used:**

- Rule used - Include ticket numbers in TODO comments to make cl... ([source](https://app.greptile.com/scale-ai/-/custom-context?memory=60a8285f-4fe2-4f02-9b88-5ea4ff033fb8))

**Learned From**
[scaleapi/scaleapi#126926](https://github.com/scaleapi/scaleapi/pull/126926)
- Rule used - Create Linear tasks for TODO comments in code and ... ([source](https://app.greptile.com/scale-ai/-/custom-context?memory=6328a8b3-afcc-487b-aac4-241716e05e94))

**Learned From**
[scaleapi/scaleapi#127117](https://github.com/scaleapi/scaleapi/pull/127117)

<!-- /greptile_comment -->