### PR TITLE
feat(agentex-ui): grow chat input vertically for multi-line prompts

### DIFF
--- a/agentex-ui/components/primary-content/prompt-input.tsx
+++ b/agentex-ui/components/primary-content/prompt-input.tsx
@@ -59,7 +59,7 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
   const sendMessageMutation = useSendMessage({ agentexClient });
   const { data: task } = useTask({ agentexClient, taskId: taskID ?? '' });
 
-  const textInputRef = useRef<HTMLInputElement>(null);
+  const textInputRef = useRef<HTMLTextAreaElement>(null);
   const codeMirrorViewRef = useRef<EditorView | null>(null);
 
   const isTaskTerminal = useMemo(() => {
@@ -200,7 +200,7 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
         </div>
       )}
       <div
-        className={`border-input dark:bg-input ${isDisabled ? 'bg-muted scale-90 cursor-not-allowed' : 'scale-100'} flex w-full items-center justify-between rounded-4xl border py-2 pr-2 pl-6 shadow-sm transition-transform duration-300 disabled:cursor-not-allowed`}
+        className={`border-input dark:bg-input ${isDisabled ? 'bg-muted scale-90 cursor-not-allowed' : 'scale-100'} flex w-full items-end justify-between rounded-4xl border py-2 pr-2 pl-6 shadow-sm transition-transform duration-300 disabled:cursor-not-allowed`}
       >
         {isSendingJSON ? (
           <DataInput
@@ -247,6 +247,11 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
   );
 }
 
+// Cap the auto-grow height of the plain-text prompt textarea. Matches the
+// JSON / CodeMirror branch's `maxHeight="200px"` so both variants feel
+// consistent when authoring longer prompts.
+const TEXT_INPUT_MAX_HEIGHT_PX = 200;
+
 const TextInput = ({
   prompt,
   setPrompt,
@@ -262,20 +267,42 @@ const TextInput = ({
   isTaskTerminal: boolean;
   taskStatus: string | null | undefined;
   handleSendPrompt: () => void;
-  inputRef: React.RefObject<HTMLInputElement | null>;
+  inputRef: React.RefObject<HTMLTextAreaElement | null>;
 }) => {
+  // Auto-resize the textarea height to fit content up to the max, then scroll
+  // internally. Reset to 'auto' first so the height can shrink when the user
+  // deletes lines, not just grow.
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const next = Math.min(el.scrollHeight, TEXT_INPUT_MAX_HEIGHT_PX);
+    el.style.height = `${next}px`;
+    el.style.overflowY =
+      el.scrollHeight > TEXT_INPUT_MAX_HEIGHT_PX ? 'auto' : 'hidden';
+  }, [prompt, inputRef]);
+
   return (
-    <input
+    <textarea
       ref={inputRef}
       id="prompt-text-input"
-      type="text"
+      rows={1}
       value={prompt}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
         setPrompt(e.target.value)
       }
-      onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter' && !isDisabled && prompt.trim()) {
-          handleSendPrompt();
+      onKeyDown={(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        // Enter sends; Shift+Enter inserts a newline. Ignore Enter while an
+        // IME composition is active so it can commit the candidate normally.
+        if (
+          e.key === 'Enter' &&
+          !e.shiftKey &&
+          !e.nativeEvent.isComposing
+        ) {
+          e.preventDefault();
+          if (!isDisabled && prompt.trim()) {
+            handleSendPrompt();
+          }
         }
       }}
       disabled={isDisabled}
@@ -286,10 +313,11 @@ const TextInput = ({
             ? 'Select an agent to start'
             : 'Enter your prompt'
       }
-      className="mr-2 flex-1 outline-none focus:ring-0 focus:outline-none"
+      className="mr-2 flex-1 resize-none py-2 leading-6 outline-none focus:ring-0 focus:outline-none"
       style={{
         backgroundColor: 'inherit',
         cursor: 'inherit',
+        maxHeight: `${TEXT_INPUT_MAX_HEIGHT_PX}px`,
       }}
     />
   );

--- a/agentex-ui/components/primary-content/prompt-input.tsx
+++ b/agentex-ui/components/primary-content/prompt-input.tsx
@@ -294,11 +294,7 @@ const TextInput = ({
       onKeyDown={(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         // Enter sends; Shift+Enter inserts a newline. Ignore Enter while an
         // IME composition is active so it can commit the candidate normally.
-        if (
-          e.key === 'Enter' &&
-          !e.shiftKey &&
-          !e.nativeEvent.isComposing
-        ) {
+        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
           e.preventDefault();
           if (!isDisabled && prompt.trim()) {
             handleSendPrompt();


### PR DESCRIPTION
## Problem

The plain-text prompt input in the golden agent UI (`agentex-ui/components/primary-content/prompt-input.tsx`) is an `<input type="text">`. Longer messages scroll horizontally inside the single line, so authors of multi-line prompts (lists, code snippets, paragraphs) can't see what they've typed or edit it comfortably before sending. Prompt quality directly affects agent output, so the friction matters.

## Fix

Swap the plain-text input for an auto-growing `<textarea>` in the same component. The JSON / CodeMirror branch already grows vertically up to `200px` — use the same cap on the text branch so the two variants feel consistent.

Specifically:

- Replace `<input type="text">` with `<textarea rows={1}>` in the `TextInput` subcomponent.
- Auto-resize on every prompt change: reset to `auto`, then set `height = min(scrollHeight, 200px)`; toggle `overflow-y` to `auto` once the cap is hit so it scrolls internally.
- Update the outer flex container from `items-center` to `items-end` so the `size-10` send button stays anchored at the bottom of the row as the textarea grows.
- Give the textarea `py-2 leading-6` so the single-line natural height (`8 + 24 + 8 = 40px`) matches the send button height — preserves today's container height and the visual centering of short messages.
- Keep `resize-none` and cap `maxHeight` inline so the user can't drag-resize past the cap.
- Update `textInputRef` and `TextInput`'s `inputRef` prop type from `HTMLInputElement` to `HTMLTextAreaElement`.

### Keyboard behavior

- **Enter** sends the message (same as before).
- **Shift+Enter** inserts a newline (default textarea behavior; we just don't `preventDefault` in that case).
- Enter is also ignored while an IME composition is active (`e.nativeEvent.isComposing`) so CJK candidate selection isn't hijacked.

The JSON branch continues to use `Cmd/Ctrl+Enter` (`Mod-Enter`) to send — that path is unchanged.

## Out of scope (matches the issue)

- Rich-text / markdown rendering in the composer.
- Drag-to-resize handle.
- Changes to the JSON / CodeMirror branch.

## Validation

Local validation was skipped per agent policy — relying on CI for typecheck/lint/format. The pinned prettier is `3.x`; only `2.8` is available on PATH in this environment, so I did not auto-format (mixing prettier majors causes unrelated reformatting). The diff matches the file's existing style.

## Reviewer test plan

- [ ] Open the golden agent chat surface; the prompt input renders at the same visual height as before for an empty / single-line message.
- [ ] Type a long message that wraps; the textarea grows vertically as new lines are added, and the rounded container grows with it.
- [ ] Continue typing past `~200px`; the textarea stops growing and scrolls internally.
- [ ] The send button stays visible and clickable at every height, anchored to the bottom-right of the row.
- [ ] **Enter** sends the message; **Shift+Enter** inserts a newline without sending.
- [ ] Disabled state (no agent selected, or task terminal) still renders with the muted background and `cursor-not-allowed`.
- [ ] Toggling the "Send JSON" switch still swaps in the CodeMirror editor unchanged.
- [ ] (Optional) Verify CJK IME composition: pressing Enter to commit a candidate does not send the message.

## Linear

AGX1-386

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR swaps the single-line `<input type="text">` in the `TextInput` sub-component for an auto-growing `<textarea>` capped at 200 px, matching the JSON/CodeMirror branch's existing cap. The flex container alignment is updated from `items-center` to `items-end` so the send button stays bottom-anchored as the textarea grows, and `py-2 leading-6` keeps the single-line height identical to the previous input.

- **Auto-resize effect** resets `height` to `'auto'` on each `prompt` change, reads the natural `scrollHeight`, clamps it to 200 px, and toggles `overflowY` accordingly.
- **Keyboard handling** calls `e.preventDefault()` on bare Enter while Shift+Enter inserts a newline; IME composition guard prevents hijacking CJK candidate selection.
- **Ref type** is narrowed from `HTMLInputElement` to `HTMLTextAreaElement` throughout.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is isolated to a single UI sub-component and handles all stated keyboard edge-cases correctly.

The resize effect, keyboard logic, ref-type update, and flex-alignment change are all self-contained and correct. No state management, API calls, or shared utilities are affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex-ui/components/primary-content/prompt-input.tsx | Replaces `<input type="text">` with an auto-growing `<textarea>` capped at 200px; adds IME-aware Enter/Shift+Enter keyboard handling; updates ref type and flex alignment — logic is correct with only a minor style nit in the resize effect. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User types in TextInput textarea] --> B[prompt state updates]
    B --> C[useEffect runs auto-resize logic]
    C --> D[el.style.height = 'auto']
    D --> E[Read el.scrollHeight]
    E --> F{scrollHeight > 200px?}
    F -- No --> G[height = scrollHeight, overflowY = hidden]
    F -- Yes --> H[height = 200px, overflowY = auto]
    A2[User presses key] --> I{Enter, no Shift, no IME?}
    I -- No --> J[Default browser behavior]
    I -- Yes --> K[e.preventDefault]
    K --> L{enabled AND prompt not empty?}
    L -- Yes --> M[handleSendPrompt, clears prompt]
    L -- No --> N[No-op]
    M --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User types in TextInput textarea] --> B[prompt state updates]
    B --> C[useEffect runs auto-resize logic]
    C --> D[el.style.height = 'auto']
    D --> E[Read el.scrollHeight]
    E --> F{scrollHeight > 200px?}
    F -- No --> G[height = scrollHeight, overflowY = hidden]
    F -- Yes --> H[height = 200px, overflowY = auto]
    A2[User presses key] --> I{Enter, no Shift, no IME?}
    I -- No --> J[Default browser behavior]
    I -- Yes --> K[e.preventDefault]
    K --> L{enabled AND prompt not empty?}
    L -- Yes --> M[handleSendPrompt, clears prompt]
    L -- No --> N[No-op]
    M --> B
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["style(agentex-ui): collapse Enter keydow..."](https://github.com/scaleapi/scale-agentex/commit/95f9771ad9e2053fa766b44a8f1e3749affd41ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39172603)</sub>

<!-- /greptile_comment -->