### PR TITLE
fix(authz): grant legacy agent register principal

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -5221,6 +5221,12 @@ components:
         acp_type:
           $ref: '#/components/schemas/ACPType'
           description: The type of ACP to use for the agent.
+        principal_context:
+          anyOf:
+          - {}
+          - type: 'null'
+          title: Principal Context
+          description: Principal used for authorization
         registration_metadata:
           anyOf:
           - additionalProperties: true

--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -195,11 +195,15 @@ async def register_agent(
     If agent_id is not provided, the system will look for an existing agent by name and update it,
     or create a new one if it doesn't exist.
     """
-    enforce_ownership = _has_resolvable_creator(authorization_service.principal_context)
+    principal_context = authorization_service.principal_context
+    if not _has_resolvable_creator(principal_context):
+        principal_context = request.principal_context
+    enforce_ownership = _has_resolvable_creator(principal_context)
     if enforce_ownership:
         await authorization_service.check(
             AgentexResource.agent("*"),
             AuthorizedOperationType.create,
+            principal_context=principal_context,
         )
     logger.info(
         "Registering agent name=%s agent_id=%s acp_type=%s",
@@ -220,6 +224,7 @@ async def register_agent(
         if enforce_ownership:
             await authorization_service.grant(
                 AgentexResource.agent(agent_entity.id),
+                principal_context=principal_context,
             )
         response_fields = agent_entity.model_dump()
         existing_key = await api_keys_use_case.get_internal_api_key_by_agent_id(

--- a/agentex/src/api/schemas/agents.py
+++ b/agentex/src/api/schemas/agents.py
@@ -88,6 +88,9 @@ class RegisterAgentRequest(BaseModel):
         description="Optional agent ID if the agent already exists and needs to be updated.",
     )
     acp_type: ACPType = Field(..., description="The type of ACP to use for the agent.")
+    principal_context: Any | None = Field(
+        default=None, description="Principal used for authorization"
+    )
     registration_metadata: dict[str, Any] | None = Field(
         default=None,
         description="The metadata for the agent's registration.",

--- a/agentex/tests/unit/api/test_agents_authz.py
+++ b/agentex/tests/unit/api/test_agents_authz.py
@@ -392,12 +392,13 @@ class TestRegisterAgentOwnershipEnforcement:
         return authorization, agents_use_case, api_keys_use_case
 
     @staticmethod
-    def _request():
+    def _request(principal_context=None):
         return RegisterAgentRequest(
             name="my-agent",
             description="d",
             acp_url="http://agent:5000",
             acp_type=ACPType.ASYNC,
+            principal_context=principal_context,
         )
 
     @pytest.mark.parametrize("principal_context", [None, {}, {"account_id": "acct"}])
@@ -412,6 +413,21 @@ class TestRegisterAgentOwnershipEnforcement:
         authz.grant.assert_not_awaited()
         use_case.register_agent.assert_awaited_once()
         assert resp.agent_api_key == "internal-key"
+
+    async def test_body_principal_enforces_check_and_grant(self):
+        # Legacy deployed pods send the deploy principal in the body because
+        # /agents/register is whitelisted and has no request-state principal.
+        body_principal = {"user_id": "u", "account_id": "acct"}
+        authz, use_case, api_keys = self._mocks(principal_context=None)
+
+        await register_agent(
+            self._request(principal_context=body_principal), use_case, authz, api_keys
+        )
+
+        authz.check.assert_awaited_once()
+        assert authz.check.await_args.kwargs["principal_context"] == body_principal
+        authz.grant.assert_awaited_once()
+        assert authz.grant.await_args.kwargs["principal_context"] == body_principal
 
     async def test_dict_principal_enforces_check_and_grant(self):
         authz, use_case, api_keys = self._mocks(


### PR DESCRIPTION
## Summary

- Restore legacy `/agents/register` compatibility by accepting `principal_context` in the register request body.
- Use the request-state principal when present, otherwise fall back to the body principal for create-check and ownership grant.
- Keep the #292 behavior where register skips authz when no resolvable principal is provided, avoiding the unauthenticated self-register crashloop.
- Regenerate the Agentex OpenAPI spec.

## Validation

- `uv run pytest agentex/tests/unit/api/test_agents_authz.py -q`
- `uv run ruff check agentex/src/api/routes/agents.py agentex/src/api/schemas/agents.py agentex/tests/unit/api/test_agents_authz.py`
- `uv run ruff format --check agentex/src/api/routes/agents.py agentex/src/api/schemas/agents.py agentex/tests/unit/api/test_agents_authz.py`
- `make gen-openapi`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Overview

This PR restores legacy `/agents/register` compatibility by accepting `principal_context` in the **request body** and falling back to it when the request-state principal (set by auth middleware) is not resolvable. The new `principal_context: Any | None` field on `RegisterAgentRequest` is forwarded directly to `authorization_service.check(...)` and `authorization_service.grant(...)` when the endpoint is hit without an authenticated session.

## Key Changes

- **`RegisterAgentRequest`** gains `principal_context: Any | None` (defaults to `None`), exposed publicly in the OpenAPI schema.
- **`register_agent` route logic**: if `authorization_service.principal_context` is unresolvable (no `user_id`/`service_account_id`), falls back to `request.principal_context` from the body. Both `check` and `grant` now receive an explicit `principal_context=` kwarg.
- **New test** (`test_body_principal_enforces_check_and_grant`) verifies the body principal is forwarded to both `check` and `grant`.

## Issues Found

### Trust Boundary — Body principal injection on whitelisted endpoint
`/agents/register` is in `WHITELISTED_ROUTES`; the auth middleware sets `request.state.principal_context = None` and performs **no authentication**. Any external caller can now POST to this endpoint with an arbitrary `principal_context: {"user_id": "victim-id"}` in the body. When the request-state principal is None, the code falls back to this body-supplied dict, `_has_resolvable_creator` returns True, and `authorization_service.grant(...)` is called forwarding the attacker-controlled dict to `agentex-auth /v1/authz/grant` with no cryptographic proof that the caller is that identity. Whether exploitation succeeds depends entirely on whether agentex-auth validates the principal independently.

### Missing test coverage for priority logic
1. **Unresolvable non-None auth-service principal + resolvable body principal**: `test_unresolvable_creator_skips_check_and_grant` always uses `_request()` (body=None). The case `auth_service.principal={"account_id":"acct"}` + `body={"user_id":"u"}` — where body fallback triggers `enforce_ownership=True` — is not tested.
2. **Request-state principal takes precedence over body when both are resolvable**: No test verifies that a resolvable request-state principal prevents the body principal from being used.

### Existing tests don't assert `principal_context` kwarg on the request-state principal path
`test_dict_principal_enforces_check_and_grant` and `test_object_principal_enforces_check_and_grant` assert `check`/`grant` were called once but do not inspect `await_args.kwargs["principal_context"]`. A regression where the wrong principal is passed would not be caught, unlike the new body-principal test which does check kwargs.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Functionally correct for the intended legacy case, but the trust model relies on network isolation with no code-level guard, and three meaningful test coverage gaps exist in the priority/fallback logic.

The core fallback logic is correct and the new test covers the primary intended case. However: (1) the security trust boundary is fully open at the code layer — any caller who can reach the whitelisted endpoint can forge any principal; (2) two critical test gaps leave the priority ordering (request-state > body, and unresolvable-state + resolvable-body) completely uncovered; (3) the existing request-state tests don't assert the correct principal_context kwarg after the API change. These are real risks to correctness and security, not theoretical ones.

agentex/src/api/routes/agents.py (lines 199-201, trust boundary), agentex/tests/unit/api/test_agents_authz.py (missing priority and fallback test cases), agentex/src/api/schemas/agents.py (Any type too permissive)
</details>


<details open><summary><h3>Security Review</h3></summary>

- **Unauthenticated principal injection** (`agentex/src/api/routes/agents.py:199-200`, `agentex/src/api/schemas/agents.py:91-93`): `/agents/register` is whitelisted so authentication is skipped for all callers. The new `principal_context: Any | None` body field means any external caller can supply `{"user_id": "arbitrary-id"}`. The code falls back to this dict when the request-state principal is None, calls `authorization_service.check(...)` and `authorization_service.grant(...)` with the caller-supplied identity, and forwards it directly to agentex-auth without any cryptographic validation at the route layer. Trust relies entirely on network isolation of the endpoint.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agentex/src/api/routes/agents.py | Adds body-principal fallback in register_agent: when auth-service principal is unresolvable, falls back to request.principal_context from the body and forwards it explicitly to check/grant. The fallback logic is correct, but the trust boundary is fully open — any unauthenticated caller to the whitelisted endpoint can supply an arbitrary principal dict. |
| agentex/src/api/schemas/agents.py | Adds principal_context: Any | None field to RegisterAgentRequest. The Any type is overly permissive; dict[str, Any] | None would be more appropriate and generate a cleaner OpenAPI schema. |
| agentex/tests/unit/api/test_agents_authz.py | Adds test_body_principal_enforces_check_and_grant and updates _request helper. New test correctly asserts principal_context kwargs. Missing: (1) test for unresolvable-non-None auth-service principal + resolvable body principal, (2) test for request-state precedence over body when both are resolvable, (3) existing enforce tests don't assert principal_context kwarg. |
| agentex/openapi.yaml | Regenerated spec adds principal_context field. Uses anyOf: [{}] (any JSON value) which is technically correct for Any|None but provides no schema guidance on expected structure or keys. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `agentex/tests/unit/api/test_agents_authz.py`, line 432-440 ([link](https://github.com/scaleapi/scale-agentex/blob/cfcc63d95e041f7ae76d7c6f5d2d3f911f2be06d/agentex/tests/unit/api/test_agents_authz.py#L432-L440)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing test: request-state principal takes precedence over body principal**

   There is no test for the case where **both** the request-state principal (resolvable, e.g. `{"user_id":"req-user"}`) **and** the body `principal_context` (e.g. `{"user_id":"body-user"}`) are present. The request-state principal should win and the body should be silently ignored.

   Without a test, a future refactor that accidentally reverses the precedence (falling back to body even when the request-state is resolvable) would pass all current tests. This is a straightforward case to add:

   ```python
   async def test_request_state_principal_takes_precedence_over_body(self):
       req_principal = {"user_id": "req-user", "account_id": "acct"}
       body_principal = {"user_id": "body-user", "account_id": "acct"}
       authz, use_case, api_keys = self._mocks(principal_context=req_principal)

       await register_agent(
           self._request(principal_context=body_principal), use_case, authz, api_keys
       )

       authz.check.assert_awaited_once()
       assert authz.check.await_args.kwargs["principal_context"] == req_principal  # not body_principal
       authz.grant.assert_awaited_once()
       assert authz.grant.await_args.kwargs["principal_context"] == req_principal
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: agentex/tests/unit/api/test_agents_authz.py
   Line: 432-440

   Comment:
   **Missing test: request-state principal takes precedence over body principal**

   There is no test for the case where **both** the request-state principal (resolvable, e.g. `{"user_id":"req-user"}`) **and** the body `principal_context` (e.g. `{"user_id":"body-user"}`) are present. The request-state principal should win and the body should be silently ignored.

   Without a test, a future refactor that accidentally reverses the precedence (falling back to body even when the request-state is resolvable) would pass all current tests. This is a straightforward case to add:

   ```python
   async def test_request_state_principal_takes_precedence_over_body(self):
       req_principal = {"user_id": "req-user", "account_id": "acct"}
       body_principal = {"user_id": "body-user", "account_id": "acct"}
       authz, use_case, api_keys = self._mocks(principal_context=req_principal)

       await register_agent(
           self._request(principal_context=body_principal), use_case, authz, api_keys
       )

       authz.check.assert_awaited_once()
       assert authz.check.await_args.kwargs["principal_context"] == req_principal  # not body_principal
       authz.grant.assert_awaited_once()
       assert authz.grant.await_args.kwargs["principal_context"] == req_principal
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%0ALine%3A%20432-440%0A%0AComment%3A%0A**Missing%20test%3A%20request-state%20principal%20takes%20precedence%20over%20body%20principal**%0A%0AThere%20is%20no%20test%20for%20the%20case%20where%20**both**%20the%20request-state%20principal%20%28resolvable%2C%20e.g.%20%60%7B%22user_id%22%3A%22req-user%22%7D%60%29%20**and**%20the%20body%20%60principal_context%60%20%28e.g.%20%60%7B%22user_id%22%3A%22body-user%22%7D%60%29%20are%20present.%20The%20request-state%20principal%20should%20win%20and%20the%20body%20should%20be%20silently%20ignored.%0A%0AWithout%20a%20test%2C%20a%20future%20refactor%20that%20accidentally%20reverses%20the%20precedence%20%28falling%20back%20to%20body%20even%20when%20the%20request-state%20is%20resolvable%29%20would%20pass%20all%20current%20tests.%20This%20is%20a%20straightforward%20case%20to%20add%3A%0A%0A%60%60%60python%0Aasync%20def%20test_request_state_principal_takes_precedence_over_body%28self%29%3A%0A%20%20%20%20req_principal%20%3D%20%7B%22user_id%22%3A%20%22req-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20body_principal%20%3D%20%7B%22user_id%22%3A%20%22body-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20authz%2C%20use_case%2C%20api_keys%20%3D%20self._mocks%28principal_context%3Dreq_principal%29%0A%0A%20%20%20%20await%20register_agent%28%0A%20%20%20%20%20%20%20%20self._request%28principal_context%3Dbody_principal%29%2C%20use_case%2C%20authz%2C%20api_keys%0A%20%20%20%20%29%0A%0A%20%20%20%20authz.check.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%20%20%23%20not%20body_principal%0A%20%20%20%20authz.grant.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%0ALine%3A%20432-440%0A%0AComment%3A%0A**Missing%20test%3A%20request-state%20principal%20takes%20precedence%20over%20body%20principal**%0A%0AThere%20is%20no%20test%20for%20the%20case%20where%20**both**%20the%20request-state%20principal%20%28resolvable%2C%20e.g.%20%60%7B%22user_id%22%3A%22req-user%22%7D%60%29%20**and**%20the%20body%20%60principal_context%60%20%28e.g.%20%60%7B%22user_id%22%3A%22body-user%22%7D%60%29%20are%20present.%20The%20request-state%20principal%20should%20win%20and%20the%20body%20should%20be%20silently%20ignored.%0A%0AWithout%20a%20test%2C%20a%20future%20refactor%20that%20accidentally%20reverses%20the%20precedence%20%28falling%20back%20to%20body%20even%20when%20the%20request-state%20is%20resolvable%29%20would%20pass%20all%20current%20tests.%20This%20is%20a%20straightforward%20case%20to%20add%3A%0A%0A%60%60%60python%0Aasync%20def%20test_request_state_principal_takes_precedence_over_body%28self%29%3A%0A%20%20%20%20req_principal%20%3D%20%7B%22user_id%22%3A%20%22req-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20body_principal%20%3D%20%7B%22user_id%22%3A%20%22body-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20authz%2C%20use_case%2C%20api_keys%20%3D%20self._mocks%28principal_context%3Dreq_principal%29%0A%0A%20%20%20%20await%20register_agent%28%0A%20%20%20%20%20%20%20%20self._request%28principal_context%3Dbody_principal%29%2C%20use_case%2C%20authz%2C%20api_keys%0A%20%20%20%20%29%0A%0A%20%20%20%20authz.check.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%20%20%23%20not%20body_principal%0A%20%20%20%20authz.grant.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22codex%2Flegacy-register-principal-grant%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Flegacy-register-principal-grant%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%0ALine%3A%20432-440%0A%0AComment%3A%0A**Missing%20test%3A%20request-state%20principal%20takes%20precedence%20over%20body%20principal**%0A%0AThere%20is%20no%20test%20for%20the%20case%20where%20**both**%20the%20request-state%20principal%20%28resolvable%2C%20e.g.%20%60%7B%22user_id%22%3A%22req-user%22%7D%60%29%20**and**%20the%20body%20%60principal_context%60%20%28e.g.%20%60%7B%22user_id%22%3A%22body-user%22%7D%60%29%20are%20present.%20The%20request-state%20principal%20should%20win%20and%20the%20body%20should%20be%20silently%20ignored.%0A%0AWithout%20a%20test%2C%20a%20future%20refactor%20that%20accidentally%20reverses%20the%20precedence%20%28falling%20back%20to%20body%20even%20when%20the%20request-state%20is%20resolvable%29%20would%20pass%20all%20current%20tests.%20This%20is%20a%20straightforward%20case%20to%20add%3A%0A%0A%60%60%60python%0Aasync%20def%20test_request_state_principal_takes_precedence_over_body%28self%29%3A%0A%20%20%20%20req_principal%20%3D%20%7B%22user_id%22%3A%20%22req-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20body_principal%20%3D%20%7B%22user_id%22%3A%20%22body-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20authz%2C%20use_case%2C%20api_keys%20%3D%20self._mocks%28principal_context%3Dreq_principal%29%0A%0A%20%20%20%20await%20register_agent%28%0A%20%20%20%20%20%20%20%20self._request%28principal_context%3Dbody_principal%29%2C%20use_case%2C%20authz%2C%20api_keys%0A%20%20%20%20%29%0A%0A%20%20%20%20authz.check.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%20%20%23%20not%20body_principal%0A%20%20%20%20authz.grant.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `agentex/tests/unit/api/test_agents_authz.py`, line 432-453 ([link](https://github.com/scaleapi/scale-agentex/blob/cfcc63d95e041f7ae76d7c6f5d2d3f911f2be06d/agentex/tests/unit/api/test_agents_authz.py#L432-L453)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Existing tests don't assert `principal_context` kwarg for the request-state principal path**

   Both `test_dict_principal_enforces_check_and_grant` and `test_object_principal_enforces_check_and_grant` only check `assert_awaited_once()` without inspecting `await_args.kwargs["principal_context"]`. Now that the route explicitly passes `principal_context=principal_context` as a kwarg (new in this PR), the test should verify the correct principal is forwarded — especially since a bug where the wrong principal was passed (e.g., `None` or the body principal) would be invisible to the current assertions.

   The new `test_body_principal_enforces_check_and_grant` correctly asserts `await_args.kwargs["principal_context"] == body_principal`. The same pattern should be applied to these two existing tests:

   ```python
   # In test_dict_principal_enforces_check_and_grant:
   assert authz.check.await_args.kwargs["principal_context"] == {"user_id": "u", "account_id": "acct"}
   assert authz.grant.await_args.kwargs["principal_context"] == {"user_id": "u", "account_id": "acct"}

   # In test_object_principal_enforces_check_and_grant:
   expected = SimpleNamespace(user_id="u", service_account_id=None, account_id="acct")
   assert authz.check.await_args.kwargs["principal_context"] == expected
   assert authz.grant.await_args.kwargs["principal_context"] == expected
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: agentex/tests/unit/api/test_agents_authz.py
   Line: 432-453

   Comment:
   **Existing tests don't assert `principal_context` kwarg for the request-state principal path**

   Both `test_dict_principal_enforces_check_and_grant` and `test_object_principal_enforces_check_and_grant` only check `assert_awaited_once()` without inspecting `await_args.kwargs["principal_context"]`. Now that the route explicitly passes `principal_context=principal_context` as a kwarg (new in this PR), the test should verify the correct principal is forwarded — especially since a bug where the wrong principal was passed (e.g., `None` or the body principal) would be invisible to the current assertions.

   The new `test_body_principal_enforces_check_and_grant` correctly asserts `await_args.kwargs["principal_context"] == body_principal`. The same pattern should be applied to these two existing tests:

   ```python
   # In test_dict_principal_enforces_check_and_grant:
   assert authz.check.await_args.kwargs["principal_context"] == {"user_id": "u", "account_id": "acct"}
   assert authz.grant.await_args.kwargs["principal_context"] == {"user_id": "u", "account_id": "acct"}

   # In test_object_principal_enforces_check_and_grant:
   expected = SimpleNamespace(user_id="u", service_account_id=None, account_id="acct")
   assert authz.check.await_args.kwargs["principal_context"] == expected
   assert authz.grant.await_args.kwargs["principal_context"] == expected
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%0ALine%3A%20432-453%0A%0AComment%3A%0A**Existing%20tests%20don't%20assert%20%60principal_context%60%20kwarg%20for%20the%20request-state%20principal%20path**%0A%0ABoth%20%60test_dict_principal_enforces_check_and_grant%60%20and%20%60test_object_principal_enforces_check_and_grant%60%20only%20check%20%60assert_awaited_once%28%29%60%20without%20inspecting%20%60await_args.kwargs%5B%22principal_context%22%5D%60.%20Now%20that%20the%20route%20explicitly%20passes%20%60principal_context%3Dprincipal_context%60%20as%20a%20kwarg%20%28new%20in%20this%20PR%29%2C%20the%20test%20should%20verify%20the%20correct%20principal%20is%20forwarded%20%E2%80%94%20especially%20since%20a%20bug%20where%20the%20wrong%20principal%20was%20passed%20%28e.g.%2C%20%60None%60%20or%20the%20body%20principal%29%20would%20be%20invisible%20to%20the%20current%20assertions.%0A%0AThe%20new%20%60test_body_principal_enforces_check_and_grant%60%20correctly%20asserts%20%60await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20body_principal%60.%20The%20same%20pattern%20should%20be%20applied%20to%20these%20two%20existing%20tests%3A%0A%0A%60%60%60python%0A%23%20In%20test_dict_principal_enforces_check_and_grant%3A%0Aassert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0Aassert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%0A%23%20In%20test_object_principal_enforces_check_and_grant%3A%0Aexpected%20%3D%20SimpleNamespace%28user_id%3D%22u%22%2C%20service_account_id%3DNone%2C%20account_id%3D%22acct%22%29%0Aassert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20expected%0Aassert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20expected%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%0ALine%3A%20432-453%0A%0AComment%3A%0A**Existing%20tests%20don't%20assert%20%60principal_context%60%20kwarg%20for%20the%20request-state%20principal%20path**%0A%0ABoth%20%60test_dict_principal_enforces_check_and_grant%60%20and%20%60test_object_principal_enforces_check_and_grant%60%20only%20check%20%60assert_awaited_once%28%29%60%20without%20inspecting%20%60await_args.kwargs%5B%22principal_context%22%5D%60.%20Now%20that%20the%20route%20explicitly%20passes%20%60principal_context%3Dprincipal_context%60%20as%20a%20kwarg%20%28new%20in%20this%20PR%29%2C%20the%20test%20should%20verify%20the%20correct%20principal%20is%20forwarded%20%E2%80%94%20especially%20since%20a%20bug%20where%20the%20wrong%20principal%20was%20passed%20%28e.g.%2C%20%60None%60%20or%20the%20body%20principal%29%20would%20be%20invisible%20to%20the%20current%20assertions.%0A%0AThe%20new%20%60test_body_principal_enforces_check_and_grant%60%20correctly%20asserts%20%60await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20body_principal%60.%20The%20same%20pattern%20should%20be%20applied%20to%20these%20two%20existing%20tests%3A%0A%0A%60%60%60python%0A%23%20In%20test_dict_principal_enforces_check_and_grant%3A%0Aassert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0Aassert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%0A%23%20In%20test_object_principal_enforces_check_and_grant%3A%0Aexpected%20%3D%20SimpleNamespace%28user_id%3D%22u%22%2C%20service_account_id%3DNone%2C%20account_id%3D%22acct%22%29%0Aassert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20expected%0Aassert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20expected%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22codex%2Flegacy-register-principal-grant%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Flegacy-register-principal-grant%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%0ALine%3A%20432-453%0A%0AComment%3A%0A**Existing%20tests%20don't%20assert%20%60principal_context%60%20kwarg%20for%20the%20request-state%20principal%20path**%0A%0ABoth%20%60test_dict_principal_enforces_check_and_grant%60%20and%20%60test_object_principal_enforces_check_and_grant%60%20only%20check%20%60assert_awaited_once%28%29%60%20without%20inspecting%20%60await_args.kwargs%5B%22principal_context%22%5D%60.%20Now%20that%20the%20route%20explicitly%20passes%20%60principal_context%3Dprincipal_context%60%20as%20a%20kwarg%20%28new%20in%20this%20PR%29%2C%20the%20test%20should%20verify%20the%20correct%20principal%20is%20forwarded%20%E2%80%94%20especially%20since%20a%20bug%20where%20the%20wrong%20principal%20was%20passed%20%28e.g.%2C%20%60None%60%20or%20the%20body%20principal%29%20would%20be%20invisible%20to%20the%20current%20assertions.%0A%0AThe%20new%20%60test_body_principal_enforces_check_and_grant%60%20correctly%20asserts%20%60await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20body_principal%60.%20The%20same%20pattern%20should%20be%20applied%20to%20these%20two%20existing%20tests%3A%0A%0A%60%60%60python%0A%23%20In%20test_dict_principal_enforces_check_and_grant%3A%0Aassert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0Aassert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%0A%23%20In%20test_object_principal_enforces_check_and_grant%3A%0Aexpected%20%3D%20SimpleNamespace%28user_id%3D%22u%22%2C%20service_account_id%3DNone%2C%20account_id%3D%22acct%22%29%0Aassert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20expected%0Aassert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20expected%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Aagentex%2Fsrc%2Fapi%2Froutes%2Fagents.py%3A199-201%0A**Security%20%2F%20trust-boundary%20concern%3A%20unauthenticated%20body%20principal%20injection**%0A%0A%60%2Fagents%2Fregister%60%20is%20in%20%60WHITELISTED_ROUTES%60%2C%20so%20the%20auth%20middleware%20sets%20%60request.state.principal_context%20%3D%20None%60%20and%20skips%20all%20credential%20validation%20for%20every%20request%20to%20this%20path%20%E2%80%94%20including%20requests%20from%20external%2C%20untrusted%20callers.%0A%0AWith%20this%20PR%2C%20any%20caller%20to%20the%20endpoint%20can%20supply%3A%0A%60%60%60json%0A%7B%22principal_context%22%3A%20%7B%22user_id%22%3A%20%22any-user-id%22%2C%20%22account_id%22%3A%20%22any-account%22%7D%7D%0A%60%60%60%0A%60_has_resolvable_creator%60%20will%20return%20%60True%60%20for%20that%20dict%2C%20%60enforce_ownership%60%20becomes%20%60True%60%2C%20and%20the%20code%20proceeds%20to%20call%20%60authorization_service.grant%28AgentexResource.agent%28...%29%2C%20principal_context%3D%3Cattacker_dict%3E%29%60.%20The%20%60AgentexAuthorizationProxy.grant%60%20then%20forwards%20this%20dict%20verbatim%20to%20%60agentex-auth%20%2Fv1%2Fauthz%2Fgrant%60%20with%20no%20cryptographic%20proof%20that%20the%20caller%20is%20actually%20that%20user.%0A%0AWhether%20this%20results%20in%20a%20successful%20ownership%20escalation%20depends%20on%20whether%20agentex-auth%20performs%20independent%20principal%20validation%20server-side.%20If%20it%20accepts%20the%20principal%20dict%20at%20face%20value%20%28as%20a%20trusted%20internal%20call%29%2C%20any%20caller%20who%20can%20reach%20this%20endpoint%20can%20claim%20ownership%20of%20agents%20under%20any%20identity.%0A%0A**Recommendation%3A**%20If%20the%20body-principal%20trust%20model%20depends%20on%20network%20isolation%20%28only%20internal%20pods%20can%20reach%20this%20endpoint%29%2C%20document%20that%20assumption%20explicitly.%20Consider%20adding%20a%20comment%20on%20the%20%60principal_context%60%20field%20and%20here%20explaining%20the%20trust%20model%2C%20and%2For%20adding%20a%20check%20that%20explicitly%20limits%20this%20fallback%20to%20only%20when%20%60AGENTEX_AUTH_URL%60%20is%20configured%20in%20a%20way%20that%20signals%20internal-only%20trust.%0A%0A%23%23%23%20Issue%202%20of%206%0Aagentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%3A404-415%0A**Missing%20test%3A%20unresolvable%20non-None%20auth-service%20principal%20%2B%20resolvable%20body%20principal**%0A%0AThe%20parametrize%20covers%20%60%5BNone%2C%20%7B%7D%2C%20%7B%22account_id%22%3A%22acct%22%7D%5D%60%20for%20the%20auth-service%20principal%2C%20but%20always%20calls%20%60self._request%28%29%60%20with%20no%20body%20%60principal_context%60.%20This%20means%20the%20case%3A%0A%0A-%20auth%20service%20has%20%60%7B%22account_id%22%3A%20%22acct%22%7D%60%20%28unresolvable%29%20**AND**%20body%20has%20%60%7B%22user_id%22%3A%20%22u%22%7D%60%20%28resolvable%29%0A%0Ais%20never%20tested.%20With%20the%20new%20fallback%20logic%2C%20the%20body%20principal%20would%20be%20used%20here%20%28%60enforce_ownership%3DTrue%60%29%2C%20which%20is%20the%20intended%20behavior%20%E2%80%94%20but%20there%20is%20zero%20coverage%20for%20it.%20A%20regression%20that%20skips%20enforcement%20in%20this%20case%20would%20pass%20all%20current%20tests.%0A%0AConsider%20adding%20a%20parametrized%20variant%20like%3A%0A%60%60%60python%0A%40pytest.mark.parametrize%28%0A%20%20%20%20%22auth_principal%2Cbody_principal%22%2C%0A%20%20%20%20%5B%0A%20%20%20%20%20%20%20%20%28%7B%7D%2C%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%29%2C%0A%20%20%20%20%20%20%20%20%28%7B%22account_id%22%3A%20%22acct%22%7D%2C%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%29%2C%0A%20%20%20%20%5D%2C%0A%29%0Aasync%20def%20test_unresolvable_auth_service_with_resolvable_body_enforces%28self%2C%20auth_principal%2C%20body_principal%29%3A%0A%20%20%20%20authz%2C%20use_case%2C%20api_keys%20%3D%20self._mocks%28principal_context%3Dauth_principal%29%0A%20%20%20%20await%20register_agent%28self._request%28principal_context%3Dbody_principal%29%2C%20use_case%2C%20authz%2C%20api_keys%29%0A%20%20%20%20authz.check.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20body_principal%0A%20%20%20%20authz.grant.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20body_principal%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0Aagentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%3A432-440%0A**Missing%20test%3A%20request-state%20principal%20takes%20precedence%20over%20body%20principal**%0A%0AThere%20is%20no%20test%20for%20the%20case%20where%20**both**%20the%20request-state%20principal%20%28resolvable%2C%20e.g.%20%60%7B%22user_id%22%3A%22req-user%22%7D%60%29%20**and**%20the%20body%20%60principal_context%60%20%28e.g.%20%60%7B%22user_id%22%3A%22body-user%22%7D%60%29%20are%20present.%20The%20request-state%20principal%20should%20win%20and%20the%20body%20should%20be%20silently%20ignored.%0A%0AWithout%20a%20test%2C%20a%20future%20refactor%20that%20accidentally%20reverses%20the%20precedence%20%28falling%20back%20to%20body%20even%20when%20the%20request-state%20is%20resolvable%29%20would%20pass%20all%20current%20tests.%20This%20is%20a%20straightforward%20case%20to%20add%3A%0A%0A%60%60%60python%0Aasync%20def%20test_request_state_principal_takes_precedence_over_body%28self%29%3A%0A%20%20%20%20req_principal%20%3D%20%7B%22user_id%22%3A%20%22req-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20body_principal%20%3D%20%7B%22user_id%22%3A%20%22body-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20authz%2C%20use_case%2C%20api_keys%20%3D%20self._mocks%28principal_context%3Dreq_principal%29%0A%0A%20%20%20%20await%20register_agent%28%0A%20%20%20%20%20%20%20%20self._request%28principal_context%3Dbody_principal%29%2C%20use_case%2C%20authz%2C%20api_keys%0A%20%20%20%20%29%0A%0A%20%20%20%20authz.check.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%20%20%23%20not%20body_principal%0A%20%20%20%20authz.grant.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%0A%60%60%60%0A%0A%283%20more%20issues%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Cursor%22%20links%20for%20remaining%20issues.%29%0A&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Aagentex%2Fsrc%2Fapi%2Froutes%2Fagents.py%3A199-201%0A**Security%20%2F%20trust-boundary%20concern%3A%20unauthenticated%20body%20principal%20injection**%0A%0A%60%2Fagents%2Fregister%60%20is%20in%20%60WHITELISTED_ROUTES%60%2C%20so%20the%20auth%20middleware%20sets%20%60request.state.principal_context%20%3D%20None%60%20and%20skips%20all%20credential%20validation%20for%20every%20request%20to%20this%20path%20%E2%80%94%20including%20requests%20from%20external%2C%20untrusted%20callers.%0A%0AWith%20this%20PR%2C%20any%20caller%20to%20the%20endpoint%20can%20supply%3A%0A%60%60%60json%0A%7B%22principal_context%22%3A%20%7B%22user_id%22%3A%20%22any-user-id%22%2C%20%22account_id%22%3A%20%22any-account%22%7D%7D%0A%60%60%60%0A%60_has_resolvable_creator%60%20will%20return%20%60True%60%20for%20that%20dict%2C%20%60enforce_ownership%60%20becomes%20%60True%60%2C%20and%20the%20code%20proceeds%20to%20call%20%60authorization_service.grant%28AgentexResource.agent%28...%29%2C%20principal_context%3D%3Cattacker_dict%3E%29%60.%20The%20%60AgentexAuthorizationProxy.grant%60%20then%20forwards%20this%20dict%20verbatim%20to%20%60agentex-auth%20%2Fv1%2Fauthz%2Fgrant%60%20with%20no%20cryptographic%20proof%20that%20the%20caller%20is%20actually%20that%20user.%0A%0AWhether%20this%20results%20in%20a%20successful%20ownership%20escalation%20depends%20on%20whether%20agentex-auth%20performs%20independent%20principal%20validation%20server-side.%20If%20it%20accepts%20the%20principal%20dict%20at%20face%20value%20%28as%20a%20trusted%20internal%20call%29%2C%20any%20caller%20who%20can%20reach%20this%20endpoint%20can%20claim%20ownership%20of%20agents%20under%20any%20identity.%0A%0A**Recommendation%3A**%20If%20the%20body-principal%20trust%20model%20depends%20on%20network%20isolation%20%28only%20internal%20pods%20can%20reach%20this%20endpoint%29%2C%20document%20that%20assumption%20explicitly.%20Consider%20adding%20a%20comment%20on%20the%20%60principal_context%60%20field%20and%20here%20explaining%20the%20trust%20model%2C%20and%2For%20adding%20a%20check%20that%20explicitly%20limits%20this%20fallback%20to%20only%20when%20%60AGENTEX_AUTH_URL%60%20is%20configured%20in%20a%20way%20that%20signals%20internal-only%20trust.%0A%0A%23%23%23%20Issue%202%20of%206%0Aagentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%3A404-415%0A**Missing%20test%3A%20unresolvable%20non-None%20auth-service%20principal%20%2B%20resolvable%20body%20principal**%0A%0AThe%20parametrize%20covers%20%60%5BNone%2C%20%7B%7D%2C%20%7B%22account_id%22%3A%22acct%22%7D%5D%60%20for%20the%20auth-service%20principal%2C%20but%20always%20calls%20%60self._request%28%29%60%20with%20no%20body%20%60principal_context%60.%20This%20means%20the%20case%3A%0A%0A-%20auth%20service%20has%20%60%7B%22account_id%22%3A%20%22acct%22%7D%60%20%28unresolvable%29%20**AND**%20body%20has%20%60%7B%22user_id%22%3A%20%22u%22%7D%60%20%28resolvable%29%0A%0Ais%20never%20tested.%20With%20the%20new%20fallback%20logic%2C%20the%20body%20principal%20would%20be%20used%20here%20%28%60enforce_ownership%3DTrue%60%29%2C%20which%20is%20the%20intended%20behavior%20%E2%80%94%20but%20there%20is%20zero%20coverage%20for%20it.%20A%20regression%20that%20skips%20enforcement%20in%20this%20case%20would%20pass%20all%20current%20tests.%0A%0AConsider%20adding%20a%20parametrized%20variant%20like%3A%0A%60%60%60python%0A%40pytest.mark.parametrize%28%0A%20%20%20%20%22auth_principal%2Cbody_principal%22%2C%0A%20%20%20%20%5B%0A%20%20%20%20%20%20%20%20%28%7B%7D%2C%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%29%2C%0A%20%20%20%20%20%20%20%20%28%7B%22account_id%22%3A%20%22acct%22%7D%2C%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%29%2C%0A%20%20%20%20%5D%2C%0A%29%0Aasync%20def%20test_unresolvable_auth_service_with_resolvable_body_enforces%28self%2C%20auth_principal%2C%20body_principal%29%3A%0A%20%20%20%20authz%2C%20use_case%2C%20api_keys%20%3D%20self._mocks%28principal_context%3Dauth_principal%29%0A%20%20%20%20await%20register_agent%28self._request%28principal_context%3Dbody_principal%29%2C%20use_case%2C%20authz%2C%20api_keys%29%0A%20%20%20%20authz.check.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20body_principal%0A%20%20%20%20authz.grant.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20body_principal%0A%60%60%60%0A%0A%284%20more%20issues%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=scaleapi%2Fscale-agentex&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22codex%2Flegacy-register-principal-grant%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Flegacy-register-principal-grant%22.%0A%0AFix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Aagentex%2Fsrc%2Fapi%2Froutes%2Fagents.py%3A199-201%0A**Security%20%2F%20trust-boundary%20concern%3A%20unauthenticated%20body%20principal%20injection**%0A%0A%60%2Fagents%2Fregister%60%20is%20in%20%60WHITELISTED_ROUTES%60%2C%20so%20the%20auth%20middleware%20sets%20%60request.state.principal_context%20%3D%20None%60%20and%20skips%20all%20credential%20validation%20for%20every%20request%20to%20this%20path%20%E2%80%94%20including%20requests%20from%20external%2C%20untrusted%20callers.%0A%0AWith%20this%20PR%2C%20any%20caller%20to%20the%20endpoint%20can%20supply%3A%0A%60%60%60json%0A%7B%22principal_context%22%3A%20%7B%22user_id%22%3A%20%22any-user-id%22%2C%20%22account_id%22%3A%20%22any-account%22%7D%7D%0A%60%60%60%0A%60_has_resolvable_creator%60%20will%20return%20%60True%60%20for%20that%20dict%2C%20%60enforce_ownership%60%20becomes%20%60True%60%2C%20and%20the%20code%20proceeds%20to%20call%20%60authorization_service.grant%28AgentexResource.agent%28...%29%2C%20principal_context%3D%3Cattacker_dict%3E%29%60.%20The%20%60AgentexAuthorizationProxy.grant%60%20then%20forwards%20this%20dict%20verbatim%20to%20%60agentex-auth%20%2Fv1%2Fauthz%2Fgrant%60%20with%20no%20cryptographic%20proof%20that%20the%20caller%20is%20actually%20that%20user.%0A%0AWhether%20this%20results%20in%20a%20successful%20ownership%20escalation%20depends%20on%20whether%20agentex-auth%20performs%20independent%20principal%20validation%20server-side.%20If%20it%20accepts%20the%20principal%20dict%20at%20face%20value%20%28as%20a%20trusted%20internal%20call%29%2C%20any%20caller%20who%20can%20reach%20this%20endpoint%20can%20claim%20ownership%20of%20agents%20under%20any%20identity.%0A%0A**Recommendation%3A**%20If%20the%20body-principal%20trust%20model%20depends%20on%20network%20isolation%20%28only%20internal%20pods%20can%20reach%20this%20endpoint%29%2C%20document%20that%20assumption%20explicitly.%20Consider%20adding%20a%20comment%20on%20the%20%60principal_context%60%20field%20and%20here%20explaining%20the%20trust%20model%2C%20and%2For%20adding%20a%20check%20that%20explicitly%20limits%20this%20fallback%20to%20only%20when%20%60AGENTEX_AUTH_URL%60%20is%20configured%20in%20a%20way%20that%20signals%20internal-only%20trust.%0A%0A%23%23%23%20Issue%202%20of%206%0Aagentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%3A404-415%0A**Missing%20test%3A%20unresolvable%20non-None%20auth-service%20principal%20%2B%20resolvable%20body%20principal**%0A%0AThe%20parametrize%20covers%20%60%5BNone%2C%20%7B%7D%2C%20%7B%22account_id%22%3A%22acct%22%7D%5D%60%20for%20the%20auth-service%20principal%2C%20but%20always%20calls%20%60self._request%28%29%60%20with%20no%20body%20%60principal_context%60.%20This%20means%20the%20case%3A%0A%0A-%20auth%20service%20has%20%60%7B%22account_id%22%3A%20%22acct%22%7D%60%20%28unresolvable%29%20**AND**%20body%20has%20%60%7B%22user_id%22%3A%20%22u%22%7D%60%20%28resolvable%29%0A%0Ais%20never%20tested.%20With%20the%20new%20fallback%20logic%2C%20the%20body%20principal%20would%20be%20used%20here%20%28%60enforce_ownership%3DTrue%60%29%2C%20which%20is%20the%20intended%20behavior%20%E2%80%94%20but%20there%20is%20zero%20coverage%20for%20it.%20A%20regression%20that%20skips%20enforcement%20in%20this%20case%20would%20pass%20all%20current%20tests.%0A%0AConsider%20adding%20a%20parametrized%20variant%20like%3A%0A%60%60%60python%0A%40pytest.mark.parametrize%28%0A%20%20%20%20%22auth_principal%2Cbody_principal%22%2C%0A%20%20%20%20%5B%0A%20%20%20%20%20%20%20%20%28%7B%7D%2C%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%29%2C%0A%20%20%20%20%20%20%20%20%28%7B%22account_id%22%3A%20%22acct%22%7D%2C%20%7B%22user_id%22%3A%20%22u%22%2C%20%22account_id%22%3A%20%22acct%22%7D%29%2C%0A%20%20%20%20%5D%2C%0A%29%0Aasync%20def%20test_unresolvable_auth_service_with_resolvable_body_enforces%28self%2C%20auth_principal%2C%20body_principal%29%3A%0A%20%20%20%20authz%2C%20use_case%2C%20api_keys%20%3D%20self._mocks%28principal_context%3Dauth_principal%29%0A%20%20%20%20await%20register_agent%28self._request%28principal_context%3Dbody_principal%29%2C%20use_case%2C%20authz%2C%20api_keys%29%0A%20%20%20%20authz.check.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20body_principal%0A%20%20%20%20authz.grant.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20body_principal%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0Aagentex%2Ftests%2Funit%2Fapi%2Ftest_agents_authz.py%3A432-440%0A**Missing%20test%3A%20request-state%20principal%20takes%20precedence%20over%20body%20principal**%0A%0AThere%20is%20no%20test%20for%20the%20case%20where%20**both**%20the%20request-state%20principal%20%28resolvable%2C%20e.g.%20%60%7B%22user_id%22%3A%22req-user%22%7D%60%29%20**and**%20the%20body%20%60principal_context%60%20%28e.g.%20%60%7B%22user_id%22%3A%22body-user%22%7D%60%29%20are%20present.%20The%20request-state%20principal%20should%20win%20and%20the%20body%20should%20be%20silently%20ignored.%0A%0AWithout%20a%20test%2C%20a%20future%20refactor%20that%20accidentally%20reverses%20the%20precedence%20%28falling%20back%20to%20body%20even%20when%20the%20request-state%20is%20resolvable%29%20would%20pass%20all%20current%20tests.%20This%20is%20a%20straightforward%20case%20to%20add%3A%0A%0A%60%60%60python%0Aasync%20def%20test_request_state_principal_takes_precedence_over_body%28self%29%3A%0A%20%20%20%20req_principal%20%3D%20%7B%22user_id%22%3A%20%22req-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20body_principal%20%3D%20%7B%22user_id%22%3A%20%22body-user%22%2C%20%22account_id%22%3A%20%22acct%22%7D%0A%20%20%20%20authz%2C%20use_case%2C%20api_keys%20%3D%20self._mocks%28principal_context%3Dreq_principal%29%0A%0A%20%20%20%20await%20register_agent%28%0A%20%20%20%20%20%20%20%20self._request%28principal_context%3Dbody_principal%29%2C%20use_case%2C%20authz%2C%20api_keys%0A%20%20%20%20%29%0A%0A%20%20%20%20authz.check.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.check.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%20%20%23%20not%20body_principal%0A%20%20%20%20authz.grant.assert_awaited_once%28%29%0A%20%20%20%20assert%20authz.grant.await_args.kwargs%5B%22principal_context%22%5D%20%3D%3D%20req_principal%0A%60%60%60%0A%0A%283%20more%20issues%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Codex%22%20links%20for%20remaining%20issues.%29%0A&repo=scaleapi%2Fscale-agentex&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 6 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 6
agentex/src/api/routes/agents.py:199-201
**Security / trust-boundary concern: unauthenticated body principal injection**

`/agents/register` is in `WHITELISTED_ROUTES`, so the auth middleware sets `request.state.principal_context = None` and skips all credential validation for every request to this path — including requests from external, untrusted callers.

With this PR, any caller to the endpoint can supply:
```json
{"principal_context": {"user_id": "any-user-id", "account_id": "any-account"}}
```
`_has_resolvable_creator` will return `True` for that dict, `enforce_ownership` becomes `True`, and the code proceeds to call `authorization_service.grant(AgentexResource.agent(...), principal_context=<attacker_dict>)`. The `AgentexAuthorizationProxy.grant` then forwards this dict verbatim to `agentex-auth /v1/authz/grant` with no cryptographic proof that the caller is actually that user.

Whether this results in a successful ownership escalation depends on whether agentex-auth performs independent principal validation server-side. If it accepts the principal dict at face value (as a trusted internal call), any caller who can reach this endpoint can claim ownership of agents under any identity.

**Recommendation:** If the body-principal trust model depends on network isolation (only internal pods can reach this endpoint), document that assumption explicitly. Consider adding a comment on the `principal_context` field and here explaining the trust model, and/or adding a check that explicitly limits this fallback to only when `AGENTEX_AUTH_URL` is configured in a way that signals internal-only trust.

### Issue 2 of 6
agentex/tests/unit/api/test_agents_authz.py:404-415
**Missing test: unresolvable non-None auth-service principal + resolvable body principal**

The parametrize covers `[None, {}, {"account_id":"acct"}]` for the auth-service principal, but always calls `self._request()` with no body `principal_context`. This means the case:

- auth service has `{"account_id": "acct"}` (unresolvable) **AND** body has `{"user_id": "u"}` (resolvable)

is never tested. With the new fallback logic, the body principal would be used here (`enforce_ownership=True`), which is the intended behavior — but there is zero coverage for it. A regression that skips enforcement in this case would pass all current tests.

Consider adding a parametrized variant like:
```python
@pytest.mark.parametrize(
    "auth_principal,body_principal",
    [
        ({}, {"user_id": "u", "account_id": "acct"}),
        ({"account_id": "acct"}, {"user_id": "u", "account_id": "acct"}),
    ],
)
async def test_unresolvable_auth_service_with_resolvable_body_enforces(self, auth_principal, body_principal):
    authz, use_case, api_keys = self._mocks(principal_context=auth_principal)
    await register_agent(self._request(principal_context=body_principal), use_case, authz, api_keys)
    authz.check.assert_awaited_once()
    assert authz.check.await_args.kwargs["principal_context"] == body_principal
    authz.grant.assert_awaited_once()
    assert authz.grant.await_args.kwargs["principal_context"] == body_principal
```

### Issue 3 of 6
agentex/tests/unit/api/test_agents_authz.py:432-440
**Missing test: request-state principal takes precedence over body principal**

There is no test for the case where **both** the request-state principal (resolvable, e.g. `{"user_id":"req-user"}`) **and** the body `principal_context` (e.g. `{"user_id":"body-user"}`) are present. The request-state principal should win and the body should be silently ignored.

Without a test, a future refactor that accidentally reverses the precedence (falling back to body even when the request-state is resolvable) would pass all current tests. This is a straightforward case to add:

```python
async def test_request_state_principal_takes_precedence_over_body(self):
    req_principal = {"user_id": "req-user", "account_id": "acct"}
    body_principal = {"user_id": "body-user", "account_id": "acct"}
    authz, use_case, api_keys = self._mocks(principal_context=req_principal)

    await register_agent(
        self._request(principal_context=body_principal), use_case, authz, api_keys
    )

    authz.check.assert_awaited_once()
    assert authz.check.await_args.kwargs["principal_context"] == req_principal  # not body_principal
    authz.grant.assert_awaited_once()
    assert authz.grant.await_args.kwargs["principal_context"] == req_principal
```

### Issue 4 of 6
agentex/tests/unit/api/test_agents_authz.py:432-453
**Existing tests don't assert `principal_context` kwarg for the request-state principal path**

Both `test_dict_principal_enforces_check_and_grant` and `test_object_principal_enforces_check_and_grant` only check `assert_awaited_once()` without inspecting `await_args.kwargs["principal_context"]`. Now that the route explicitly passes `principal_context=principal_context` as a kwarg (new in this PR), the test should verify the correct principal is forwarded — especially since a bug where the wrong principal was passed (e.g., `None` or the body principal) would be invisible to the current assertions.

The new `test_body_principal_enforces_check_and_grant` correctly asserts `await_args.kwargs["principal_context"] == body_principal`. The same pattern should be applied to these two existing tests:

```python
# In test_dict_principal_enforces_check_and_grant:
assert authz.check.await_args.kwargs["principal_context"] == {"user_id": "u", "account_id": "acct"}
assert authz.grant.await_args.kwargs["principal_context"] == {"user_id": "u", "account_id": "acct"}

# In test_object_principal_enforces_check_and_grant:
expected = SimpleNamespace(user_id="u", service_account_id=None, account_id="acct")
assert authz.check.await_args.kwargs["principal_context"] == expected
assert authz.grant.await_args.kwargs["principal_context"] == expected
```

### Issue 5 of 6
agentex/src/api/schemas/agents.py:91-93
**`principal_context: Any | None` accepts any JSON value without structural validation**

The `Any | None` type passes no shape constraint to either Pydantic or the OpenAPI schema. This means callers can supply a string, a list, or a deeply-nested object — none of which are meaningful principals. While `_has_resolvable_creator` safely returns `False` for non-dict/non-object values (so enforcement is skipped), the field still accepts arbitrary input.

Consider narrowing to `dict[str, Any] | None` to at minimum enforce that the principal is a JSON object, which matches the actual expected shape and generates a cleaner OpenAPI schema:

```python
principal_context: dict[str, Any] | None = Field(
    default=None,
    description=(
        "Principal used for authorization. "
        "Expected keys: 'user_id' or 'service_account_id'. "
        "Only honoured when the endpoint has no request-state principal "
        "(legacy whitelisted self-registration)."
    ),
)
```

This also makes the intent and expected format discoverable from the schema alone.

### Issue 6 of 6
agentex/openapi.yaml:5222-5229
**`anyOf: [{}]` is maximally permissive and the description omits expected structure**

```yaml
principal_context:
  anyOf:
  - {}
  - type: 'null'
  title: Principal Context
  description: Principal used for authorization
```

`{}` in JSON Schema means "validates anything" — any string, number, list, or object will pass. The description says only "Principal used for authorization" without naming expected keys (`user_id` / `service_account_id`). API consumers reading the spec will not know what to supply.

If the schema is narrowed to `dict[str, Any] | None` in the Python model (see comment on `agents.py`), the generated spec would become:
```yaml
principal_context:
  anyOf:
  - type: object
    additionalProperties: true
  - type: 'null'
```
which is significantly more descriptive and filters out non-object values at the serialization layer.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(authz): grant legacy agent register ..."](https://github.com/scaleapi/scale-agentex/commit/cfcc63d95e041f7ae76d7c6f5d2d3f911f2be06d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38515392)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->