### PR TITLE
fix(agentex-ui): include account_id in investigate traces link

### DIFF
--- a/agentex-ui/components/task-header/investigate-traces-button.tsx
+++ b/agentex-ui/components/task-header/investigate-traces-button.tsx
@@ -28,7 +28,7 @@ export const InvestigateTracesButton = forwardRef<
   if (sgpAccountID) {
     params.set('account_id', sgpAccountID);
   }
-  const sgpTracesURL = `${sgpAppURL}/beta/monitor?${params.toString()}`;
+  const sgpTracesURL = `${sgpAppURL}/monitor?${params.toString()}`;
 
   if (!sgpAppURL) {
     return null;

--- a/agentex-ui/components/task-header/investigate-traces-button.tsx
+++ b/agentex-ui/components/task-header/investigate-traces-button.tsx
@@ -5,6 +5,7 @@ import { forwardRef } from 'react';
 import { ArrowRight } from 'lucide-react';
 
 import { useAgentexClient } from '@/components/providers';
+import { useSafeSearchParams } from '@/hooks/use-safe-search-params';
 import { cn } from '@/lib/utils';
 
 type InvestigateTracesButtonProps = {
@@ -18,7 +19,16 @@ export const InvestigateTracesButton = forwardRef<
   InvestigateTracesButtonProps
 >(({ className, disabled = false, traceId, ...props }, ref) => {
   const { sgpAppURL } = useAgentexClient();
-  const sgpTracesURL = `${sgpAppURL}/beta/monitor?trace_id=${traceId}&tt-trace-id=${traceId}`;
+  const { sgpAccountID } = useSafeSearchParams();
+
+  const params = new URLSearchParams({
+    trace_id: traceId,
+    'tt-trace-id': traceId,
+  });
+  if (sgpAccountID) {
+    params.set('account_id', sgpAccountID);
+  }
+  const sgpTracesURL = `${sgpAppURL}/beta/monitor?${params.toString()}`;
 
   if (!sgpAppURL) {
     return null;


### PR DESCRIPTION
# Pull Request Summary

The AgentEx "Investigate traces" link opened SGP monitor with only trace ID query params. When a user had multiple tenants, SGP could load traces under the wrong active account. This change reads `account_id` from the current AgentEx URL and appends it to the monitor link so SGP switches to the correct tenant.

## Test Plan

- Verified the link builder adds `account_id` when the AgentEx page URL includes `account_id`.
- Agentex UI lint passed via pre-commit on the changed file.

## Linear Issue

No Linear ticket.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a multi-tenant issue in the "Investigate traces" button by reading `account_id` from the current AgentEx URL and appending it to the SGP monitor link, ensuring SGP loads the correct tenant context.

- Introduces `useSafeSearchParams` to extract `account_id` from the current page's search params and conditionally appends it to the outbound SGP URL.
- Refactors the URL construction to use `URLSearchParams` for cleaner parameter handling.
- The diff also silently changes the SGP monitor path from `/beta/monitor` to `/monitor`; this is not mentioned in the PR description and warrants confirmation that SGP no longer requires the `/beta/` prefix.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The account_id forwarding logic is correct and well-guarded, but the undocumented removal of the `/beta/` path segment in the monitor URL could silently break the link for all users if SGP has not retired that route.

The path change from `/beta/monitor` to `/monitor` is unmentioned in the PR description and untested in the stated test plan — if SGP still routes the monitor behind `/beta/`, every "Investigate traces" click will land on the wrong or missing page.

agentex-ui/components/task-header/investigate-traces-button.tsx — confirm the `/beta/monitor` → `/monitor` path change is intentional and that the new route is live in SGP.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| agentex-ui/components/task-header/investigate-traces-button.tsx | Reads `account_id` from search params and appends it to the SGP monitor URL; also silently changes the monitor path from `/beta/monitor` to `/monitor` |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant AgentEx UI
    participant useSafeSearchParams
    participant SGP Monitor

    User->>AgentEx UI: Visits page with ?account_id=XYZ&task_id=ABC
    AgentEx UI->>useSafeSearchParams: read search params
    useSafeSearchParams-->>AgentEx UI: sgpAccountID = "XYZ"
    AgentEx UI->>AgentEx UI: Build URL: /monitor?trace_id=...&tt-trace-id=...&account_id=XYZ
    User->>SGP Monitor: Clicks "Investigate traces" link
    SGP Monitor-->>User: Opens monitor under account XYZ
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant AgentEx UI
    participant useSafeSearchParams
    participant SGP Monitor

    User->>AgentEx UI: Visits page with ?account_id=XYZ&task_id=ABC
    AgentEx UI->>useSafeSearchParams: read search params
    useSafeSearchParams-->>AgentEx UI: sgpAccountID = "XYZ"
    AgentEx UI->>AgentEx UI: Build URL: /monitor?trace_id=...&tt-trace-id=...&account_id=XYZ
    User->>SGP Monitor: Clicks "Investigate traces" link
    SGP Monitor-->>User: Opens monitor under account XYZ
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex-ui%2Fcomponents%2Ftask-header%2Finvestigate-traces-button.tsx%3A31%0A**Silent%20path%20change%20from%20%60%2Fbeta%2Fmonitor%60%20to%20%60%2Fmonitor%60**%0A%0AThe%20old%20URL%20used%20%60%24%7BsgpAppURL%7D%2Fbeta%2Fmonitor%3F...%60%20but%20the%20new%20URL%20drops%20the%20%60%2Fbeta%2F%60%20segment.%20This%20change%20is%20not%20mentioned%20in%20the%20PR%20description%20and%20may%20be%20intentional%20%28the%20route%20graduated%20from%20beta%29%20or%20accidental.%20If%20SGP%20still%20serves%20the%20monitor%20at%20%60%2Fbeta%2Fmonitor%60%2C%20this%20link%20will%20silently%20404%20or%20redirect%20to%20an%20unrelated%20page%20for%20all%20users.%0A%0A&pr=310&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex-ui%2Fcomponents%2Ftask-header%2Finvestigate-traces-button.tsx%3A31%0A**Silent%20path%20change%20from%20%60%2Fbeta%2Fmonitor%60%20to%20%60%2Fmonitor%60**%0A%0AThe%20old%20URL%20used%20%60%24%7BsgpAppURL%7D%2Fbeta%2Fmonitor%3F...%60%20but%20the%20new%20URL%20drops%20the%20%60%2Fbeta%2F%60%20segment.%20This%20change%20is%20not%20mentioned%20in%20the%20PR%20description%20and%20may%20be%20intentional%20%28the%20route%20graduated%20from%20beta%29%20or%20accidental.%20If%20SGP%20still%20serves%20the%20monitor%20at%20%60%2Fbeta%2Fmonitor%60%2C%20this%20link%20will%20silently%20404%20or%20redirect%20to%20an%20unrelated%20page%20for%20all%20users.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=310&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22chris-villegas%2Ffix-investigate-traces-account-id%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chris-villegas%2Ffix-investigate-traces-account-id%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex-ui%2Fcomponents%2Ftask-header%2Finvestigate-traces-button.tsx%3A31%0A**Silent%20path%20change%20from%20%60%2Fbeta%2Fmonitor%60%20to%20%60%2Fmonitor%60**%0A%0AThe%20old%20URL%20used%20%60%24%7BsgpAppURL%7D%2Fbeta%2Fmonitor%3F...%60%20but%20the%20new%20URL%20drops%20the%20%60%2Fbeta%2F%60%20segment.%20This%20change%20is%20not%20mentioned%20in%20the%20PR%20description%20and%20may%20be%20intentional%20%28the%20route%20graduated%20from%20beta%29%20or%20accidental.%20If%20SGP%20still%20serves%20the%20monitor%20at%20%60%2Fbeta%2Fmonitor%60%2C%20this%20link%20will%20silently%20404%20or%20redirect%20to%20an%20unrelated%20page%20for%20all%20users.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=310&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex-ui/components/task-header/investigate-traces-button.tsx:31
**Silent path change from `/beta/monitor` to `/monitor`**

The old URL used `${sgpAppURL}/beta/monitor?...` but the new URL drops the `/beta/` segment. This change is not mentioned in the PR description and may be intentional (the route graduated from beta) or accidental. If SGP still serves the monitor at `/beta/monitor`, this link will silently 404 or redirect to an unrelated page for all users.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agentex-ui): use /monitor instead of..."](https://github.com/scaleapi/scale-agentex/commit/a2dbb4a33a3396ae47aca1504d9e7d194616b5fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37776633)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->