### PR TITLE
fix(agentex): only bracket IPv6 literals when building the OTLP metrics URL

### DIFF
--- a/agentex/src/temporal/run_worker.py
+++ b/agentex/src/temporal/run_worker.py
@@ -40,6 +40,19 @@ logger = make_logger(__name__)
 # Task queue name for agentex server operations
 AGENTEX_SERVER_TASK_QUEUE = "agentex-server"
 
+
+def build_metrics_url(host_url: str | None) -> str | None:
+    """Build the OTLP metrics endpoint URL from a host.
+
+    Per RFC 3986, only IPv6 literals are wrapped in brackets; hostnames and
+    IPv4 literals are used as-is. Returns None when no host is configured.
+    """
+    if not host_url:
+        return None
+    host = f"[{host_url}]" if ":" in host_url else host_url
+    return f"http://{host}:4317"
+
+
 # Global worker instance
 health_check_worker: Worker | None = None
 
@@ -84,7 +97,7 @@ async def run_worker(
 
         # Check for metrics configuration
         host_url = os.environ.get("DD_AGENT_HOST")
-        metrics_url = f"http://[{host_url}]:4317" if host_url else None
+        metrics_url = build_metrics_url(host_url)
         if metrics_url:
             logger.info(f"Configuring worker with metrics URL: {metrics_url}")
 

--- a/agentex/src/temporal/run_worker.py
+++ b/agentex/src/temporal/run_worker.py
@@ -41,16 +41,34 @@ logger = make_logger(__name__)
 AGENTEX_SERVER_TASK_QUEUE = "agentex-server"
 
 
-def build_metrics_url(host_url: str | None) -> str | None:
-    """Build the OTLP metrics endpoint URL from a host.
+OTLP_METRICS_DEFAULT_PORT = 4317
 
-    Per RFC 3986, only IPv6 literals are wrapped in brackets; hostnames and
-    IPv4 literals are used as-is. Returns None when no host is configured.
+
+def build_metrics_url(host_url: str | None) -> str | None:
+    """Build the OTLP metrics endpoint URL from a ``host`` or ``host:port`` value.
+
+    Accepts a bare hostname/IPv4, an IPv6 literal (bracketed or not), or any of
+    those with an explicit ``:port`` suffix. Per RFC 3986 only IPv6 literals are
+    wrapped in brackets, and the default OTLP gRPC port is appended only when the
+    value does not already carry one. Returns None when no host is configured.
     """
     if not host_url:
         return None
-    host = f"[{host_url}]" if ":" in host_url else host_url
-    return f"http://{host}:4317"
+
+    host = host_url.strip()
+    port: str | None = None
+
+    if host.startswith("["):
+        bracket_end = host.find("]")
+        if bracket_end != -1:
+            rest = host[bracket_end + 1 :]
+            port = rest[1:] if rest.startswith(":") else None
+            host = host[1:bracket_end]
+    elif host.count(":") == 1:
+        host, port = host.split(":", 1)
+
+    bracketed = f"[{host}]" if ":" in host else host
+    return f"http://{bracketed}:{port or OTLP_METRICS_DEFAULT_PORT}"
 
 
 # Global worker instance

--- a/agentex/tests/unit/temporal/test_run_worker_metrics_url.py
+++ b/agentex/tests/unit/temporal/test_run_worker_metrics_url.py
@@ -1,0 +1,23 @@
+import pytest
+from src.temporal.run_worker import build_metrics_url
+
+
+@pytest.mark.unit
+def test_metrics_url_is_none_when_host_unset():
+    assert build_metrics_url(None) is None
+    assert build_metrics_url("") is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("host", ["localhost", "datadog-agent", "10.0.0.5"])
+def test_hostname_and_ipv4_are_not_bracketed(host):
+    assert build_metrics_url(host) == f"http://{host}:4317"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "host,expected",
+    [("::1", "http://[::1]:4317"), ("fe80::1", "http://[fe80::1]:4317")],
+)
+def test_ipv6_literal_is_bracketed(host, expected):
+    assert build_metrics_url(host) == expected

--- a/agentex/tests/unit/temporal/test_run_worker_metrics_url.py
+++ b/agentex/tests/unit/temporal/test_run_worker_metrics_url.py
@@ -21,3 +21,29 @@ def test_hostname_and_ipv4_are_not_bracketed(host):
 )
 def test_ipv6_literal_is_bracketed(host, expected):
     assert build_metrics_url(host) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        ("datadog-agent:4317", "http://datadog-agent:4317"),
+        ("10.0.0.5:4317", "http://10.0.0.5:4317"),
+        ("datadog-agent:5555", "http://datadog-agent:5555"),
+    ],
+)
+def test_hostname_with_explicit_port_is_not_bracketed(host, expected):
+    assert build_metrics_url(host) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        ("[::1]", "http://[::1]:4317"),
+        ("[fe80::1]", "http://[fe80::1]:4317"),
+        ("[::1]:5555", "http://[::1]:5555"),
+    ],
+)
+def test_already_bracketed_ipv6_literal(host, expected):
+    assert build_metrics_url(host) == expected


### PR DESCRIPTION
## What

`run_worker` built the worker's OTLP metrics endpoint by unconditionally wrapping `DD_AGENT_HOST` in IPv6 literal brackets:

```python
metrics_url = f"http://[{host_url}]:4317" if host_url else None
```

This change extracts a small `build_metrics_url` helper that brackets the host **only when it is an IPv6 literal** (i.e. it contains a colon), and uses the host as-is otherwise.

## Why

Per RFC 3986, brackets are only valid around an IPv6 literal. For the common cases, a hostname (`localhost`), a Kubernetes service name (`datadog-agent`), or an IPv4 literal (`10.0.0.5`) - the old code produced a malformed URL like `http://[localhost]:4317`.

That `metrics_url` flows into `TemporalClientFactory.create_client_from_env(...)` → `create_client(...)` → `OpenTelemetryConfig(url=metrics_url)`. The Temporal SDK validates the URL eagerly when building the `Runtime`, raising `Invalid OTel URL: invalid IPv6 address`. Because that construction is inside the `try` block in `create_client`, it is re-raised as `TemporalConnectionError`, so the worker fails to start entirely whenever `DD_AGENT_HOST` is set to anything other than a bare IPv6 literal.

This also matches how `DD_AGENT_HOST` is already used elsewhere in the repo without brackets (e.g. `app.py`'s `statsd_host=os.getenv("DD_AGENT_HOST", "localhost")`).

## How it was verified

Reproduced on Linux (WSL Ubuntu, Python 3.12, `temporalio` 1.23.0 per `uv.lock`): feeding `http://[localhost]:4317` / `http://[datadog-agent]:4317` / `http://[10.0.0.5]:4317` to `OpenTelemetryConfig` raises `Invalid OTel URL: invalid IPv6 address`; the bracket-less forms are accepted.

Added `tests/unit/temporal/test_run_worker_metrics_url.py` covering hostname / IPv4 (not bracketed), IPv6 literal (bracketed), and the unset case (`None`). The hostname/IPv4 assertions fail against the previous always-bracket behavior and pass with this change.

```
uv run ruff check src/temporal/run_worker.py tests/unit/temporal/test_run_worker_metrics_url.py   # All checks passed!
uv run ruff format --check ...                                                                     # 2 files already formatted
uv run pytest tests/unit/temporal/test_run_worker_metrics_url.py -m unit -q                        # 6 passed
```

## Closes https://github.com/scaleapi/scale-agentex/issues/313

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds a `build_metrics_url` helper for constructing the worker OTLP metrics endpoint from `DD_AGENT_HOST`.
- Brackets IPv6 literals while leaving hostnames and IPv4 addresses unbracketed.
- Adds unit tests covering unset hosts, hostnames, IPv4, IPv6, explicit ports, and already-bracketed IPv6 inputs.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is narrowly scoped to OTLP metrics URL construction and is covered by focused unit tests for the relevant host forms.

The helper behavior matches the described URL requirements, and the tests exercise unset, hostname, IPv4, IPv6, explicit port, and already-bracketed IPv6 cases.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured the baseline metrics URL state as documented in the before-state log.
- T-Rex captured the post-change metrics URL state as documented in the after-state log.
- T-Rex compared the before and after outputs to confirm the updated host formatting and URL expansion.

<a href="https://app.greptile.com/trex/runs/11482370/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agentex): handle host:port and brack..."](https://github.com/scaleapi/scale-agentex/commit/32c5211470a0508aa114c647327a5a8c35a1c12c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38214076)</sub>

<!-- /greptile_comment -->