### PR TITLE
feat(task-messages): add optional is_error to ToolResponseContent

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -1213,19 +1213,25 @@ paths:
             : {\n          \"anyOf\": [\n            {},\n            {\n        \
             \      \"type\": \"null\"\n            }\n          ],\n          \"default\"\
             : null,\n          \"description\": \"The result of the tool.\",\n   \
-            \       \"title\": \"Content\"\n        }\n      },\n      \"title\":\
-            \ \"ToolResponseContentEntityOptional\",\n      \"type\": \"object\"\n\
-            \    }\n  },\n  \"description\": \"Filter model for TaskMessage - all\
-            \ fields optional for flexible filtering.\\n\\nThe `exclude` field determines\
-            \ whether this filter is inclusionary or exclusionary.\\nWhen multiple\
-            \ filters are provided:\\n- Inclusionary filters (exclude=False) are OR'd\
-            \ together\\n- Exclusionary filters (exclude=True) are OR'd together and\
-            \ negated with $nor\\n- The two groups are AND'd: (include1 OR include2)\
-            \ AND NOT (exclude1 OR exclude2)\",\n  \"properties\": {\n    \"content\"\
-            : {\n      \"anyOf\": [\n        {\n          \"$ref\": \"#/$defs/ToolRequestContentEntityOptional\"\
-            \n        },\n        {\n          \"$ref\": \"#/$defs/DataContentEntityOptional\"\
-            \n        },\n        {\n          \"$ref\": \"#/$defs/TextContentEntityOptional\"\
-            \n        },\n        {\n          \"$ref\": \"#/$defs/ToolResponseContentEntityOptional\"\
+            \       \"title\": \"Content\"\n        },\n        \"is_error\": {\n\
+            \          \"anyOf\": [\n            {\n              \"type\": \"boolean\"\
+            \n            },\n            {\n              \"type\": \"null\"\n  \
+            \          }\n          ],\n          \"default\": null,\n          \"\
+            description\": \"Whether the tool call resulted in an error. `None` when\
+            \ the harness does not report a status.\",\n          \"title\": \"Is\
+            \ Error\"\n        }\n      },\n      \"title\": \"ToolResponseContentEntityOptional\"\
+            ,\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"Filter\
+            \ model for TaskMessage - all fields optional for flexible filtering.\\\
+            n\\nThe `exclude` field determines whether this filter is inclusionary\
+            \ or exclusionary.\\nWhen multiple filters are provided:\\n- Inclusionary\
+            \ filters (exclude=False) are OR'd together\\n- Exclusionary filters (exclude=True)\
+            \ are OR'd together and negated with $nor\\n- The two groups are AND'd:\
+            \ (include1 OR include2) AND NOT (exclude1 OR exclude2)\",\n  \"properties\"\
+            : {\n    \"content\": {\n      \"anyOf\": [\n        {\n          \"$ref\"\
+            : \"#/$defs/ToolRequestContentEntityOptional\"\n        },\n        {\n\
+            \          \"$ref\": \"#/$defs/DataContentEntityOptional\"\n        },\n\
+            \        {\n          \"$ref\": \"#/$defs/TextContentEntityOptional\"\n\
+            \        },\n        {\n          \"$ref\": \"#/$defs/ToolResponseContentEntityOptional\"\
             \n        },\n        {\n          \"$ref\": \"#/$defs/ReasoningContentEntityOptional\"\
             \n        },\n        {\n          \"type\": \"null\"\n        }\n   \
             \   ],\n      \"default\": null,\n      \"description\": \"Filter by message\
@@ -1416,19 +1422,24 @@ paths:
           \            {},\n            {\n              \"type\": \"null\"\n    \
           \        }\n          ],\n          \"default\": null,\n          \"description\"\
           : \"The result of the tool.\",\n          \"title\": \"Content\"\n     \
-          \   }\n      },\n      \"title\": \"ToolResponseContentEntityOptional\"\
-          ,\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"Filter\
-          \ model for TaskMessage - all fields optional for flexible filtering.\\\
-          n\\nThe `exclude` field determines whether this filter is inclusionary or\
-          \ exclusionary.\\nWhen multiple filters are provided:\\n- Inclusionary filters\
-          \ (exclude=False) are OR'd together\\n- Exclusionary filters (exclude=True)\
-          \ are OR'd together and negated with $nor\\n- The two groups are AND'd:\
-          \ (include1 OR include2) AND NOT (exclude1 OR exclude2)\",\n  \"properties\"\
-          : {\n    \"content\": {\n      \"anyOf\": [\n        {\n          \"$ref\"\
-          : \"#/$defs/ToolRequestContentEntityOptional\"\n        },\n        {\n\
-          \          \"$ref\": \"#/$defs/DataContentEntityOptional\"\n        },\n\
-          \        {\n          \"$ref\": \"#/$defs/TextContentEntityOptional\"\n\
-          \        },\n        {\n          \"$ref\": \"#/$defs/ToolResponseContentEntityOptional\"\
+          \   },\n        \"is_error\": {\n          \"anyOf\": [\n            {\n\
+          \              \"type\": \"boolean\"\n            },\n            {\n  \
+          \            \"type\": \"null\"\n            }\n          ],\n         \
+          \ \"default\": null,\n          \"description\": \"Whether the tool call\
+          \ resulted in an error. `None` when the harness does not report a status.\"\
+          ,\n          \"title\": \"Is Error\"\n        }\n      },\n      \"title\"\
+          : \"ToolResponseContentEntityOptional\",\n      \"type\": \"object\"\n \
+          \   }\n  },\n  \"description\": \"Filter model for TaskMessage - all fields\
+          \ optional for flexible filtering.\\n\\nThe `exclude` field determines whether\
+          \ this filter is inclusionary or exclusionary.\\nWhen multiple filters are\
+          \ provided:\\n- Inclusionary filters (exclude=False) are OR'd together\\\
+          n- Exclusionary filters (exclude=True) are OR'd together and negated with\
+          \ $nor\\n- The two groups are AND'd: (include1 OR include2) AND NOT (exclude1\
+          \ OR exclude2)\",\n  \"properties\": {\n    \"content\": {\n      \"anyOf\"\
+          : [\n        {\n          \"$ref\": \"#/$defs/ToolRequestContentEntityOptional\"\
+          \n        },\n        {\n          \"$ref\": \"#/$defs/DataContentEntityOptional\"\
+          \n        },\n        {\n          \"$ref\": \"#/$defs/TextContentEntityOptional\"\
+          \n        },\n        {\n          \"$ref\": \"#/$defs/ToolResponseContentEntityOptional\"\
           \n        },\n        {\n          \"$ref\": \"#/$defs/ReasoningContentEntityOptional\"\
           \n        },\n        {\n          \"type\": \"null\"\n        }\n     \
           \ ],\n      \"default\": null,\n      \"description\": \"Filter by message\
@@ -1769,19 +1780,25 @@ paths:
             : {\n          \"anyOf\": [\n            {},\n            {\n        \
             \      \"type\": \"null\"\n            }\n          ],\n          \"default\"\
             : null,\n          \"description\": \"The result of the tool.\",\n   \
-            \       \"title\": \"Content\"\n        }\n      },\n      \"title\":\
-            \ \"ToolResponseContentEntityOptional\",\n      \"type\": \"object\"\n\
-            \    }\n  },\n  \"description\": \"Filter model for TaskMessage - all\
-            \ fields optional for flexible filtering.\\n\\nThe `exclude` field determines\
-            \ whether this filter is inclusionary or exclusionary.\\nWhen multiple\
-            \ filters are provided:\\n- Inclusionary filters (exclude=False) are OR'd\
-            \ together\\n- Exclusionary filters (exclude=True) are OR'd together and\
-            \ negated with $nor\\n- The two groups are AND'd: (include1 OR include2)\
-            \ AND NOT (exclude1 OR exclude2)\",\n  \"properties\": {\n    \"content\"\
-            : {\n      \"anyOf\": [\n        {\n          \"$ref\": \"#/$defs/ToolRequestContentEntityOptional\"\
-            \n        },\n        {\n          \"$ref\": \"#/$defs/DataContentEntityOptional\"\
-            \n        },\n        {\n          \"$ref\": \"#/$defs/TextContentEntityOptional\"\
-            \n        },\n        {\n          \"$ref\": \"#/$defs/ToolResponseContentEntityOptional\"\
+            \       \"title\": \"Content\"\n        },\n        \"is_error\": {\n\
+            \          \"anyOf\": [\n            {\n              \"type\": \"boolean\"\
+            \n            },\n            {\n              \"type\": \"null\"\n  \
+            \          }\n          ],\n          \"default\": null,\n          \"\
+            description\": \"Whether the tool call resulted in an error. `None` when\
+            \ the harness does not report a status.\",\n          \"title\": \"Is\
+            \ Error\"\n        }\n      },\n      \"title\": \"ToolResponseContentEntityOptional\"\
+            ,\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"Filter\
+            \ model for TaskMessage - all fields optional for flexible filtering.\\\
+            n\\nThe `exclude` field determines whether this filter is inclusionary\
+            \ or exclusionary.\\nWhen multiple filters are provided:\\n- Inclusionary\
+            \ filters (exclude=False) are OR'd together\\n- Exclusionary filters (exclude=True)\
+            \ are OR'd together and negated with $nor\\n- The two groups are AND'd:\
+            \ (include1 OR include2) AND NOT (exclude1 OR exclude2)\",\n  \"properties\"\
+            : {\n    \"content\": {\n      \"anyOf\": [\n        {\n          \"$ref\"\
+            : \"#/$defs/ToolRequestContentEntityOptional\"\n        },\n        {\n\
+            \          \"$ref\": \"#/$defs/DataContentEntityOptional\"\n        },\n\
+            \        {\n          \"$ref\": \"#/$defs/TextContentEntityOptional\"\n\
+            \        },\n        {\n          \"$ref\": \"#/$defs/ToolResponseContentEntityOptional\"\
             \n        },\n        {\n          \"$ref\": \"#/$defs/ReasoningContentEntityOptional\"\
             \n        },\n        {\n          \"type\": \"null\"\n        }\n   \
             \   ],\n      \"default\": null,\n      \"description\": \"Filter by message\
@@ -1972,19 +1989,24 @@ paths:
           \            {},\n            {\n              \"type\": \"null\"\n    \
           \        }\n          ],\n          \"default\": null,\n          \"description\"\
           : \"The result of the tool.\",\n          \"title\": \"Content\"\n     \
-          \   }\n      },\n      \"title\": \"ToolResponseContentEntityOptional\"\
-          ,\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"Filter\
-          \ model for TaskMessage - all fields optional for flexible filtering.\\\
-          n\\nThe `exclude` field determines whether this filter is inclusionary or\
-          \ exclusionary.\\nWhen multiple filters are provided:\\n- Inclusionary filters\
-          \ (exclude=False) are OR'd together\\n- Exclusionary filters (exclude=True)\
-          \ are OR'd together and negated with $nor\\n- The two groups are AND'd:\
-          \ (include1 OR include2) AND NOT (exclude1 OR exclude2)\",\n  \"properties\"\
-          : {\n    \"content\": {\n      \"anyOf\": [\n        {\n          \"$ref\"\
-          : \"#/$defs/ToolRequestContentEntityOptional\"\n        },\n        {\n\
-          \          \"$ref\": \"#/$defs/DataContentEntityOptional\"\n        },\n\
-          \        {\n          \"$ref\": \"#/$defs/TextContentEntityOptional\"\n\
-          \        },\n        {\n          \"$ref\": \"#/$defs/ToolResponseContentEntityOptional\"\
+          \   },\n        \"is_error\": {\n          \"anyOf\": [\n            {\n\
+          \              \"type\": \"boolean\"\n            },\n            {\n  \
+          \            \"type\": \"null\"\n            }\n          ],\n         \
+          \ \"default\": null,\n          \"description\": \"Whether the tool call\
+          \ resulted in an error. `None` when the harness does not report a status.\"\
+          ,\n          \"title\": \"Is Error\"\n        }\n      },\n      \"title\"\
+          : \"ToolResponseContentEntityOptional\",\n      \"type\": \"object\"\n \
+          \   }\n  },\n  \"description\": \"Filter model for TaskMessage - all fields\
+          \ optional for flexible filtering.\\n\\nThe `exclude` field determines whether\
+          \ this filter is inclusionary or exclusionary.\\nWhen multiple filters are\
+          \ provided:\\n- Inclusionary filters (exclude=False) are OR'd together\\\
+          n- Exclusionary filters (exclude=True) are OR'd together and negated with\
+          \ $nor\\n- The two groups are AND'd: (include1 OR include2) AND NOT (exclude1\
+          \ OR exclude2)\",\n  \"properties\": {\n    \"content\": {\n      \"anyOf\"\
+          : [\n        {\n          \"$ref\": \"#/$defs/ToolRequestContentEntityOptional\"\
+          \n        },\n        {\n          \"$ref\": \"#/$defs/DataContentEntityOptional\"\
+          \n        },\n        {\n          \"$ref\": \"#/$defs/TextContentEntityOptional\"\
+          \n        },\n        {\n          \"$ref\": \"#/$defs/ToolResponseContentEntityOptional\"\
           \n        },\n        {\n          \"$ref\": \"#/$defs/ReasoningContentEntityOptional\"\
           \n        },\n        {\n          \"type\": \"null\"\n        }\n     \
           \ ],\n      \"default\": null,\n      \"description\": \"Filter by message\
@@ -6445,6 +6467,13 @@ components:
         content:
           title: Content
           description: The result of the tool.
+        is_error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Error
+          description: Whether the tool call resulted in an error. `None` when the
+            harness does not report a status.
       type: object
       required:
       - author
@@ -6480,6 +6509,13 @@ components:
         content:
           title: Content
           description: The result of the tool.
+        is_error:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Is Error
+          description: Whether the tool call resulted in an error. `None` when the
+            harness does not report a status.
       type: object
       required:
       - author

--- a/agentex/src/api/schemas/task_messages.py
+++ b/agentex/src/api/schemas/task_messages.py
@@ -108,6 +108,10 @@ class ToolResponseContent(BaseTaskMessageContent):
         ..., description="The name of the tool that is being responded to."
     )
     content: Any = Field(..., description="The result of the tool.")
+    is_error: bool | None = Field(
+        default=None,
+        description="Whether the tool call resulted in an error. `None` when the harness does not report a status.",
+    )
 
 
 class DataContent(BaseTaskMessageContent):

--- a/agentex/src/domain/entities/task_messages.py
+++ b/agentex/src/domain/entities/task_messages.py
@@ -125,6 +125,10 @@ class ToolResponseContentEntity(BaseTaskMessageContentEntity):
         ..., description="The name of the tool that is being responded to."
     )
     content: Any = Field(..., description="The result of the tool.")
+    is_error: bool | None = Field(
+        default=None,
+        description="Whether the tool call resulted in an error. `None` when the harness does not report a status.",
+    )
 
 
 OptionalToolResponseContentEntity = make_optional(ToolResponseContentEntity)
@@ -207,6 +211,7 @@ def convert_task_message_content_to_entity(
             tool_call_id=content.tool_call_id,
             name=content.name,
             content=content.content,
+            is_error=content.is_error,
         )
 
     assert_never(content)


### PR DESCRIPTION
## What

Adds an additive optional `is_error: bool | None` field to `ToolResponseContent` (API schema + domain entity), threaded through the schema→entity converter. `agentex/openapi.yaml` is regenerated accordingly.

## Why (AGX1-371)

The unified harness surface in `scale-agentex-python` derives tool spans from the canonical `StreamTaskMessage*` stream and closes a tool span on the matching `ToolResponseContent`. Today there is no structured error status on `ToolResponseContent` — tool failures are only encoded as an `"Error: ..."` string inside the opaque `content` field — so a derived tool span cannot mark failure.

Harnesses that track tool errors (e.g. golden agent's `ToolCompleted.is_error`) lose that status the moment they normalize onto the harness surface, which is a tracing-fidelity regression flagged in review on scaleapi/scale-agentex-python#412.

Since it's an additive optional field, landing it here first (then regenerating the SDK) unblocks wiring the status onto the closed tool span in the harness.

## Changes

- `agentex/src/api/schemas/task_messages.py` — `ToolResponseContent.is_error: bool | None = None`
- `agentex/src/domain/entities/task_messages.py` — same field on `ToolResponseContentEntity` + carried through `convert_task_message_content_to_entity`
- `agentex/openapi.yaml` — regenerated (is_error-only diff)

Defaults to `None` when the harness reports no status, so existing producers/consumers are unaffected.

## Follow-up

After this lands and the SDK is regenerated, the harness PRs in scale-agentex-python wire `ToolResponseContent.is_error` → `CloseSpan` → span status, and the `parallel-tools-with-error` conformance fixture is extended to assert error status propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional `is_error: bool | None = None` field to `ToolResponseContent` (API schema) and `ToolResponseContentEntity` (domain entity), carrying it through the schema→entity converter. The `openapi.yaml` is regenerated to reflect the new field.

- The field defaults to `None`, making this fully additive and backward-compatible with all existing producers and consumers.
- The converter at `convert_task_message_content_to_entity` now explicitly passes `is_error=content.is_error` to the entity constructor, ensuring the field propagates correctly from API layer to persistence.
- Existing construction sites in `agents_acp_use_case.py` that build `ToolResponseContentEntity` directly (e.g. the streaming delta accumulator) do not pass `is_error`, which is safe because the default is `None`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely additive optional field with a None default that leaves all existing producers and consumers untouched.

The change is a single optional field added in three consistent places (API schema, domain entity, converter). The default of None means no existing code path needs updating, and the OpenAPI spec regeneration matches the Python changes exactly.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/api/schemas/task_messages.py | Adds optional `is_error: bool | None = None` field to `ToolResponseContent`; purely additive, default preserves backwards compatibility |
| agentex/src/domain/entities/task_messages.py | Mirrors `is_error` on `ToolResponseContentEntity` and threads it through `convert_task_message_content_to_entity`; no existing callers broken since the field defaults to `None` |
| agentex/openapi.yaml | Regenerated to include `is_error` in `ToolResponseContent` and `ToolResponseContentEntityOptional` schemas; diff is consistent with the Python-side changes |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Harness as Harness (scale-agentex-python)
    participant API as API Schema<br/>(ToolResponseContent)
    participant Converter as convert_task_message_content_to_entity
    participant Entity as Domain Entity<br/>(ToolResponseContentEntity)
    participant ACP as ACP Service<br/>(model_validate)

    Harness->>API: "POST /messages { is_error: true | false | null }"
    API->>Converter: ToolResponseContent (with is_error)
    Converter->>Entity: "ToolResponseContentEntity(is_error=content.is_error)"
    Note over Entity: Stored in MongoDB

    ACP->>Entity: ToolResponseContentEntity.model_validate(result)
    Note over ACP: is_error carried through if present in result dict
    Entity-->>Harness: "Stream back via StreamTaskMessage*"
    Note over Harness: Can now close tool span with correct error status
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Harness as Harness (scale-agentex-python)
    participant API as API Schema<br/>(ToolResponseContent)
    participant Converter as convert_task_message_content_to_entity
    participant Entity as Domain Entity<br/>(ToolResponseContentEntity)
    participant ACP as ACP Service<br/>(model_validate)

    Harness->>API: "POST /messages { is_error: true | false | null }"
    API->>Converter: ToolResponseContent (with is_error)
    Converter->>Entity: "ToolResponseContentEntity(is_error=content.is_error)"
    Note over Entity: Stored in MongoDB

    ACP->>Entity: ToolResponseContentEntity.model_validate(result)
    Note over ACP: is_error carried through if present in result dict
    Entity-->>Harness: "Stream back via StreamTaskMessage*"
    Note over Harness: Can now close tool span with correct error status
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(task-messages): add optional is\_err..."](https://github.com/scaleapi/scale-agentex/commit/9a2e334bbc87c5bf23abdedfe496572825bb93da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39112373)</sub>

<!-- /greptile_comment -->