### PR TITLE
feat(authz): support 'unscoped' wildcard sentinel in /v1/authz/search

### DIFF
--- a/agentex/docs/docs/development_guides/auth_provider_contract.md
+++ b/agentex/docs/docs/development_guides/auth_provider_contract.md
@@ -70,7 +70,7 @@ decide what happened. The body matters only where noted (`/v1/authn` principal,
 
 | Status | Meaning to Agentex | Resulting behavior |
 | --- | --- | --- |
-| `200` | Success | Proceed. For `check`, the principal is authorized. For `search`, read `items`. |
+| `200` | Success | Proceed. For `check`, the principal is authorized. For `search`, read `items` or the `unscoped` sentinel. |
 | `401` | Unauthenticated — missing/invalid credentials | Request rejected as `401 Unauthorized` |
 | `403` | Authenticated but not permitted | Treated as a permission denial (e.g. `check` failed) |
 | `502` | Provider acted as a bad gateway | Surfaced as a gateway error |

--- a/agentex/docs/docs/development_guides/auth_provider_contract.md
+++ b/agentex/docs/docs/development_guides/auth_provider_contract.md
@@ -211,14 +211,25 @@ the returned `items` to **scope list endpoints** — effectively a
 { "items": ["task_1", "task_2", "task_3"], "success": true }
 ```
 
+To grant access to **every** resource of the type without enumerating ids, return
+the wildcard sentinel instead:
+
+```json
+{ "unscoped": true }
+```
+
 | Field | Type | Notes |
 | --- | --- | --- |
-| `items` | `string[]` | Resource ids the principal may access. **Required.** |
+| `items` | `string[]` | Resource ids the principal may access. Required unless `unscoped` is `true`. |
+| `unscoped` | `boolean` | Optional. `true` signals **all resources of this type** — no filter. When set, `items` is ignored. |
 
 > ⚠️ **`items` is an inclusion filter, not a hint.** Returning `[]` hides *every*
-> resource of that type from the principal. There is no "all resources" sentinel
-> in the base contract, so a provider that intends to grant broad access must
-> return the actual set of accessible ids.
+> resource of that type from the principal. To grant **broad** access without
+> enumerating ids, return the wildcard sentinel `{ "unscoped": true }` — Agentex
+> maps it to *no filter at all* (the same path used when authorization is
+> disabled), so a permissive single-account provider can answer `search`
+> statelessly. `unscoped` is an explicit opt-in: omit it (or set it `false`) and
+> `items` is treated as the exact, exhaustive set of accessible ids.
 
 ### `POST /v1/authz/grant`
 
@@ -278,7 +289,7 @@ its relationships.
 | --- | --- | --- | --- |
 | `POST /v1/authn` | Authenticate, return principal | `200` + principal | `401` |
 | `POST /v1/authz/check` | Read gate | `200` | `403` |
-| `POST /v1/authz/search` | List accessible ids | `200` + `{items}` | `200` + `{items: []}` |
+| `POST /v1/authz/search` | List accessible ids | `200` + `{items}` or `{unscoped: true}` | `200` + `{items: []}` |
 | `POST /v1/authz/grant` | Share a resource | `200` | `403` |
 | `POST /v1/authz/revoke` | Un-share a resource | `200` | `403` |
 | `POST /v1/authz/register` | Register created resource | `200` | `403` |

--- a/agentex/src/adapters/authorization/adapter_agentex_authz_proxy.py
+++ b/agentex/src/adapters/authorization/adapter_agentex_authz_proxy.py
@@ -74,7 +74,7 @@ class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext
         principal: AgentexAuthPrincipalContext,
         filter_resource: AgentexResourceType,
         filter_operation: AuthorizedOperationType = AuthorizedOperationType.read,
-    ) -> Iterable[str]:
+    ) -> Iterable[str] | None:
         payload = {
             "principal": principal,
             "filter_resource": filter_resource,
@@ -83,6 +83,14 @@ class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext
         response = await HttpRequestHandler.post_with_error_handling(
             self.agentex_auth_url, "/v1/authz/search", json=payload
         )
+        # Wildcard sentinel: a provider signals "all resources of this type" with
+        # {"unscoped": true} rather than enumerating ids. Map it onto the existing
+        # unscoped path (None == no id filter) so permissive providers stay
+        # stateless. We index response["items"] in the normal case (rather than
+        # .get) so a malformed response missing both fields raises instead of
+        # silently failing open.
+        if response.get("unscoped"):
+            return None
         return response["items"]
 
     async def register_resource(

--- a/agentex/src/adapters/authorization/adapter_agentex_authz_proxy.py
+++ b/agentex/src/adapters/authorization/adapter_agentex_authz_proxy.py
@@ -84,12 +84,12 @@ class AgentexAuthorizationProxy(AuthorizationGateway[AgentexAuthPrincipalContext
             self.agentex_auth_url, "/v1/authz/search", json=payload
         )
         # Wildcard sentinel: a provider signals "all resources of this type" with
-        # {"unscoped": true} rather than enumerating ids. Map it onto the existing
-        # unscoped path (None == no id filter) so permissive providers stay
-        # stateless. We index response["items"] in the normal case (rather than
-        # .get) so a malformed response missing both fields raises instead of
-        # silently failing open.
-        if response.get("unscoped"):
+        # {"unscoped": true} rather than enumerating ids. Map only the exact JSON
+        # boolean sentinel onto the existing unscoped path (None == no id filter)
+        # so malformed truthy values do not broaden access. We index
+        # response["items"] in the normal case (rather than .get) so a malformed
+        # response missing both fields raises instead of silently failing open.
+        if response.get("unscoped") is True:
             return None
         return response["items"]
 

--- a/agentex/src/adapters/authorization/port.py
+++ b/agentex/src/adapters/authorization/port.py
@@ -47,8 +47,12 @@ class AuthorizationGateway(Generic[PrincipalT], ABC):
         principal: PrincipalT,
         filter_resource: AgentexResourceType,
         filter_operation: AuthorizedOperationType = AuthorizedOperationType.read,
-    ) -> Iterable[str]:
-        """List resource_ids for a given principal"""
+    ) -> Iterable[str] | None:
+        """List resource_ids for a given principal.
+
+        Return ``None`` to signal *unscoped* access (all resources of the type,
+        i.e. no id filter) rather than an enumerated id list.
+        """
 
     @abstractmethod
     async def register_resource(

--- a/agentex/tests/unit/adapters/authorization/test_adapter_agentex_authz_proxy.py
+++ b/agentex/tests/unit/adapters/authorization/test_adapter_agentex_authz_proxy.py
@@ -1,0 +1,68 @@
+"""Unit tests for AgentexAuthorizationProxy.list_resources sentinel handling.
+
+The proxy maps a provider's wildcard sentinel ({"unscoped": true}) onto the
+existing unscoped path (None == no id filter), while ordinary {"items": [...]}
+responses pass through as an inclusion filter.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from src.adapters.authorization.adapter_agentex_authz_proxy import (
+    AgentexAuthorizationProxy,
+)
+from src.api.schemas.authorization_types import (
+    AgentexResourceType,
+    AuthorizedOperationType,
+)
+
+PROXY_TARGET = (
+    "src.adapters.authorization.adapter_agentex_authz_proxy."
+    "HttpRequestHandler.post_with_error_handling"
+)
+
+
+def _proxy() -> AgentexAuthorizationProxy:
+    return AgentexAuthorizationProxy(agentex_auth_url="http://auth.test")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestListResourcesSentinel:
+    async def test_items_list_passes_through(self):
+        with patch(PROXY_TARGET, new=AsyncMock(return_value={"items": ["a", "b"]})):
+            result = await _proxy().list_resources(
+                principal={"user_id": "u"},
+                filter_resource=AgentexResourceType.task,
+                filter_operation=AuthorizedOperationType.read,
+            )
+        assert result == ["a", "b"]
+
+    async def test_unscoped_true_returns_none(self):
+        with patch(PROXY_TARGET, new=AsyncMock(return_value={"unscoped": True})):
+            result = await _proxy().list_resources(
+                principal={"user_id": "u"},
+                filter_resource=AgentexResourceType.task,
+            )
+        assert result is None
+
+    async def test_unscoped_wins_over_items(self):
+        with patch(
+            PROXY_TARGET,
+            new=AsyncMock(return_value={"unscoped": True, "items": ["x"]}),
+        ):
+            result = await _proxy().list_resources(
+                principal={"user_id": "u"},
+                filter_resource=AgentexResourceType.task,
+            )
+        assert result is None
+
+    async def test_empty_items_is_not_a_sentinel(self):
+        with patch(PROXY_TARGET, new=AsyncMock(return_value={"items": []})):
+            result = await _proxy().list_resources(
+                principal={"user_id": "u"},
+                filter_resource=AgentexResourceType.task,
+            )
+        assert result == []

--- a/agentex/tests/unit/adapters/authorization/test_adapter_agentex_authz_proxy.py
+++ b/agentex/tests/unit/adapters/authorization/test_adapter_agentex_authz_proxy.py
@@ -68,12 +68,27 @@ class TestListResourcesSentinel:
         assert result == []
 
     async def test_truthy_non_boolean_unscoped_is_not_a_sentinel(self):
+        # 1 is truthy but `1 is True` is False, so the strict identity check must
+        # not treat it as the sentinel; only the JSON boolean `true` qualifies.
         with patch(
             PROXY_TARGET,
-            new=AsyncMock(return_value={"unscoped": "false", "items": []}),
+            new=AsyncMock(return_value={"unscoped": 1, "items": []}),
         ):
             result = await _proxy().list_resources(
                 principal={"user_id": "u"},
                 filter_resource=AgentexResourceType.task,
             )
         assert result == []
+
+    async def test_missing_unscoped_and_items_fails_closed(self):
+        # A malformed response with neither field must raise rather than silently
+        # return [] or None — the guard against a provider accidentally failing open.
+        with patch(
+            PROXY_TARGET,
+            new=AsyncMock(return_value={"unexpected_key": "val"}),
+        ):
+            with pytest.raises(KeyError):
+                await _proxy().list_resources(
+                    principal={"user_id": "u"},
+                    filter_resource=AgentexResourceType.task,
+                )

--- a/agentex/tests/unit/adapters/authorization/test_adapter_agentex_authz_proxy.py
+++ b/agentex/tests/unit/adapters/authorization/test_adapter_agentex_authz_proxy.py
@@ -66,3 +66,14 @@ class TestListResourcesSentinel:
                 filter_resource=AgentexResourceType.task,
             )
         assert result == []
+
+    async def test_truthy_non_boolean_unscoped_is_not_a_sentinel(self):
+        with patch(
+            PROXY_TARGET,
+            new=AsyncMock(return_value={"unscoped": "false", "items": []}),
+        ):
+            result = await _proxy().list_resources(
+                principal={"user_id": "u"},
+                filter_resource=AgentexResourceType.task,
+            )
+        assert result == []


### PR DESCRIPTION
## Summary

Lets an auth provider answer `POST /v1/authz/search` with the wildcard sentinel `{ "unscoped": true }` to mean **all resources of this type**, which the Agentex authorization proxy maps onto the existing *unscoped* path (`None` → no `id IN (...)` filter) instead of an enumerated id list.

- **Proxy** (`adapter_agentex_authz_proxy.py`): recognize `unscoped: true` and return `None`; otherwise pass `items` through unchanged.
- **Port** (`port.py`): widen `list_resources` return type to `Iterable[str] | None`.
- **Contract doc** (`auth_provider_contract.md`): formalize the `unscoped` sentinel in the `search` response schema, the inclusion-filter note, and the endpoint summary.
- **Tests**: unit coverage for the four cases.

## Motivation

A provider that grants broad access (e.g. a single-account "allow everything" authorization model) previously had to enumerate **every** accessible id, because `items: []` hides everything and there was no "all resources" signal in the contract. Enumeration couples the provider to Agentex's storage and scales poorly on large accounts. The sentinel lets such a provider answer `search` statelessly.

## Design notes

- **Explicit boolean** chosen over overloading `items: null`: a provider must *deliberately* opt into "everything", and a malformed response missing both fields raises rather than silently failing **open**.
- **No downstream changes.** `AuthorizationService.list_resources` already returns `Iterable[str] | None`, and every consumer (`DAuthorizedResourceIds`, the list routes, the Postgres list filter) already treats `None` as "no filter" — the path taken when authorization is disabled. The sentinel reuses that exact, already-tested path.
- The sentinel is opt-in and backward compatible: existing providers returning an `items` array behave exactly as before.

## Test plan

- [x] New unit tests (`tests/unit/adapters/authorization/test_adapter_agentex_authz_proxy.py`):
  - `{ "items": ["a","b"] }` → `["a","b"]`
  - `{ "unscoped": true }` → `None`
  - `{ "unscoped": true, "items": ["x"] }` → `None` (unscoped wins)
  - `{ "items": [] }` → `[]` (sentinel not triggered; still hides everything)
- [x] Existing authz unit suite passes (no regression).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an explicit wildcard response for authz search results. The main changes are:
- Maps `{ "unscoped": true }` from `/v1/authz/search` to `None` in the authz proxy.
- Keeps ordinary `items` responses as the exact inclusion filter.
- Widens the authorization gateway return type to allow unscoped results.
- Documents the new auth provider contract behavior.
- Adds unit coverage for sentinel and fail-closed cases.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The wildcard path requires the exact JSON boolean sentinel.
- Malformed search responses still raise instead of opening access.
- Direct downstream consumers already handle `None` as the existing no-filter path.

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused authz search sentinel repro was executed to validate the sentinel handling.
- The repro exercised items passthrough, empty items, unscoped: true returning None, and unscoped: true winning over items to confirm expected control flow.
- Truthiness tests confirmed that truthy non-boolean values are not treated as the wildcard sentinel.
- Malformed responses without both unscoped and items were verified to raise instead of returning an unscoped result.
- Downstream list-resource consumers were checked to handle None as the existing no-filter path.

<a href="https://app.greptile.com/trex/runs/11311489/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/authz-sear..."](https://github.com/scaleapi/scale-agentex/commit/435dd59b78c006ebcc7f54a3afc29ac608165c17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37083614)</sub>

<!-- /greptile_comment -->