### PR TITLE
fix(streams): snapshot SSE cursor before "connected" to stop first-token drops

### DIFF
--- a/agentex/src/domain/use_cases/streams_use_case.py
+++ b/agentex/src/domain/use_cases/streams_use_case.py
@@ -101,14 +101,15 @@ class StreamsUseCase:
             task_id = task.id
 
         stream_topic = get_task_event_stream_topic(task_id=task_id)
+        # Snapshot the read cursor BEFORE yielding "connected". "connected" is
+        # the client's cue to send its message, which makes the agent start
+        # XADD-ing deltas. Snapshotting after the yield lets a congested relay
+        # fall behind far enough that those deltas land before the snapshot and
+        # are never read. Snapshotting first resolves to "0-0" (stream is empty
+        # until the client sends), so we read from the beginning.
+        last_id = await self.stream_repository.get_stream_tail_id(stream_topic)
         # Send initial connection data
         yield f"data: {TaskStreamConnectedEventEntity(type='connected', taskId=task_id).model_dump_json()}\n\n"
-        # Snapshot the tail once on entry rather than passing "$" to every
-        # XREAD. "$" re-resolves to the current tail on each call, so any
-        # entry XADD'd in the gap between BLOCKing reads lands behind the
-        # new "$" and is unreachable — silently dropping deltas from
-        # fast-emitting agents.
-        last_id = await self.stream_repository.get_stream_tail_id(stream_topic)
         last_message_time = asyncio.get_running_loop().time()
         ping_interval = float(
             self.environment_variables.SSE_KEEPALIVE_PING_INTERVAL

--- a/agentex/tests/integration/test_task_stream.py
+++ b/agentex/tests/integration/test_task_stream.py
@@ -563,6 +563,54 @@ class TestTaskEventStream:
                 pass
             repo.read_messages = original_read_messages
 
+    async def test_event_xadded_after_connected_is_delivered(
+        self, test_agent_and_task, streams_use_case
+    ):
+        """
+        Regression for the SSE entry-gap drop bug: a delta XADDed right after
+        "connected" must still be delivered.
+
+        We step the generator manually so the XADD lands while it's suspended
+        at the "connected" yield. If the cursor is snapshotted after that yield
+        the delta is lost; snapshotting before it (the fix) delivers it.
+        """
+        from src.utils.stream_topics import get_task_event_stream_topic
+
+        _agent, task = test_agent_and_task
+        stream_topic = get_task_event_stream_topic(task_id=task.id)
+        repo = streams_use_case.stream_repository
+
+        gen = streams_use_case.stream_task_events(task_id=task.id)
+        try:
+            # First yielded event is "connected"; generator is now suspended here.
+            first = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert "connected" in first, f"expected connected event first, got: {first}"
+
+            # Emit a delta while the generator is suspended at the yield.
+            sentinel = "after-connected-sentinel"
+            await repo.send_data(
+                stream_topic, {"type": "error", "message": sentinel}
+            )
+
+            # The delta must be delivered; a silent stream means it was dropped.
+            received = False
+            for _ in range(10):
+                try:
+                    evt = await asyncio.wait_for(gen.__anext__(), timeout=4)
+                except (TimeoutError, asyncio.TimeoutError):
+                    break  # stream went silent — sentinel was dropped
+                if evt.startswith("data: ") and sentinel in evt:
+                    received = True
+                    break
+
+            assert received, (
+                "A delta XADDed after 'connected' was not delivered. The read "
+                "cursor was snapshotted after signaling connected, so the entry "
+                "landed behind the tail and was lost (the SSE entry-gap bug)."
+            )
+        finally:
+            await gen.aclose()
+
     async def test_stream_sends_keepalive_pings_during_idle_periods(
         self, test_agent_and_task, streams_use_case
     ):


### PR DESCRIPTION
## Summary

The SSE relay (`stream_task_events`) snapshots its Redis-stream read cursor **after** it yields the `connected` event. Under concurrent streaming load this opens a race that **silently drops a load-proportional share of streams' first tokens** — the client sees an open-but-silent SSE and times out, even though the agent produced and published the whole turn. Fix: snapshot the cursor **before** signaling `connected`.

## Background (how streaming works here)

Agents stream tokens by `XADD`-ing delta events onto a per-task Redis Stream (`task:<id>`). The platform relay serves `GET /tasks/{id}/stream`, reading that stream with `XREAD` from a cursor and forwarding over SSE. A client subscribes, waits for `connected`, **then** sends its message — which is what makes the agent start producing/`XADD`-ing.

## Root cause

In `stream_task_events`, the order was:

```python
yield "...connected..."                                  # (1) client's cue to send → agent starts XADD-ing
last_id = await get_stream_tail_id(stream_topic)         # (2) snapshot the cursor (one await later)
```

Between (1) and (2) there is an `await`. The relay is a single-process event loop serving many streams; under load it can fall far behind between these two steps. In that window the client receives `connected`, sends, and the (uncongested) agent produces and `XADD`s the turn's deltas. When (2) finally runs, the stream already holds those entries, so the snapshot lands **past** them and the subsequent `XREAD`s never return them → the client gets nothing and times out.

`get_stream_tail_id` returns `"0-0"` for an empty stream, so the bug only triggers when the agent wins the race — i.e. precisely under relay congestion. Symptoms match exactly: delivery-side, load-proportional, clusters at connection-establishment waves, non-monotonic, and silent (a missed read logs nothing).

## The fix

```python
last_id = await get_stream_tail_id(stream_topic)         # snapshot FIRST
yield "...connected..."                                   # THEN signal connected
```

Because the client always subscribes before sending, the stream is empty when the cursor is snapshotted → resolves to `"0-0"` (read from the beginning) → every delta the agent later writes is delivered, no matter how congested the relay is. The race window is closed. (Same cursor-advance semantics as #241 otherwise.)

## How it was validated

Found while load-testing a streaming agent (OneEdge) at 50–100 concurrent new chats (~9% / ~28–34% first-token failures). Three independent confirmations:

1. **Server-side**: the agent emitted a first-token for **100%** of requests, including all "failures" — the token was produced, just never delivered.
2. **Deterministic mechanism repro** (real Redis, throwaway key): `XADD` an entry, snapshot the tail *after* it, then `XREAD` from that snapshot → returns **nothing**; snapshotting *before* (empty → `"0-0"`) → returns it.
3. **End-to-end**: for **220/220** failed requests, the per-task Redis stream was **non-empty** (8–13 events incl. the agent's content) — published but never delivered.

## Test

`test_event_xadded_after_connected_is_delivered` — steps the generator manually so a delta is `XADD`ed while it's suspended at the `connected` yield, then asserts the delta is delivered. Fails on the pre-fix ordering (snapshot-after-connected drops it); passes with the fix. Sits next to the existing `test_event_xadded_in_inter_cycle_gap_is_delivered` (#241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Fixes the SSE task-event relay by snapshotting the Redis stream cursor before emitting the initial `connected` event.
- Preserves the existing cursor-advance behavior for subsequent stream reads.
- Adds an integration regression test covering an event XADDed while the generator is suspended at the `connected` yield.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrowly scoped to the SSE stream cursor ordering and is covered by a targeted regression test.

The implementation matches the intended race fix, preserves existing read-loop behavior, and adds coverage for the entry-time gap; remaining risk is limited to streaming behavior under production concurrency that is hard to fully model locally.

No specific files need additional attention beyond normal CI coverage for the streaming integration test.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the base commit 421f70d (trex-artifacts/sse-entry-cursor-race-01-before.log) with the head commit c46c484 (trex-artifacts/sse-entry-cursor-race-02-after.log) to verify how the race behaves across commits.
- Observed that the before-log shows the connection was established and an after-connected-sentinel was added but not delivered, while the after-log shows the after-connected-sentinel was delivered as an error payload, supporting the PR claim about closing the race by snapshotting before yielding connected.

<a href="https://app.greptile.com/trex/runs/11838649/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(streams): snapshot SSE cursor before..."](https://github.com/scaleapi/scale-agentex/commit/c46c484cf8cd89b251d10da515722c4fdc95be84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38996449)</sub>

<!-- /greptile_comment -->