### PR TITLE
fix(authz): check authorization through gateway

### DIFF
--- a/agentex/src/domain/services/authorization_service.py
+++ b/agentex/src/domain/services/authorization_service.py
@@ -6,7 +6,6 @@ from fastapi import Depends, Request
 from src.adapters.authorization.adapter_agentex_authz_proxy import (
     DAgentexAuthorization,
 )
-from src.api.authentication_cache import get_auth_cache
 from src.api.authentication_middleware import DAuthorizationEnabled
 from src.api.schemas.authorization_types import (
     AgentexResource,
@@ -107,26 +106,6 @@ class AuthorizationService:
             else self.principal_context
         )
 
-        # Try to get cached result first
-        auth_cache = await get_auth_cache()
-        cached_result = await auth_cache.get_authorization_check(
-            resource_type=str(resource.type),
-            resource_selector=resource.selector,
-            operation=str(operation),
-            principal_context=effective_principal,
-        )
-
-        if cached_result is not None:
-            logger.info(
-                "[authorization_service] Using cached result for %s permission on %s:%s: %s",
-                operation,
-                resource.type,
-                resource.selector,
-                "allowed" if cached_result else "denied",
-            )
-            return cached_result
-
-        # Not in cache, perform actual check
         logger.info(
             "[authorization_service] Checking %s permission on %s:%s",
             operation,
@@ -137,15 +116,6 @@ class AuthorizationService:
             effective_principal,
             resource,
             operation,
-        )
-
-        # Cache the result
-        await auth_cache.set_authorization_check(
-            resource_type=str(resource.type),
-            resource_selector=resource.selector,
-            operation=str(operation),
-            principal_context=effective_principal,
-            allowed=result,
         )
 
         logger.info(

--- a/agentex/tests/integration/api/agents/test_agents_auth_api.py
+++ b/agentex/tests/integration/api/agents/test_agents_auth_api.py
@@ -165,15 +165,18 @@ class TestAgentsAuthAPIIntegration:
         assert authz_data["operation"] == "read"
         assert authz_data["principal"] == MOCK_PRINCIPAL_CONTEXT
 
-        # Second call will use auth cache and not make a request to the authn service
+        # Second call still uses the authn cache, but authorization checks go
+        # directly to Spark so share/revoke changes are visible immediately.
         post_with_error_handling_mock.reset_mock()
         response = await isolated_client.get("/agents/name/test-authorized-agent")
         assert response.status_code == 200
         agent = response.json()
         assert agent["id"] == test_authorized_agent.id
 
-        # No request to the authz service thanks to auth cache
-        assert post_with_error_handling_mock.call_count == 0
+        assert post_with_error_handling_mock.call_count == 1
+        assert (
+            post_with_error_handling_mock.call_args_list[0][0][1] == "/v1/authz/check"
+        )
 
     @pytest.mark.asyncio
     @patch(

--- a/agentex/tests/unit/services/test_authorization_service_cache.py
+++ b/agentex/tests/unit/services/test_authorization_service_cache.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from src.api.schemas.authorization_types import AgentexResource, AuthorizedOperationType
+from src.domain.services.authorization_service import AuthorizationService
+
+
+def _request_with_principal(principal_context):
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            principal_context=principal_context,
+            agent_identity=None,
+        )
+    )
+
+
+def _service(principal_context, gateway):
+    return AuthorizationService(
+        enabled=True,
+        gateway=gateway,
+        request=_request_with_principal(principal_context),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resource",
+    [
+        AgentexResource.agent("agent-1"),
+        AgentexResource.task("task-1"),
+        AgentexResource.api_key("api-key-1"),
+        AgentexResource.schedule("agent-1/schedule-1"),
+    ],
+)
+async def test_authorization_checks_call_gateway_each_time(resource):
+    gateway = AsyncMock()
+    gateway.check.return_value = True
+    service = _service({"user_id": "user-1", "account_id": "acct-1"}, gateway)
+
+    assert await service.check(resource, AuthorizedOperationType.read) is True
+    assert await service.check(resource, AuthorizedOperationType.read) is True
+
+    assert gateway.check.await_count == 2


### PR DESCRIPTION
## Summary
- remove the local authorization-check cache from AuthorizationService.check
- route agent, task, api key, and schedule authorization checks directly through Spark
- update unit and integration tests to expect repeated authorization checks to call Spark

## Why
Sharing/revoking permissions updates Spark directly, but Agentex's local authorization-check cache was not centrally managed or invalidated by Spark. A cached allow/deny could remain stale until TTL expiry, so checks now ask Spark for current permission state.

## Test Plan
- uv run ruff check src/domain/services/authorization_service.py tests/unit/services/test_authorization_service_cache.py tests/integration/api/agents/test_agents_auth_api.py
- uv run --group test pytest tests/unit/api/test_authentication_cache_metrics.py tests/unit/services/test_authorization_service_cache.py tests/unit/services/test_authorization_service_logging.py tests/unit/api/test_agents_authz.py tests/unit/api/test_tasks_authz.py tests/unit/api/test_schedules_authz.py tests/unit/api/test_agent_api_keys_authz.py -q
- uv run --group test pytest tests/integration/api/agents/test_agents_auth_api.py::TestAgentsAuthAPIIntegration::test_agent_check --collect-only -q

Note: local execution of the Docker-backed integration test was blocked because Docker was unavailable in this environment; CI should run it with Docker.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the local in-process authorization-check cache from `AuthorizationService.check`, routing every `check` call directly to the Spark gateway so that share/revoke changes are immediately visible rather than waiting for a TTL expiry.

- **`authorization_service.py`**: Drops the `get_auth_cache` import and removes the cache read/write blocks from `check()`, leaving the method as a thin pass-through to `self.gateway.check`.
- **`test_authorization_service_cache.py`**: New parametrized unit test covering all four resource types (agent, task, api_key, schedule) to confirm `gateway.check` is called on every invocation.
- **`test_agents_auth_api.py`**: Updates `test_agent_check` to assert one `/v1/authz/check` call on the second HTTP request (previously zero, thanks to the now-removed cache); `test_agent_list` is unchanged because `list_resources` was never cached.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted removal of a stale local cache with no risk of data loss or regression in authorization decisions.

The diff is a clean deletion of ~20 lines of caching logic. The gateway call it exposed already existed and is exercised by both the new parametrized unit test and the updated integration test. The list_resources path (authz/search) was already uncached and is unaffected. No new code paths are introduced.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/services/authorization_service.py | Removed local authorization-check cache (get_auth_cache import and all cache get/set calls in check()); every authorization check now flows directly to the Spark gateway. Change is targeted and correct. |
| agentex/tests/unit/services/test_authorization_service_cache.py | New unit test verifying that gateway.check is called on every invocation (no caching) across all four resource types (agent, task, api_key, schedule). |
| agentex/tests/integration/api/agents/test_agents_auth_api.py | Updated test_agent_check to assert a second HTTP request still produces one /v1/authz/check call instead of zero, matching the new no-cache behavior. test_agent_list (list_resources path) was not modified since it already called authz/search each time. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AuthorizationService
    participant SparkGateway

    Note over AuthorizationService: Before this PR
    Client->>AuthorizationService: check(resource, op) [call 1]
    AuthorizationService->>SparkGateway: gateway.check(...)
    SparkGateway-->>AuthorizationService: allowed/denied
    AuthorizationService-->>Client: result (cached locally)

    Client->>AuthorizationService: check(resource, op) [call 2]
    Note over AuthorizationService: Cache HIT – no RPC
    AuthorizationService-->>Client: cached result (possibly stale)

    Note over AuthorizationService: After this PR
    Client->>AuthorizationService: check(resource, op) [call 1]
    AuthorizationService->>SparkGateway: gateway.check(...)
    SparkGateway-->>AuthorizationService: allowed/denied
    AuthorizationService-->>Client: result

    Client->>AuthorizationService: check(resource, op) [call 2]
    AuthorizationService->>SparkGateway: gateway.check(...)
    SparkGateway-->>AuthorizationService: allowed/denied (always fresh)
    AuthorizationService-->>Client: result
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(authz): check authorization through ..."](https://github.com/scaleapi/scale-agentex/commit/e1a4fcbde0bb3cfcf6bee69576b5e5427a544b71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37156045)</sub>

<!-- /greptile_comment -->