### PR TITLE
feat(channels): add extensible channel abstraction with generic webho…

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -364,6 +364,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /channels/webhook/{route_id}:
+    post:
+      tags:
+      - Channels
+      summary: Generic webhook channel
+      description: 'Authenticated webhook ingress: verifies a per-route secret/HMAC
+        and drives an agent turn. Auth is whitelisted at the middleware; the channel
+        verifies the route secret instead.'
+      operationId: handle_webhook_channels_webhook__route_id__post
+      parameters:
+      - name: route_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Route Id
+      - name: wait
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: 'If true, wait for the agent''s reply and return it (for synchronous
+            callers). Default false: return immediately with the task_id.'
+          default: false
+          title: Wait
+        description: 'If true, wait for the agent''s reply and return it (for synchronous
+          callers). Default false: return immediately with the task_id.'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Handle Webhook Channels Webhook  Route Id  Post
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /tasks/{task_id}:
     get:
       tags:

--- a/agentex/src/api/app.py
+++ b/agentex/src/api/app.py
@@ -31,6 +31,7 @@ from src.api.routes import (
     agent_api_keys,
     agent_task_tracker,
     agents,
+    channels,
     checkpoints,
     deployment_history,
     deployments,
@@ -193,6 +194,7 @@ async def handle_unexpected(request, exc):
 
 # Include all routers
 fastapi_app.include_router(agents.router)
+fastapi_app.include_router(channels.router)
 fastapi_app.include_router(tasks.router)
 fastapi_app.include_router(messages.router)
 fastapi_app.include_router(spans.router)

--- a/agentex/src/api/middleware_utils.py
+++ b/agentex/src/api/middleware_utils.py
@@ -28,6 +28,9 @@ WHITELISTED_ROUTES: set[str] = {
     "/readyz",
     "/ping",
     "/echo",
+    # Channels (webhook, …) bypass agentex API-key auth and verify a per-route
+    # shared secret / HMAC inside the channel instead.
+    "/channels/webhook",
 }
 
 DROP_HEADERS: set[str] = {

--- a/agentex/src/api/routes/channels.py
+++ b/agentex/src/api/routes/channels.py
@@ -1,0 +1,124 @@
+"""Channels API: external surfaces (webhook now, Slack later) that drive agent turns.
+
+The webhook endpoint is auth-whitelisted in `middleware_utils.WHITELISTED_ROUTES`
+(it bypasses the agentex API-key auth) and instead verifies a per-route shared
+secret / HMAC inside the channel. Each route binds to one agent and an opaque
+`params` dict forwarded verbatim to task/create (agentex does not interpret it —
+the bound agent does).
+
+Route bindings live in the CHANNELS_WEBHOOK_ROUTES env var (JSON) for now — the
+seam where a real per-config store (resolving a saved agent_config_id) plugs in later:
+
+    CHANNELS_WEBHOOK_ROUTES='{"demo": {"secret": "<shared-secret>",
+        "agent_name": "golden-agent",
+        "params": {"system_prompt": "You are ...", "mcps": []}}}'
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from src.domain.channels.base import ChannelBinding
+from src.domain.channels.router import ChannelRouter
+from src.domain.channels.webhook import MAX_BODY_BYTES, WebhookChannel
+from src.domain.services.task_message_service import DTaskMessageService
+from src.domain.use_cases.agents_acp_use_case import DAgentsACPUseCase
+from src.domain.use_cases.agents_use_case import DAgentsUseCase
+from src.utils.logging import make_logger
+
+logger = make_logger(__name__)
+
+router = APIRouter(prefix="/channels", tags=["Channels"])
+
+# Channel registry — add "slack": SlackChannel() here when it lands.
+_WEBHOOK = WebhookChannel()
+
+
+def _webhook_binding(route_id: str) -> ChannelBinding | None:
+    """Resolve a webhook route's binding. Env-backed seam; replace with a config store."""
+    raw = os.environ.get("CHANNELS_WEBHOOK_ROUTES")
+    if not raw:
+        return None
+    try:
+        routes = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.error("[channels] CHANNELS_WEBHOOK_ROUTES is not valid JSON")
+        return None
+    cfg = routes.get(route_id)
+    if not isinstance(cfg, dict) or not cfg.get("secret") or not cfg.get("agent_name"):
+        return None
+    # `params` is opaque — forwarded verbatim to task/create; agentex does not
+    # interpret it (an agent like golden-agent reads system_prompt/mcps/etc. there).
+    params = cfg.get("params")
+    return ChannelBinding(
+        secret=cfg["secret"],
+        agent_name=cfg["agent_name"],
+        params=params if isinstance(params, dict) else {},
+    )
+
+
+@router.post(
+    "/webhook/{route_id}",
+    summary="Generic webhook channel",
+    description="Authenticated webhook ingress: verifies a per-route secret/HMAC and "
+    "drives an agent turn. Auth is whitelisted at the middleware; the channel verifies "
+    "the route secret instead.",
+)
+async def handle_webhook(
+    route_id: str,
+    request: Request,
+    agents_acp_use_case: DAgentsACPUseCase,
+    agents_use_case: DAgentsUseCase,
+    task_message_service: DTaskMessageService,
+    wait: bool = Query(
+        False,
+        description="If true, wait for the agent's reply and return it (for synchronous "
+        "callers). Default false: return immediately with the task_id.",
+    ),
+) -> dict:
+    binding = _webhook_binding(route_id)
+    if binding is None:
+        raise HTTPException(status_code=404, detail="unknown route")
+
+    raw = await request.body()
+    if len(raw) > MAX_BODY_BYTES:
+        raise HTTPException(status_code=413, detail="payload too large")
+    if not _WEBHOOK.authenticate(binding, request, raw):
+        raise HTTPException(status_code=401, detail="unauthorized")
+    if "application/json" not in request.headers.get("content-type", ""):
+        raise HTTPException(status_code=400, detail="expected application/json")
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="invalid json")
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="json body must be an object")
+
+    # Resolve the agent's ACP type so the router picks the right turn method
+    # (sync -> message/send returns the reply inline; async -> event/send).
+    agent = await agents_use_case.get(name=binding.agent_name)
+
+    inbound = _WEBHOOK.to_inbound(route_id, body)
+    router_ = ChannelRouter(agents_acp_use_case, task_message_service)
+    result = await router_.dispatch(inbound, binding, agent.acp_type)
+
+    # A plain webhook has no outbound push (supports_outbound is False) — its reply is
+    # the HTTP response. Sync agents reply inline; for async, `wait` streams it back.
+    # A push channel (Slack) would instead: reply = result.reply or await_reply(...);
+    # await deliver_reply(channel, peer_id, reply).
+    reply = result.reply
+    if reply is None and wait:
+        reply = await router_.await_reply(result.task_id, result.after_id)
+
+    response = {
+        "ok": True,
+        "channel": "webhook",
+        "route_id": route_id,
+        "task_id": result.task_id,
+    }
+    if reply is not None:
+        response["reply"] = reply
+    return response

--- a/agentex/src/domain/channels/__init__.py
+++ b/agentex/src/domain/channels/__init__.py
@@ -1,0 +1,1 @@
+"""Channels: normalize external surfaces (webhook, Slack, …) into agent turns."""

--- a/agentex/src/domain/channels/base.py
+++ b/agentex/src/domain/channels/base.py
@@ -1,0 +1,131 @@
+"""Channel abstraction: normalize any external surface (webhook, Slack, …) into one
+inbound shape, and drive an agent turn from it.
+
+Modeled on OpenClaw's channel plugins (github.com/openclaw/openclaw,
+`src/channels/**`) and the claw0 tutorial: every platform produces the same
+`InboundMessage`; the agent-driving core is channel-agnostic. A new channel
+(Slack, etc.) implements `Channel` — `authenticate` + `to_inbound` for ingress,
+and (when it needs to push replies) its own outbound — without touching the router.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+from starlette.requests import Request
+
+
+@dataclass
+class InboundMessage:
+    """Normalized inbound event. Every channel produces this; the router only sees this."""
+
+    text: str
+    channel: str  # "webhook" | "slack" | …
+    route_id: str = ""  # which binding received it (webhook route / slack team)
+    peer_id: str = ""  # conversation scope: DM user, channel:thread, route_id, …
+    sender_id: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def session_key(self, agent_name: str) -> str:
+        """Stable per-conversation key → reused as the agentex task name (get-or-create)."""
+        basis = self.peer_id or self.route_id or "main"
+        digest = hashlib.sha1(
+            f"{agent_name}:{self.channel}:{basis}".encode()
+        ).hexdigest()[:16]
+        return f"ch-{self.channel}-{digest}"
+
+
+@dataclass
+class ChannelBinding:
+    """A route's binding to one agent.
+
+    `params` is an OPAQUE dict forwarded verbatim as the task/create params — the
+    agentex platform does not interpret it. Whatever a given agent expects there
+    (e.g. golden-agent's system_prompt / mcps / harness / model) is that agent's
+    concern, not the channel layer's. Later this can be sourced from a saved config.
+    """
+
+    secret: str
+    agent_name: str
+    params: dict[str, Any] = field(default_factory=dict)
+    # Headers the router forwards to the agent (auth/delegation). Empty for local/open.
+    forward_headers: dict[str, str] = field(default_factory=dict)
+
+
+def verify_shared_secret(presented: str | None, secret: str) -> bool:
+    """Timing-safe shared-secret check (OpenClaw `safeEqualSecret`)."""
+    if not presented or not secret:
+        return False
+    return hmac.compare_digest(presented, secret)
+
+
+def verify_hmac_sha256(secret: str, body: bytes, signature_header: str | None) -> bool:
+    """Verify an `sha256=<hex>` HMAC signature (GitHub/Gitea-style)."""
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+class Channel(ABC):
+    """One external surface, modeled on OpenClaw's channel plugin facets.
+
+    Ingress (required): `authenticate` + `to_inbound` (normalize an inbound event).
+    Outbound (optional): `deliver` + `chunk` — OpenClaw's `ChannelOutboundAdapter`
+    (`deliver` + `chunker`/`textChunkLimit`). Interactive channels that push replies
+    (Slack -> chat.postMessage) set `supports_outbound = True` and implement `deliver`.
+    A plain webhook leaves it unset — its reply is the HTTP response, so the caller
+    returns the reply rather than pushing it. `deliver_reply()` (below) is OpenClaw's
+    buffered dispatcher: it chunks the agent reply and calls `deliver` per block.
+    """
+
+    name: str = "unknown"
+    supports_outbound: bool = False
+    # Platform message size limit for chunking (OpenClaw textChunkLimit). None = no split.
+    text_chunk_limit: int | None = None
+
+    @abstractmethod
+    def authenticate(
+        self, binding: ChannelBinding, request: Request, raw_body: bytes
+    ) -> bool:
+        """Return True iff the request is authentic for this binding."""
+
+    @abstractmethod
+    def to_inbound(self, route_id: str, body: dict[str, Any]) -> InboundMessage:
+        """Normalize the parsed JSON payload into an InboundMessage."""
+
+    async def deliver(self, peer_id: str, text: str) -> None:
+        """Send one (already-chunked) reply block to conversation `peer_id`.
+
+        Default: unsupported. Push channels override this (and set supports_outbound).
+        """
+        raise NotImplementedError(f"channel {self.name!r} has no outbound deliver()")
+
+    def chunk(self, text: str) -> list[str]:
+        """Split a reply to `text_chunk_limit`, preferring paragraph boundaries
+        (OpenClaw's chunker, markdown-agnostic default)."""
+        limit = self.text_chunk_limit
+        if not limit or len(text) <= limit:
+            return [text]
+        out: list[str] = []
+        cur = ""
+        for para in text.split("\n\n"):
+            if cur and len(cur) + len(para) + 2 > limit:
+                out.append(cur)
+                cur = ""
+            cur = f"{cur}\n\n{para}" if cur else para
+        if cur:
+            out.append(cur)
+        return out or [text[:limit]]
+
+
+async def deliver_reply(channel: Channel, peer_id: str, text: str) -> None:
+    """Buffered reply dispatcher (OpenClaw dispatchReplyWithBufferedBlockDispatcher):
+    chunk the agent reply and deliver each block through the channel's outbound."""
+    for block in channel.chunk(text):
+        if block.strip():
+            await channel.deliver(peer_id, block)

--- a/agentex/src/domain/channels/router.py
+++ b/agentex/src/domain/channels/router.py
@@ -1,0 +1,171 @@
+"""ChannelRouter: turn a normalized InboundMessage into an agent turn, and (for
+channels that respond) retrieve the agent's reply.
+
+Channel-agnostic — the same path serves webhook, Slack, or any future channel.
+Works for both ACP types: sync agents take the turn via message/send (reply returned
+inline); async/agentic agents via event/send (reply lands on the task's message
+stream, retrieved by `await_reply`). Continuity is free: the InboundMessage's
+session_key is reused as the agentex task name (task/create is get-or-create on name).
+
+A responding channel pairs this with the outbound side (OpenClaw deliver/chunker):
+    result = await router.dispatch(inbound, binding, acp_type)
+    reply = result.reply or await router.await_reply(result.task_id, result.after_id)
+    await deliver_reply(channel, inbound.peer_id, reply)   # chunk + deliver per block
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from src.domain.channels.base import ChannelBinding, InboundMessage
+from src.domain.entities.agents import ACPType
+from src.domain.entities.agents_rpc import (
+    AgentRPCMethod,
+    CreateTaskRequestEntity,
+    SendEventRequestEntity,
+    SendMessageRequestEntity,
+)
+from src.domain.entities.task_messages import (
+    MessageAuthor,
+    TaskMessageContentType,
+    TextContentEntity,
+)
+from src.domain.services.task_message_service import TaskMessageService
+from src.domain.use_cases.agents_acp_use_case import AgentsACPUseCase
+from src.utils.logging import make_logger
+
+logger = make_logger(__name__)
+
+
+@dataclass
+class DispatchResult:
+    task_id: str
+    # Sync agents return their reply inline. Async agents reply later on the task
+    # stream — `reply` is None and `after_id` marks where to read new messages from.
+    reply: str | None = None
+    after_id: str | None = None
+
+
+class ChannelRouter:
+    def __init__(
+        self,
+        acp_use_case: AgentsACPUseCase,
+        task_message_service: TaskMessageService,
+    ):
+        self._acp = acp_use_case
+        self._messages = task_message_service
+
+    async def dispatch(
+        self, inbound: InboundMessage, binding: ChannelBinding, acp_type: ACPType
+    ) -> DispatchResult:
+        session_key = inbound.session_key(binding.agent_name)
+        headers = binding.forward_headers or None
+
+        task = await self._acp.handle_rpc_request(
+            method=AgentRPCMethod.TASK_CREATE,
+            params=CreateTaskRequestEntity(
+                name=session_key,
+                params=binding.params,
+                task_metadata={
+                    "channel": inbound.channel,
+                    "route_id": inbound.route_id,
+                    "peer_id": inbound.peer_id,
+                    "sender_id": inbound.sender_id,
+                },
+            ),
+            agent_name=binding.agent_name,
+            request_headers=headers,
+        )
+        task_id = task.id
+        logger.info(
+            "[channels] %s route=%s acp=%s -> task %s (session %s)",
+            inbound.channel,
+            inbound.route_id,
+            acp_type.value,
+            task_id,
+            session_key,
+        )
+
+        content = TextContentEntity(author=MessageAuthor.USER, content=inbound.text)
+
+        if acp_type == ACPType.SYNC:
+            # Sync: message/send carries the turn and returns the reply messages inline.
+            messages = await self._acp.handle_rpc_request(
+                method=AgentRPCMethod.MESSAGE_SEND,
+                params=SendMessageRequestEntity(
+                    task_id=task_id, content=content, stream=False
+                ),
+                agent_name=binding.agent_name,
+                request_headers=headers,
+            )
+            return DispatchResult(task_id=task_id, reply=_agent_text(messages))
+
+        # Async / agentic: event/send delivers the turn; the reply lands on the stream.
+        # Mark the newest message now so await_reply only reads the new reply.
+        after_id = await self._newest_message_id(task_id)
+        await self._acp.handle_rpc_request(
+            method=AgentRPCMethod.EVENT_SEND,
+            params=SendEventRequestEntity(task_id=task_id, content=content),
+            agent_name=binding.agent_name,
+            request_headers=headers,
+        )
+        return DispatchResult(task_id=task_id, reply=None, after_id=after_id)
+
+    async def _newest_message_id(self, task_id: str) -> str | None:
+        msgs = await self._messages.get_messages(
+            task_id=task_id, limit=1, page_number=1
+        )
+        return msgs[0].id if msgs else None
+
+    async def await_reply(
+        self,
+        task_id: str,
+        after_id: str | None = None,
+        timeout_s: float = 120.0,
+        interval_s: float = 2.0,
+        quiescence_s: float = 6.0,
+    ) -> str | None:
+        """Poll the task's messages for the agent's text reply after `after_id`, until
+        it settles (no change for `quiescence_s`) or `timeout_s`. Used by responding
+        channels to retrieve an async agent's reply before delivering it."""
+        waited = 0.0
+        last: str | None = None
+        stable_for = 0.0
+        while waited < timeout_s:
+            await asyncio.sleep(interval_s)
+            waited += interval_s
+            msgs = await self._messages.get_messages(
+                task_id=task_id,
+                limit=100,
+                page_number=1,
+                order_direction="asc",
+                after_id=after_id,
+            )
+            text = _agent_text(msgs)
+            if text and text == last:
+                stable_for += interval_s
+                if stable_for >= quiescence_s:
+                    return text
+            elif text:
+                last = text
+                stable_for = 0.0
+        return last
+
+
+def _is_agent_text(message: object) -> bool:
+    content = getattr(message, "content", None)
+    return (
+        content is not None
+        and getattr(content, "type", None) == TaskMessageContentType.TEXT
+        and getattr(content, "author", None) == MessageAuthor.AGENT
+        and bool((getattr(content, "content", "") or "").strip())
+    )
+
+
+def _agent_text(messages: object) -> str | None:
+    """Join the agent-authored text from a message list (sync result or polled stream)."""
+    if not isinstance(messages, list):
+        return None
+    parts = [m.content.content.strip() for m in messages if _is_agent_text(m)]
+    return "\n\n".join(parts) if parts else None

--- a/agentex/src/domain/channels/webhook.py
+++ b/agentex/src/domain/channels/webhook.py
@@ -1,0 +1,63 @@
+"""WebhookChannel: generic HTTP ingress (GitHub/Gitea/Zapier/anything that POSTs JSON).
+
+Modeled on OpenClaw `extensions/webhooks`: per-route shared secret, POST + JSON only,
+size cap, timing-safe auth. Accepts either:
+  - `Authorization: Bearer <secret>` / `x-openclaw-webhook-secret: <secret>`  (generic), or
+  - `X-Hub-Signature-256: sha256=<hmac>`                                       (GitHub/Gitea)
+
+The payload is normalized generically (text/message/goal/prompt, else the raw JSON).
+Source-specific shaping (e.g. PR rendering) belongs to the caller or the agent's
+system prompt — this stays a generic channel.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from starlette.requests import Request
+
+from src.domain.channels.base import (
+    Channel,
+    ChannelBinding,
+    InboundMessage,
+    verify_hmac_sha256,
+    verify_shared_secret,
+)
+
+MAX_BODY_BYTES = 256 * 1024
+
+
+class WebhookChannel(Channel):
+    name = "webhook"
+
+    def authenticate(
+        self, binding: ChannelBinding, request: Request, raw_body: bytes
+    ) -> bool:
+        gh_sig = request.headers.get("x-hub-signature-256")
+        if gh_sig is not None:
+            return verify_hmac_sha256(binding.secret, raw_body, gh_sig)
+        auth = request.headers.get("authorization", "")
+        presented = (
+            auth[len("Bearer ") :].strip() if auth.startswith("Bearer ") else None
+        )
+        presented = presented or request.headers.get("x-openclaw-webhook-secret")
+        return verify_shared_secret(presented, binding.secret)
+
+    def to_inbound(self, route_id: str, body: dict[str, Any]) -> InboundMessage:
+        return InboundMessage(
+            text=_render_text(body),
+            channel=self.name,
+            route_id=route_id,
+            peer_id=route_id,
+            sender_id="webhook",
+            raw=body,
+        )
+
+
+def _render_text(body: dict[str, Any]) -> str:
+    for key in ("text", "message", "goal", "prompt"):
+        value = body.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return json.dumps(body, indent=2)[:8000]


### PR DESCRIPTION
…ok ingress

Introduce a channel layer that normalizes external surfaces into agent turns, so platforms beyond the chat UI can drive agents. The agent-driving core is channel-agnostic; a new channel (e.g. Slack) implements one interface without touching the router.

- domain/channels/base.py: InboundMessage, Channel ABC (authenticate + to_inbound), ChannelBinding (route -> agent + inline params), timing-safe shared-secret and HMAC-SHA256 verification helpers.
- domain/channels/router.py: ChannelRouter.dispatch() — InboundMessage ->
  task/create (get-or-create on a per-conversation session key) + event/send via the in-process ACP use case.
- domain/channels/webhook.py: WebhookChannel — generic HTTP ingress with a per-route secret. Accepts Authorization: Bearer / x-openclaw-webhook-secret, or an X-Hub-Signature-256 HMAC. Generic JSON normalization (no source-specific shaping).
- api/routes/channels.py: POST /channels/webhook/{route_id}. Route bindings load from the CHANNELS_WEBHOOK_ROUTES env var for now (seam for a future config store).
- Whitelist /channels/webhook in the auth middleware so it bypasses the agent API-key check and verifies its own per-route secret instead; register the router.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a channel abstraction layer that normalises external HTTP surfaces (webhooks, and future platforms like Slack) into agent turns, keeping the agent-driving core channel-agnostic. A new channel implements two methods (`authenticate` + `to_inbound`) without touching the router or existing API paths.

- **`domain/channels/`** — `InboundMessage`, `Channel` ABC, `ChannelBinding`, timing-safe HMAC-SHA256 and shared-secret helpers, and `ChannelRouter` (task get-or-create + sync/async dispatch + quiescence-based reply polling).
- **`domain/channels/webhook.py`** — `WebhookChannel` accepting `Authorization: Bearer`, `x-openclaw-webhook-secret`, or `X-Hub-Signature-256`; generic JSON text normalization with an 8 KB fallback.
- **`api/routes/channels.py`** — `POST /channels/webhook/{route_id}` with size/auth/content-type guards and an optional `wait` param for synchronous callers; route bindings loaded from `CHANNELS_WEBHOOK_ROUTES` env var.
- **`middleware_utils.py`** — `/channels/webhook` whitelisted from agentex API-key auth so per-route secret verification takes over.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — auth helpers are timing-safe, the middleware whitelist correctly scopes only webhook sub-paths, and the sync/async dispatch paths are structurally sound.

No correctness defects were found in the changed code. The auth branching (HMAC-SHA256 preferred over bearer), the get-or-create session-key continuity, and the after_id cursor for reply isolation all work as intended. The two flagged items are quality improvements, not bugs that produce wrong behavior.

No files require special attention before merging, though router.py and routes/channels.py have two findings worth addressing in a follow-up.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/channels/base.py | Introduces Channel ABC, InboundMessage, ChannelBinding dataclasses, timing-safe secret and HMAC-SHA256 helpers, and the deliver_reply dispatcher. Clean, well-structured; auth helpers use hmac.compare_digest correctly. |
| agentex/src/domain/channels/router.py | ChannelRouter dispatches InboundMessage to async/sync agent turns; await_reply polls for quiescence. The 8 s minimum latency on wait=True is undocumented and likely to exceed typical webhook platform timeouts. |
| agentex/src/domain/channels/webhook.py | WebhookChannel implements Channel with HMAC-SHA256 and bearer/shared-secret auth; _render_text normalization falls back to truncated JSON. Auth branching correctly prioritises X-Hub-Signature-256 over bearer. |
| agentex/src/api/routes/channels.py | POST /channels/webhook/{route_id} handler with size/auth/content-type guards. _webhook_binding re-parses the CHANNELS_WEBHOOK_ROUTES env var JSON on every request rather than caching the result at startup. |
| agentex/src/api/middleware_utils.py | Adds /channels/webhook to WHITELISTED_ROUTES; the boundary-aware prefix match correctly covers all /channels/webhook/{route_id} sub-paths. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as Webhook Caller
    participant MW as Auth Middleware
    participant Route as POST /channels/webhook/{route_id}
    participant WC as WebhookChannel.authenticate()
    participant CR as ChannelRouter.dispatch()
    participant ACP as AgentsACPUseCase
    participant MS as TaskMessageService

    Caller->>MW: "POST /channels/webhook/{route_id}"
    MW->>MW: is_whitelisted_route() skip API-key check
    MW->>Route: forward request
    Route->>Route: _webhook_binding(route_id) ChannelBinding
    Route->>WC: authenticate(binding, request, raw_body)
    WC-->>Route: True / False (HMAC or bearer)
    Route->>CR: dispatch(inbound, binding, acp_type)
    CR->>ACP: TASK_CREATE (get-or-create, session_key)
    ACP-->>CR: task_id
    alt "acp_type == SYNC"
        CR->>ACP: MESSAGE_SEND(task_id, content)
        ACP-->>CR: reply messages inline
        CR-->>Route: "DispatchResult(reply=text)"
    else "acp_type == ASYNC"
        CR->>MS: "get_messages(limit=1) after_id"
        CR->>ACP: EVENT_SEND(task_id, content)
        CR-->>Route: "DispatchResult(reply=None, after_id)"
    end
    alt "wait=True and reply is None"
        loop every 2s until stable 6s or 120s timeout
            Route->>MS: get_messages(after_id, asc)
            MS-->>Route: agent messages
        end
    end
    Route-->>Caller: ok, task_id, reply?
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as Webhook Caller
    participant MW as Auth Middleware
    participant Route as POST /channels/webhook/{route_id}
    participant WC as WebhookChannel.authenticate()
    participant CR as ChannelRouter.dispatch()
    participant ACP as AgentsACPUseCase
    participant MS as TaskMessageService

    Caller->>MW: "POST /channels/webhook/{route_id}"
    MW->>MW: is_whitelisted_route() skip API-key check
    MW->>Route: forward request
    Route->>Route: _webhook_binding(route_id) ChannelBinding
    Route->>WC: authenticate(binding, request, raw_body)
    WC-->>Route: True / False (HMAC or bearer)
    Route->>CR: dispatch(inbound, binding, acp_type)
    CR->>ACP: TASK_CREATE (get-or-create, session_key)
    ACP-->>CR: task_id
    alt "acp_type == SYNC"
        CR->>ACP: MESSAGE_SEND(task_id, content)
        ACP-->>CR: reply messages inline
        CR-->>Route: "DispatchResult(reply=text)"
    else "acp_type == ASYNC"
        CR->>MS: "get_messages(limit=1) after_id"
        CR->>ACP: EVENT_SEND(task_id, content)
        CR-->>Route: "DispatchResult(reply=None, after_id)"
    end
    alt "wait=True and reply is None"
        loop every 2s until stable 6s or 120s timeout
            Route->>MS: get_messages(after_id, asc)
            MS-->>Route: agent messages
        end
    end
    Route-->>Caller: ok, task_id, reply?
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fsrc%2Fapi%2Froutes%2Fchannels.py%3A43-56%0A**Env-var%20re-parsed%20on%20every%20request**%0A%0A%60_webhook_binding%60%20calls%20%60os.environ.get%60%20and%20%60json.loads%60%20inside%20the%20hot%20path%20of%20every%20incoming%20webhook.%20The%20env%20var%20is%20read%20and%20the%20JSON%20is%20re-parsed%20on%20each%20request.%20Under%20any%20meaningful%20load%20this%20is%20unnecessary%20GC%2FCPU%20pressure%2C%20and%20a%20JSON%20parse%20error%20on%20a%20malformed%20env%20var%20silently%20returns%20%60None%60%20%E2%86%92%20404%20for%20every%20route%20rather%20than%20a%20startup-time%20configuration%20failure.%20Consider%20parsing%20the%20routes%20dict%20once%20at%20module%20level%20%28or%20on%20first%20call%20with%20a%20module-level%20cache%29%20so%20misconfiguration%20is%20caught%20early%20and%20the%20hot%20path%20is%20a%20dict%20lookup.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fsrc%2Fdomain%2Fchannels%2Frouter.py%3A121-153%0A**%60wait%3DTrue%60%20minimum%20latency%20of%208%20s%20is%20undocumented%20and%20likely%20to%20timeout%20webhook%20senders**%0A%0A%60await_reply%60%20sleeps%20%60interval_s%60%20%282%20s%29%20before%20its%20first%20poll%2C%20then%20requires%20%60quiescence_s%60%20%286%20s%29%20of%20text%20stability%20before%20returning%20%E2%80%94%20a%20guaranteed%20floor%20of%208%20seconds%2C%20not%20counting%20agent%20processing%20time.%20Most%20webhook%20platforms%20have%20hard%20timeouts%20well%20below%20this%3A%20GitHub's%20webhook%20delivery%20is%2010%20s%20and%20Zapier%20is%2030%20s.%20Any%20async%20agent%20doing%20real%20work%20will%20push%20the%20total%20past%20GitHub's%20limit.%20Neither%20the%20query-parameter%20description%20nor%20the%20OpenAPI%20spec%20mentions%20this%20latency%20floor%2C%20so%20a%20caller%20who%20enables%20%60wait%3Dtrue%60%20expecting%20a%20quick%20response%20will%20silently%20time%20out%20on%20the%20platform%20side%20while%20agentex%20happily%20keeps%20polling.%20The%20%60interval_s%60%20and%20%60quiescence_s%60%20defaults%20should%20be%20documented%20prominently%20on%20the%20%60wait%60%20parameter%2C%20or%20the%20minimum%20quiescence%20should%20be%20shortened%20for%20the%20webhook%20use%20case.%0A%0A&pr=327&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fsrc%2Fapi%2Froutes%2Fchannels.py%3A43-56%0A**Env-var%20re-parsed%20on%20every%20request**%0A%0A%60_webhook_binding%60%20calls%20%60os.environ.get%60%20and%20%60json.loads%60%20inside%20the%20hot%20path%20of%20every%20incoming%20webhook.%20The%20env%20var%20is%20read%20and%20the%20JSON%20is%20re-parsed%20on%20each%20request.%20Under%20any%20meaningful%20load%20this%20is%20unnecessary%20GC%2FCPU%20pressure%2C%20and%20a%20JSON%20parse%20error%20on%20a%20malformed%20env%20var%20silently%20returns%20%60None%60%20%E2%86%92%20404%20for%20every%20route%20rather%20than%20a%20startup-time%20configuration%20failure.%20Consider%20parsing%20the%20routes%20dict%20once%20at%20module%20level%20%28or%20on%20first%20call%20with%20a%20module-level%20cache%29%20so%20misconfiguration%20is%20caught%20early%20and%20the%20hot%20path%20is%20a%20dict%20lookup.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fsrc%2Fdomain%2Fchannels%2Frouter.py%3A121-153%0A**%60wait%3DTrue%60%20minimum%20latency%20of%208%20s%20is%20undocumented%20and%20likely%20to%20timeout%20webhook%20senders**%0A%0A%60await_reply%60%20sleeps%20%60interval_s%60%20%282%20s%29%20before%20its%20first%20poll%2C%20then%20requires%20%60quiescence_s%60%20%286%20s%29%20of%20text%20stability%20before%20returning%20%E2%80%94%20a%20guaranteed%20floor%20of%208%20seconds%2C%20not%20counting%20agent%20processing%20time.%20Most%20webhook%20platforms%20have%20hard%20timeouts%20well%20below%20this%3A%20GitHub's%20webhook%20delivery%20is%2010%20s%20and%20Zapier%20is%2030%20s.%20Any%20async%20agent%20doing%20real%20work%20will%20push%20the%20total%20past%20GitHub's%20limit.%20Neither%20the%20query-parameter%20description%20nor%20the%20OpenAPI%20spec%20mentions%20this%20latency%20floor%2C%20so%20a%20caller%20who%20enables%20%60wait%3Dtrue%60%20expecting%20a%20quick%20response%20will%20silently%20time%20out%20on%20the%20platform%20side%20while%20agentex%20happily%20keeps%20polling.%20The%20%60interval_s%60%20and%20%60quiescence_s%60%20defaults%20should%20be%20documented%20prominently%20on%20the%20%60wait%60%20parameter%2C%20or%20the%20minimum%20quiescence%20should%20be%20shortened%20for%20the%20webhook%20use%20case.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=327&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22dm%2Fagentex-channels-webhook%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22dm%2Fagentex-channels-webhook%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fsrc%2Fapi%2Froutes%2Fchannels.py%3A43-56%0A**Env-var%20re-parsed%20on%20every%20request**%0A%0A%60_webhook_binding%60%20calls%20%60os.environ.get%60%20and%20%60json.loads%60%20inside%20the%20hot%20path%20of%20every%20incoming%20webhook.%20The%20env%20var%20is%20read%20and%20the%20JSON%20is%20re-parsed%20on%20each%20request.%20Under%20any%20meaningful%20load%20this%20is%20unnecessary%20GC%2FCPU%20pressure%2C%20and%20a%20JSON%20parse%20error%20on%20a%20malformed%20env%20var%20silently%20returns%20%60None%60%20%E2%86%92%20404%20for%20every%20route%20rather%20than%20a%20startup-time%20configuration%20failure.%20Consider%20parsing%20the%20routes%20dict%20once%20at%20module%20level%20%28or%20on%20first%20call%20with%20a%20module-level%20cache%29%20so%20misconfiguration%20is%20caught%20early%20and%20the%20hot%20path%20is%20a%20dict%20lookup.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fsrc%2Fdomain%2Fchannels%2Frouter.py%3A121-153%0A**%60wait%3DTrue%60%20minimum%20latency%20of%208%20s%20is%20undocumented%20and%20likely%20to%20timeout%20webhook%20senders**%0A%0A%60await_reply%60%20sleeps%20%60interval_s%60%20%282%20s%29%20before%20its%20first%20poll%2C%20then%20requires%20%60quiescence_s%60%20%286%20s%29%20of%20text%20stability%20before%20returning%20%E2%80%94%20a%20guaranteed%20floor%20of%208%20seconds%2C%20not%20counting%20agent%20processing%20time.%20Most%20webhook%20platforms%20have%20hard%20timeouts%20well%20below%20this%3A%20GitHub's%20webhook%20delivery%20is%2010%20s%20and%20Zapier%20is%2030%20s.%20Any%20async%20agent%20doing%20real%20work%20will%20push%20the%20total%20past%20GitHub's%20limit.%20Neither%20the%20query-parameter%20description%20nor%20the%20OpenAPI%20spec%20mentions%20this%20latency%20floor%2C%20so%20a%20caller%20who%20enables%20%60wait%3Dtrue%60%20expecting%20a%20quick%20response%20will%20silently%20time%20out%20on%20the%20platform%20side%20while%20agentex%20happily%20keeps%20polling.%20The%20%60interval_s%60%20and%20%60quiescence_s%60%20defaults%20should%20be%20documented%20prominently%20on%20the%20%60wait%60%20parameter%2C%20or%20the%20minimum%20quiescence%20should%20be%20shortened%20for%20the%20webhook%20use%20case.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=327&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
agentex/src/api/routes/channels.py:43-56
**Env-var re-parsed on every request**

`_webhook_binding` calls `os.environ.get` and `json.loads` inside the hot path of every incoming webhook. The env var is read and the JSON is re-parsed on each request. Under any meaningful load this is unnecessary GC/CPU pressure, and a JSON parse error on a malformed env var silently returns `None` → 404 for every route rather than a startup-time configuration failure. Consider parsing the routes dict once at module level (or on first call with a module-level cache) so misconfiguration is caught early and the hot path is a dict lookup.

### Issue 2 of 2
agentex/src/domain/channels/router.py:121-153
**`wait=True` minimum latency of 8 s is undocumented and likely to timeout webhook senders**

`await_reply` sleeps `interval_s` (2 s) before its first poll, then requires `quiescence_s` (6 s) of text stability before returning — a guaranteed floor of 8 seconds, not counting agent processing time. Most webhook platforms have hard timeouts well below this: GitHub's webhook delivery is 10 s and Zapier is 30 s. Any async agent doing real work will push the total past GitHub's limit. Neither the query-parameter description nor the OpenAPI spec mentions this latency floor, so a caller who enables `wait=true` expecting a quick response will silently time out on the platform side while agentex happily keeps polling. The `interval_s` and `quiescence_s` defaults should be documented prominently on the `wait` parameter, or the minimum quiescence should be shortened for the webhook use case.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(channels): add extensible channel a..."](https://github.com/scaleapi/scale-agentex/commit/239fb1ad33055f7ac2f40869719abbacf0fb908d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38712615)</sub>

<!-- /greptile_comment -->