### PR TITLE
feat(agent_api_keys): one-call webhook-trigger setup endpoint

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -2722,6 +2722,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /agent_api_keys/webhook-trigger:
+    post:
+      tags:
+      - Agent APIKeys
+      summary: Create Webhook Trigger
+      description: 'Wire a webhook trigger in one call.
+
+
+        Registers the source''s signature-verification key (github/slack) for the
+        agent and
+
+        returns the ready-to-paste forward webhook URL plus the signing secret (shown
+        once).
+
+        The webhook then flows through the existing /agents/forward ingress, which
+        verifies
+
+        the signature against this key. Bundles the existing key-create + URL composition
+        so
+
+        a UI (or a curl) can set up a trigger without two steps.'
+      operationId: create_webhook_trigger_agent_api_keys_webhook_trigger_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateWebhookTriggerRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateWebhookTriggerResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /agent_api_keys/name/{name}:
     get:
       tags:
@@ -4549,6 +4590,91 @@ components:
             to the agent inside the ACP payload for backward compatibility.
       type: object
       title: CreateTaskRequest
+    CreateWebhookTriggerRequest:
+      properties:
+        agent_name:
+          type: string
+          title: Agent Name
+          description: The agent the webhook drives.
+        source:
+          $ref: '#/components/schemas/AgentAPIKeyType'
+          description: Webhook source whose signature is verified (github or slack).
+          default: github
+        name:
+          type: string
+          title: Name
+          description: 'Signature-lookup key: the repo full_name (github) or api_app_id
+            (slack) that the forward ingress matches the incoming webhook against.'
+        forward_path:
+          type: string
+          title: Forward Path
+          description: Subpath the agent's own route handles, e.g. 'github-pr/<config-id>'.
+            Appended to /agents/forward/name/{agent_name}/ to form the webhook URL.
+        secret:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Secret
+          description: Optional signing secret; if unset, one is generated and returned.
+        base_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Base Url
+          description: Optional public agentex base URL for the returned webhook_url;
+            defaults to the AGENTEX_PUBLIC_URL env var.
+      type: object
+      required:
+      - agent_name
+      - name
+      - forward_path
+      title: CreateWebhookTriggerRequest
+      description: 'One-call setup for a webhook trigger: register the source''s signature
+        key and
+
+        get back the ready-to-paste forward webhook URL.'
+    CreateWebhookTriggerResponse:
+      properties:
+        key_id:
+          type: string
+          title: Key Id
+          description: The created agent API key id.
+        agent_name:
+          type: string
+          title: Agent Name
+          description: The agent the webhook drives.
+        source:
+          $ref: '#/components/schemas/AgentAPIKeyType'
+          description: Webhook source (github or slack).
+        name:
+          type: string
+          title: Name
+          description: Signature-lookup key (repo full_name / api_app_id).
+        secret:
+          type: string
+          title: Secret
+          description: The signing secret — shown once; paste into the source's webhook
+            config.
+        webhook_path:
+          type: string
+          title: Webhook Path
+          description: The forward path to POST webhooks to.
+        webhook_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Webhook Url
+          description: Full webhook URL to paste into the source (None if no base
+            URL configured).
+      type: object
+      required:
+      - key_id
+      - agent_name
+      - source
+      - name
+      - secret
+      - webhook_path
+      title: CreateWebhookTriggerResponse
     DataContent:
       properties:
         type:

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -4615,7 +4615,9 @@ components:
           - type: string
           - type: 'null'
           title: Secret
-          description: Optional signing secret; if unset, one is generated and returned.
+          description: Signing secret. For GitHub, omit to generate one, or provide
+            an existing webhook secret. For Slack, this is required and must be the
+            Slack app's Signing Secret.
         base_url:
           anyOf:
           - type: string

--- a/agentex/src/api/routes/agent_api_keys.py
+++ b/agentex/src/api/routes/agent_api_keys.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Query
 
@@ -36,6 +37,10 @@ router = APIRouter(
     prefix="/agent_api_keys",
     tags=["Agent APIKeys"],
 )
+
+
+def _has_control_chars(value: str) -> bool:
+    return any(ord(char) < 32 or ord(char) == 127 for char in value)
 
 
 @router.post(
@@ -155,7 +160,7 @@ async def create_webhook_trigger(
             ),
         )
 
-    secret = request.secret or secrets.token_hex(32)
+    secret = request.secret if request.secret is not None else secrets.token_hex(32)
     agent_api_key_entity = await agent_api_key_use_case.create(
         agent_id=agent.id,
         api_key=str(secret),
@@ -164,7 +169,14 @@ async def create_webhook_trigger(
     )
 
     forward_path = request.forward_path.lstrip("/")
-    webhook_path = f"/agents/forward/name/{request.agent_name}/{forward_path}"
+    if _has_control_chars(forward_path):
+        raise HTTPException(
+            status_code=400,
+            detail="forward_path must not contain control characters.",
+        )
+    encoded_agent_name = quote(request.agent_name, safe="")
+    encoded_forward_path = quote(forward_path, safe="/")
+    webhook_path = f"/agents/forward/name/{encoded_agent_name}/{encoded_forward_path}"
     base_url = (request.base_url or os.environ.get("AGENTEX_PUBLIC_URL", "")).rstrip(
         "/"
     )

--- a/agentex/src/api/routes/agent_api_keys.py
+++ b/agentex/src/api/routes/agent_api_keys.py
@@ -141,6 +141,20 @@ async def create_webhook_trigger(
             detail=f"A {request.source} webhook key named '{request.name}' already exists for this agent.",
         )
 
+    # GitHub lets you supply (and we can generate) a per-webhook secret to paste into the
+    # repo's Secret field. Slack is different: it signs every request with the app's own
+    # Signing Secret, so the caller must supply that exact value — a generated one would
+    # never match, and validate_slack_delivery_webhook would reject every real delivery.
+    # (See PR #329 discussion.)
+    if request.source == AgentAPIKeyType.SLACK and not request.secret:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Slack triggers must supply 'secret' set to the Slack app's Signing Secret "
+                "(from your app credentials); it can't be generated."
+            ),
+        )
+
     secret = request.secret or secrets.token_hex(32)
     agent_api_key_entity = await agent_api_key_use_case.create(
         agent_id=agent.id,

--- a/agentex/src/api/routes/agent_api_keys.py
+++ b/agentex/src/api/routes/agent_api_keys.py
@@ -1,3 +1,4 @@
+import os
 import secrets
 
 from fastapi import APIRouter, HTTPException, Query
@@ -7,6 +8,8 @@ from src.api.schemas.agent_api_keys import (
     AgentAPIKey,
     CreateAPIKeyRequest,
     CreateAPIKeyResponse,
+    CreateWebhookTriggerRequest,
+    CreateWebhookTriggerResponse,
 )
 from src.api.schemas.authorization_types import (
     AgentexResourceType,
@@ -90,6 +93,77 @@ async def create_api_key(
         name=agent_api_key_entity.name,
         api_key_type=agent_api_key_entity.api_key_type,
         api_key=str(new_api_key),  # Return the inserted API key
+    )
+
+
+@router.post(
+    "/webhook-trigger",
+    response_model=CreateWebhookTriggerResponse,
+)
+async def create_webhook_trigger(
+    request: CreateWebhookTriggerRequest,
+    agent_api_key_use_case: DAgentAPIKeysUseCase,
+    agent_use_case: DAgentsUseCase,
+    authorization_service: DAuthorizationService,
+) -> CreateWebhookTriggerResponse:
+    """Wire a webhook trigger in one call.
+
+    Registers the source's signature-verification key (github/slack) for the agent and
+    returns the ready-to-paste forward webhook URL plus the signing secret (shown once).
+    The webhook then flows through the existing /agents/forward ingress, which verifies
+    the signature against this key. Bundles the existing key-create + URL composition so
+    a UI (or a curl) can set up a trigger without two steps.
+    """
+    if request.source not in (AgentAPIKeyType.GITHUB, AgentAPIKeyType.SLACK):
+        raise HTTPException(
+            status_code=400,
+            detail="source must be 'github' or 'slack' for a webhook trigger.",
+        )
+    agent = await agent_use_case.get(name=request.agent_name)
+
+    # No api_key resource exists yet, so gate on the parent agent (update).
+    await _check_agent_or_collapse_to_404(
+        authorization_service,
+        agent.id,
+        AuthorizedOperationType.update,
+    )
+
+    existing_api_key = await agent_api_key_use_case.get_by_agent_id_and_name(
+        agent_id=agent.id,
+        name=request.name,
+        api_key_type=request.source,
+    )
+    if existing_api_key:
+        # A duplicate is an expected client condition (409), not a server error, and the
+        # message avoids leaking the internal agent UUID the caller never supplied.
+        raise HTTPException(
+            status_code=409,
+            detail=f"A {request.source} webhook key named '{request.name}' already exists for this agent.",
+        )
+
+    secret = request.secret or secrets.token_hex(32)
+    agent_api_key_entity = await agent_api_key_use_case.create(
+        agent_id=agent.id,
+        api_key=str(secret),
+        name=request.name,
+        api_key_type=request.source,
+    )
+
+    forward_path = request.forward_path.lstrip("/")
+    webhook_path = f"/agents/forward/name/{request.agent_name}/{forward_path}"
+    base_url = (request.base_url or os.environ.get("AGENTEX_PUBLIC_URL", "")).rstrip(
+        "/"
+    )
+    webhook_url = f"{base_url}{webhook_path}" if base_url else None
+
+    return CreateWebhookTriggerResponse(
+        key_id=agent_api_key_entity.id,
+        agent_name=request.agent_name,
+        source=agent_api_key_entity.api_key_type,
+        name=request.name,
+        secret=str(secret),
+        webhook_path=webhook_path,
+        webhook_url=webhook_url,
     )
 
 

--- a/agentex/src/api/routes/agent_api_keys.py
+++ b/agentex/src/api/routes/agent_api_keys.py
@@ -160,6 +160,13 @@ async def create_webhook_trigger(
             ),
         )
 
+    forward_path = request.forward_path.lstrip("/")
+    if _has_control_chars(forward_path):
+        raise HTTPException(
+            status_code=400,
+            detail="forward_path must not contain control characters.",
+        )
+
     secret = request.secret if request.secret is not None else secrets.token_hex(32)
     agent_api_key_entity = await agent_api_key_use_case.create(
         agent_id=agent.id,
@@ -168,12 +175,6 @@ async def create_webhook_trigger(
         api_key_type=request.source,
     )
 
-    forward_path = request.forward_path.lstrip("/")
-    if _has_control_chars(forward_path):
-        raise HTTPException(
-            status_code=400,
-            detail="forward_path must not contain control characters.",
-        )
     encoded_agent_name = quote(request.agent_name, safe="")
     encoded_forward_path = quote(forward_path, safe="/")
     webhook_path = f"/agents/forward/name/{encoded_agent_name}/{encoded_forward_path}"

--- a/agentex/src/api/schemas/agent_api_keys.py
+++ b/agentex/src/api/schemas/agent_api_keys.py
@@ -76,7 +76,11 @@ class CreateWebhookTriggerRequest(BaseModel):
     )
     secret: str | None = Field(
         None,
-        description="Optional signing secret; if unset, one is generated and returned.",
+        description=(
+            "Signing secret. For GitHub, omit to generate one, or provide an existing "
+            "webhook secret. For Slack, this is required and must be the Slack app's "
+            "Signing Secret."
+        ),
     )
     base_url: str | None = Field(
         None,

--- a/agentex/src/api/schemas/agent_api_keys.py
+++ b/agentex/src/api/schemas/agent_api_keys.py
@@ -53,3 +53,53 @@ class CreateAPIKeyResponse(BaseModel):
         ...,
         description="The value of the newly created API key.",
     )
+
+
+class CreateWebhookTriggerRequest(BaseModel):
+    """One-call setup for a webhook trigger: register the source's signature key and
+    get back the ready-to-paste forward webhook URL."""
+
+    agent_name: str = Field(..., description="The agent the webhook drives.")
+    source: AgentAPIKeyType = Field(
+        AgentAPIKeyType.GITHUB,
+        description="Webhook source whose signature is verified (github or slack).",
+    )
+    name: str = Field(
+        ...,
+        description="Signature-lookup key: the repo full_name (github) or api_app_id "
+        "(slack) that the forward ingress matches the incoming webhook against.",
+    )
+    forward_path: str = Field(
+        ...,
+        description="Subpath the agent's own route handles, e.g. 'github-pr/<config-id>'. "
+        "Appended to /agents/forward/name/{agent_name}/ to form the webhook URL.",
+    )
+    secret: str | None = Field(
+        None,
+        description="Optional signing secret; if unset, one is generated and returned.",
+    )
+    base_url: str | None = Field(
+        None,
+        description="Optional public agentex base URL for the returned webhook_url; "
+        "defaults to the AGENTEX_PUBLIC_URL env var.",
+    )
+
+
+class CreateWebhookTriggerResponse(BaseModel):
+    key_id: str = Field(..., description="The created agent API key id.")
+    agent_name: str = Field(..., description="The agent the webhook drives.")
+    source: AgentAPIKeyType = Field(
+        ..., description="Webhook source (github or slack)."
+    )
+    name: str = Field(
+        ..., description="Signature-lookup key (repo full_name / api_app_id)."
+    )
+    secret: str = Field(
+        ...,
+        description="The signing secret — shown once; paste into the source's webhook config.",
+    )
+    webhook_path: str = Field(..., description="The forward path to POST webhooks to.")
+    webhook_url: str | None = Field(
+        None,
+        description="Full webhook URL to paste into the source (None if no base URL configured).",
+    )

--- a/agentex/tests/unit/api/test_webhook_trigger.py
+++ b/agentex/tests/unit/api/test_webhook_trigger.py
@@ -104,15 +104,30 @@ class TestCreateWebhookTrigger:
         assert resp.webhook_url == f"https://sgp.example.com{resp.webhook_path}"
 
     async def test_forward_path_control_chars_rejected(self, monkeypatch):
+        monkeypatch.setattr(mod, "_check_agent_or_collapse_to_404", AsyncMock())
+
         req = CreateWebhookTriggerRequest(
             agent_name="a",
             source=AgentAPIKeyType.GITHUB,
             name="o/r",
             forward_path="github-pr/cfg-9\nnext",
         )
+        agent_use_case = MagicMock()
+        agent_use_case.get = AsyncMock(return_value=MagicMock(id="agent-1"))
+
+        akuc = MagicMock()
+        akuc.get_by_agent_id_and_name = AsyncMock(return_value=None)
+        akuc.create = AsyncMock()
+
         with pytest.raises(HTTPException) as exc:
-            await self._call(monkeypatch, req)
+            await create_webhook_trigger(
+                request=req,
+                agent_api_key_use_case=akuc,
+                agent_use_case=agent_use_case,
+                authorization_service=MagicMock(),
+            )
         assert exc.value.status_code == 400
+        akuc.create.assert_not_awaited()
 
     async def test_conflict_when_key_exists(self, monkeypatch):
         req = CreateWebhookTriggerRequest(

--- a/agentex/tests/unit/api/test_webhook_trigger.py
+++ b/agentex/tests/unit/api/test_webhook_trigger.py
@@ -96,3 +96,25 @@ class TestCreateWebhookTrigger:
                 authorization_service=MagicMock(),
             )
         assert exc.value.status_code == 400
+
+    async def test_slack_without_secret_rejected(self, monkeypatch):
+        # Slack signs with the app's existing Signing Secret — we can't generate one,
+        # so omitting it must 400 rather than store a random value that never matches.
+        req = CreateWebhookTriggerRequest(
+            agent_name="a", source=AgentAPIKeyType.SLACK, name="my-app", forward_path="slack"
+        )
+        with pytest.raises(HTTPException) as exc:
+            await self._call(monkeypatch, req)
+        assert exc.value.status_code == 400
+
+    async def test_slack_with_provided_secret_ok(self, monkeypatch):
+        req = CreateWebhookTriggerRequest(
+            agent_name="a",
+            source=AgentAPIKeyType.SLACK,
+            name="my-app",
+            forward_path="slack",
+            secret="slack-signing-secret",
+        )
+        resp, akuc = await self._call(monkeypatch, req)
+        assert resp.secret == "slack-signing-secret"
+        assert akuc.create.await_args.kwargs["api_key"] == "slack-signing-secret"

--- a/agentex/tests/unit/api/test_webhook_trigger.py
+++ b/agentex/tests/unit/api/test_webhook_trigger.py
@@ -1,0 +1,98 @@
+"""Unit tests for the POST /agent_api_keys/webhook-trigger convenience endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import src.api.routes.agent_api_keys as mod
+from fastapi import HTTPException
+from src.api.routes.agent_api_keys import create_webhook_trigger
+from src.api.schemas.agent_api_keys import CreateWebhookTriggerRequest
+from src.domain.entities.agent_api_keys import AgentAPIKeyType
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestCreateWebhookTrigger:
+    async def _call(self, monkeypatch, request, *, existing=None, base_env=None):
+        # The agent-authorization helper does real authz work; stub it to a no-op.
+        monkeypatch.setattr(mod, "_check_agent_or_collapse_to_404", AsyncMock())
+        if base_env is not None:
+            monkeypatch.setenv("AGENTEX_PUBLIC_URL", base_env)
+        else:
+            monkeypatch.delenv("AGENTEX_PUBLIC_URL", raising=False)
+
+        agent_use_case = MagicMock()
+        agent_use_case.get = AsyncMock(return_value=MagicMock(id="agent-1"))
+
+        akuc = MagicMock()
+        akuc.get_by_agent_id_and_name = AsyncMock(return_value=existing)
+        akuc.create = AsyncMock(
+            return_value=MagicMock(id="key-1", api_key_type=request.source)
+        )
+
+        resp = await create_webhook_trigger(
+            request=request,
+            agent_api_key_use_case=akuc,
+            agent_use_case=agent_use_case,
+            authorization_service=MagicMock(),
+        )
+        return resp, akuc
+
+    async def test_creates_key_and_composes_url(self, monkeypatch):
+        req = CreateWebhookTriggerRequest(
+            agent_name="golden-agent",
+            source=AgentAPIKeyType.GITHUB,
+            name="acme/widgets",
+            forward_path="github-pr/cfg-9",
+        )
+        resp, akuc = await self._call(
+            monkeypatch, req, base_env="https://sgp.example.com"
+        )
+
+        assert len(resp.secret) >= 32  # auto-generated signing secret
+        assert (
+            resp.webhook_url
+            == "https://sgp.example.com/agents/forward/name/golden-agent/github-pr/cfg-9"
+        )
+        assert resp.webhook_path == "/agents/forward/name/golden-agent/github-pr/cfg-9"
+        assert resp.source == AgentAPIKeyType.GITHUB
+        # key registered under the signature-lookup name + type
+        assert akuc.create.await_args.kwargs["name"] == "acme/widgets"
+        assert akuc.create.await_args.kwargs["api_key_type"] == AgentAPIKeyType.GITHUB
+        assert akuc.create.await_args.kwargs["api_key"] == resp.secret
+
+    async def test_uses_provided_secret_and_no_url_without_base(self, monkeypatch):
+        req = CreateWebhookTriggerRequest(
+            agent_name="a",
+            source=AgentAPIKeyType.GITHUB,
+            name="o/r",
+            forward_path="gh",
+            secret="mysecret",
+        )
+        resp, _ = await self._call(monkeypatch, req)
+        assert resp.secret == "mysecret"
+        assert resp.webhook_url is None  # no AGENTEX_PUBLIC_URL configured
+        assert resp.webhook_path == "/agents/forward/name/a/gh"
+
+    async def test_conflict_when_key_exists(self, monkeypatch):
+        req = CreateWebhookTriggerRequest(
+            agent_name="a", source=AgentAPIKeyType.GITHUB, name="o/r", forward_path="gh"
+        )
+        with pytest.raises(HTTPException) as exc:
+            await self._call(monkeypatch, req, existing=MagicMock())
+        assert exc.value.status_code == 409
+
+    async def test_rejects_non_webhook_source(self):
+        req = CreateWebhookTriggerRequest(
+            agent_name="a", source=AgentAPIKeyType.EXTERNAL, name="x", forward_path="gh"
+        )
+        with pytest.raises(HTTPException) as exc:
+            await create_webhook_trigger(
+                request=req,
+                agent_api_key_use_case=MagicMock(),
+                agent_use_case=MagicMock(),
+                authorization_service=MagicMock(),
+            )
+        assert exc.value.status_code == 400

--- a/agentex/tests/unit/api/test_webhook_trigger.py
+++ b/agentex/tests/unit/api/test_webhook_trigger.py
@@ -76,6 +76,44 @@ class TestCreateWebhookTrigger:
         assert resp.webhook_url is None  # no AGENTEX_PUBLIC_URL configured
         assert resp.webhook_path == "/agents/forward/name/a/gh"
 
+    async def test_github_empty_secret_is_preserved(self, monkeypatch):
+        req = CreateWebhookTriggerRequest(
+            agent_name="a",
+            source=AgentAPIKeyType.GITHUB,
+            name="o/r",
+            forward_path="gh",
+            secret="",
+        )
+        resp, akuc = await self._call(monkeypatch, req)
+        assert resp.secret == ""
+        assert akuc.create.await_args.kwargs["api_key"] == ""
+
+    async def test_forward_path_reserved_chars_are_url_encoded(self, monkeypatch):
+        req = CreateWebhookTriggerRequest(
+            agent_name="golden agent",
+            source=AgentAPIKeyType.GITHUB,
+            name="o/r",
+            forward_path="github-pr/cfg-9?mode=review#frag ment",
+        )
+        resp, _ = await self._call(monkeypatch, req, base_env="https://sgp.example.com/")
+
+        assert (
+            resp.webhook_path
+            == "/agents/forward/name/golden%20agent/github-pr/cfg-9%3Fmode%3Dreview%23frag%20ment"
+        )
+        assert resp.webhook_url == f"https://sgp.example.com{resp.webhook_path}"
+
+    async def test_forward_path_control_chars_rejected(self, monkeypatch):
+        req = CreateWebhookTriggerRequest(
+            agent_name="a",
+            source=AgentAPIKeyType.GITHUB,
+            name="o/r",
+            forward_path="github-pr/cfg-9\nnext",
+        )
+        with pytest.raises(HTTPException) as exc:
+            await self._call(monkeypatch, req)
+        assert exc.value.status_code == 400
+
     async def test_conflict_when_key_exists(self, monkeypatch):
         req = CreateWebhookTriggerRequest(
             agent_name="a", source=AgentAPIKeyType.GITHUB, name="o/r", forward_path="gh"
@@ -118,3 +156,11 @@ class TestCreateWebhookTrigger:
         resp, akuc = await self._call(monkeypatch, req)
         assert resp.secret == "slack-signing-secret"
         assert akuc.create.await_args.kwargs["api_key"] == "slack-signing-secret"
+
+    async def test_secret_schema_documents_slack_requirement(self):
+        description = CreateWebhookTriggerRequest.model_fields["secret"].description
+
+        assert description is not None
+        assert "For GitHub" in description
+        assert "For Slack" in description
+        assert "required" in description


### PR DESCRIPTION
## What
Adds `POST /agent_api_keys/webhook-trigger` — wires a webhook trigger in **one call**:
- registers a `github`/`slack` signature-verification key for the agent (auto-generates the signing secret if not provided),
- returns the ready-to-paste **forward webhook URL** + the **secret** (shown once).

```
POST /agent_api_keys/webhook-trigger
{ "agent_name": "golden-agent", "source": "github",
  "name": "<owner/repo>", "forward_path": "github-pr/<config-id>" }
→ { key_id, secret, webhook_path, webhook_url }
```

## Why
The pieces to trigger an agent from a webhook already exist (the `/agents/forward` ingress verifies the signature against an agent key, and `POST /agent_api_keys` registers keys). This bundles key-create + webhook-URL composition so a UI (or a curl) can set up a trigger in a single step instead of two — the backend for the self-serve "Add trigger" button. The webhook then flows through the existing forward ingress unchanged.

**Before** — wiring a trigger was two manual steps, and the caller had to know the agent's internal id, invent a secret, and hand-compose the forward URL:

```python
# 1. register the signing key (need the agent's internal id + your own secret)
POST /agent_api_keys
{ "agent_id": "<look-up-first>", "api_key": "<generate-yourself>",
  "name": "owner/repo", "api_key_type": "github" }

# 2. hand-build the forward URL from the convention you have to know
webhook_url = f"{public_url}/agents/forward/name/{agent_name}/github-pr/{config_id}"
```

**After** — one call, by agent **name**, returns the URL + secret ready to paste:

```python
POST /agent_api_keys/webhook-trigger
{ "agent_name": "golden-agent", "source": "github",
  "name": "owner/repo", "forward_path": "github-pr/<config-id>" }

→ { "key_id": "...", "secret": "ab3f…",            # generated for you, shown once
    "webhook_path": "/agents/forward/name/golden-agent/github-pr/<config-id>",
    "webhook_url":  "https://<host>/agents/forward/name/golden-agent/github-pr/<config-id>" }
```

No new ingress, no migration — built on the existing `agent_api_keys` + forward mechanism.

## On the signing secret
This matches how GitHub webhooks actually work. A GitHub webhook's **Secret** is a value *you* supply (GitHub doesn't generate one) — you type a high-entropy string into the webhook's Secret field, and GitHub uses it to HMAC each payload into `X-Hub-Signature-256: sha256=…`, which the receiver re-computes and compares. It's a shared secret that must exist on both sides (GitHub's config + the verifying server), and it's optional-but-recommended (no secret → no signature header at all). Refs: GitHub docs [validating-webhook-deliveries](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries), [creating-webhooks](https://docs.github.com/en/webhooks/using-webhooks/creating-webhooks).

Given that, the endpoint's `secret` handling is deliberate:
- **omit `secret`** (default) → the endpoint generates a strong one (`secrets.token_hex(32)`), stores it on the agent's verification key, and returns it once to paste into GitHub's Secret field — so the caller never has to invent entropy.
- **supply `secret`** → for when the GitHub webhook already has a secret set and the agent side just needs to match it.

## Testing
- 4 unit tests (URL composition, provided vs generated secret, 409 on duplicate, 400 on non-webhook source). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `POST /agent_api_keys/webhook-trigger`, a single-call convenience endpoint that registers a GitHub or Slack signature-verification key for an agent and returns the ready-to-paste forward webhook URL and signing secret. It builds on the existing `agent_api_keys` store and `/agents/forward` ingress without any new migration or routing.

- The handler correctly validates source type, enforces Slack callers supply their own Signing Secret (vs. auto-generating for GitHub), URL-encodes agent name and forward path via `urllib.parse.quote`, and checks for control characters in `forward_path` before the DB write — all issues from earlier review rounds have been addressed.
- Eight unit tests cover URL composition, provided vs. generated secret, empty-string secret preservation, URL-encoding of reserved characters, control-char rejection, duplicate-key 409, invalid-source 400, and Slack-without-secret 400.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all validation (source check, Slack secret requirement, control-char rejection) runs before the DB write, URL components are correctly percent-encoded, and the 409 response no longer leaks internal identifiers.

All issues raised in earlier review rounds have been addressed: input validation precedes the key creation call, the is not None guard preserves empty-string secrets without silent coercion, Slack requires the caller to supply the Signing Secret, and the forward path is properly encoded. The unit tests exercise all meaningful branches including the fixed edge cases.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/api/routes/agent_api_keys.py | New create_webhook_trigger handler with correct validation ordering (all input checks precede the DB write), explicit None-check for secret, URL-encoding for agent name and forward path, and a clean 409 message that avoids leaking internal UUIDs. |
| agentex/src/api/schemas/agent_api_keys.py | Adds CreateWebhookTriggerRequest and CreateWebhookTriggerResponse Pydantic models; secret field description now accurately documents the Slack requirement (must be supplied) and GitHub behaviour (auto-generated if omitted). |
| agentex/tests/unit/api/test_webhook_trigger.py | Eight focused unit tests covering happy path, provided/generated/empty secrets, URL-encoding of reserved characters, control-char rejection (with create mock asserting it was never called), duplicate 409, invalid source 400, Slack-without-secret 400, and Slack-with-secret success. |
| agentex/openapi.yaml | Adds the new endpoint and both request/response schemas; documents 200 and 422 consistent with all existing endpoints in the file. |

</details>

</details>

<sub>Reviews (7): Last reviewed commit: ["Merge branch &#39;main&#39; into dm/agentex-webh..."](https://github.com/scaleapi/scale-agentex/commit/b3b4ecde8c87169de7d8f3c87f7112756ea30ff2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38966389)</sub>

<!-- /greptile_comment -->