### PR TITLE
fix(agents-acp): persist user event message before forwarding to ACP

### DIFF
--- a/agentex/src/domain/use_cases/agents_acp_use_case.py
+++ b/agentex/src/domain/use_cases/agents_acp_use_case.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import random
 from collections.abc import AsyncIterator, Callable
+from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 
 from fastapi import Depends
@@ -832,6 +833,29 @@ class AgentsACPUseCase(TaskMessageMixin):
         task = await self.task_service.get_task(
             id=params.task_id, name=params.task_name
         )
+
+        # Persist user-authored event payloads as a TaskMessage on the
+        # platform side BEFORE forwarding the event to the agent. Without
+        # this, the agent runtime is the one that materializes the user's
+        # TaskMessage when it processes the forwarded event, which races
+        # against any messages the agent emits from its task-create handler
+        # (e.g. a startup "creating sandbox..." data row). BSON Date is
+        # millisecond-precision, so two writes inside the same millisecond
+        # have no defined order — and even when the writes happen in order,
+        # the agent's startup row can land first if event_send takes any
+        # round-trip time to reach the agent. Writing here closes both
+        # windows: the user row exists in the DB before the agent gets the
+        # event, and its created_at is clamped strictly after every
+        # already-existing message so the row sorts deterministically when
+        # paginated by (created_at, _id).
+        if (
+            params.content is not None
+            and params.content.author == MessageAuthor.USER
+        ):
+            await self._append_user_event_message(
+                task_id=task.id, content=params.content
+            )
+
         # Create the event in the DB
         event_entity = await self.task_service.create_event_and_forward_to_acp(
             agent=agent,
@@ -841,6 +865,42 @@ class AgentsACPUseCase(TaskMessageMixin):
             request_headers=request_headers,
         )
         return event_entity
+
+    async def _append_user_event_message(
+        self,
+        task_id: str,
+        content: TaskMessageContentEntity,
+    ) -> TaskMessageEntity:
+        """
+        Persist a user-authored event payload as a TaskMessage with a
+        created_at that is strictly greater than every existing message's
+        created_at for this task.
+
+        The clamp is `max(datetime.now(UTC), latest_existing + 1ms)`. The
+        1ms bump matches the staggering used by ``append_messages`` so the
+        stored ordering is durable against BSON Date's millisecond
+        precision: two writes that would otherwise collide on the same
+        millisecond now sort deterministically.
+        """
+        latest = await self.task_message_service.get_messages(
+            task_id=task_id,
+            limit=1,
+            page_number=1,
+            order_by="created_at",
+            order_direction="desc",
+        )
+        now = datetime.now(UTC)
+        if latest and latest[0].created_at is not None:
+            candidate = latest[0].created_at + timedelta(milliseconds=1)
+            clamped_created_at = max(now, candidate)
+        else:
+            clamped_created_at = now
+
+        return await self.task_message_service.append_message(
+            task_id=task_id,
+            content=content,
+            created_at=clamped_created_at,
+        )
 
 
 DAgentsACPUseCase = Annotated[AgentsACPUseCase, Depends(AgentsACPUseCase)]

--- a/agentex/tests/unit/use_cases/test_agents_acp_use_case.py
+++ b/agentex/tests/unit/use_cases/test_agents_acp_use_case.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from unittest.mock import AsyncMock
 from uuid import uuid4
 from zoneinfo import ZoneInfo
@@ -19,6 +20,7 @@ from src.domain.entities.task_message_updates import (
     StreamTaskMessageStartEntity,
 )
 from src.domain.entities.task_messages import (
+    DataContentEntity,
     MessageAuthor,
     MessageStyle,
     TaskMessageContentType,
@@ -1899,6 +1901,213 @@ class TestAgentsACPUseCase:
             )
 
         assert "Either task_id or task_name must be provided" in str(exc_info.value)
+
+    async def test_handle_event_send_persists_user_message_with_clamped_created_at(
+        self,
+        agents_acp_use_case,
+        mock_http_gateway,
+        agent_repository,
+        task_service,
+        task_message_service,
+        sample_agent,
+        sample_text_content,
+    ):
+        """
+        AGX1-369: A user-authored event must materialize into a TaskMessage on
+        the platform side before the event is forwarded, with a created_at
+        strictly later than any already-existing message for that task.
+
+        This reproduces the same-millisecond race between an agent's startup
+        ``data`` row (e.g. "Creating sandbox...") and the user's first
+        message: both can land at the same wall-clock millisecond, and BSON
+        Date is millisecond-precision so without an explicit clamp the
+        stored order is unspecified. The clamp guarantees the user message
+        sorts deterministically.
+        """
+        # Given - Create agent and task first
+        await create_or_get_agent(agent_repository, sample_agent)
+        created_task = await task_service.create_task(
+            agent=sample_agent, task_name="event-ordering-task"
+        )
+
+        # Simulate the racing agent-authored startup message. We stamp it at
+        # *now* explicitly so the platform-side write of the user message
+        # would collide at the same millisecond if no clamp were applied.
+        race_instant = datetime.now(UTC)
+        sandbox_create = await task_message_service.append_message(
+            task_id=created_task.id,
+            content=DataContentEntity(
+                type=TaskMessageContentType.DATA,
+                author=MessageAuthor.AGENT,
+                style=MessageStyle.STATIC,
+                data={"event": "sandbox_create_started"},
+            ),
+            created_at=race_instant,
+        )
+        assert sandbox_create.created_at == race_instant
+
+        # Mock ACP forward — we only care about the persistence path here.
+        async def mock_async_call(*args, **kwargs):
+            payload = kwargs.get("payload", {})
+            return {
+                "jsonrpc": "2.0",
+                "result": {"status": "event_sent", "event_id": "event-369"},
+                "id": payload.get("id", ""),
+            }
+
+        mock_http_gateway.async_call.side_effect = mock_async_call
+
+        # When
+        await agents_acp_use_case._handle_event_send(
+            agent=sample_agent,
+            params=SendEventRequest(
+                task_id=created_task.id,
+                content=sample_text_content,  # author=USER fixture
+            ),
+            acp_url=sample_agent.acp_url,
+        )
+
+        # Then - exactly two messages, in the expected order, and the user
+        # message's created_at is strictly greater than the agent message's.
+        messages_asc = await task_message_service.get_messages(
+            task_id=created_task.id,
+            limit=10,
+            page_number=1,
+            order_direction="asc",
+        )
+        assert len(messages_asc) == 2, (
+            f"Expected 1 pre-existing agent message + 1 platform-persisted "
+            f"user message, got {len(messages_asc)}"
+        )
+        assert messages_asc[0].id == sandbox_create.id
+        assert messages_asc[1].content.author == MessageAuthor.USER
+        assert messages_asc[1].content.content == sample_text_content.content
+        assert messages_asc[1].created_at is not None
+        assert messages_asc[0].created_at is not None
+        assert messages_asc[1].created_at > messages_asc[0].created_at, (
+            "User message must be timestamped strictly after every "
+            "pre-existing message so the (created_at, _id) sort key is "
+            "deterministic under BSON's millisecond precision."
+        )
+        # Defense-in-depth: enforce the >= +1ms gap the clamp promises.
+        assert (
+            messages_asc[1].created_at - messages_asc[0].created_at
+            >= timedelta(milliseconds=1)
+        )
+
+    async def test_handle_event_send_persists_user_message_when_task_is_empty(
+        self,
+        agents_acp_use_case,
+        mock_http_gateway,
+        agent_repository,
+        task_service,
+        task_message_service,
+        sample_agent,
+        sample_text_content,
+    ):
+        """
+        AGX1-369: When no prior messages exist for the task, the user
+        message is persisted with ``now`` and no clamp is needed — but the
+        message must still be visible in the list response before any
+        agent-emitted reply.
+        """
+        await create_or_get_agent(agent_repository, sample_agent)
+        created_task = await task_service.create_task(
+            agent=sample_agent, task_name="event-ordering-task-empty"
+        )
+
+        async def mock_async_call(*args, **kwargs):
+            payload = kwargs.get("payload", {})
+            return {
+                "jsonrpc": "2.0",
+                "result": {"status": "event_sent", "event_id": "event-empty"},
+                "id": payload.get("id", ""),
+            }
+
+        mock_http_gateway.async_call.side_effect = mock_async_call
+
+        before = datetime.now(UTC)
+        await agents_acp_use_case._handle_event_send(
+            agent=sample_agent,
+            params=SendEventRequest(
+                task_id=created_task.id,
+                content=sample_text_content,
+            ),
+            acp_url=sample_agent.acp_url,
+        )
+        after = datetime.now(UTC)
+
+        messages = await task_message_service.get_messages(
+            task_id=created_task.id,
+            limit=10,
+            page_number=1,
+            order_direction="asc",
+        )
+        assert len(messages) == 1
+        assert messages[0].content.author == MessageAuthor.USER
+        assert messages[0].created_at is not None
+        # Must be stamped with wall-clock at the time of the call (no clamp
+        # bump when there is nothing to clamp against).
+        assert before <= messages[0].created_at <= after
+
+    async def test_handle_event_send_skips_persistence_for_agent_authored_event(
+        self,
+        agents_acp_use_case,
+        mock_http_gateway,
+        agent_repository,
+        task_service,
+        task_message_service,
+        sample_agent,
+    ):
+        """
+        AGX1-369: Only user-authored events are materialized into a
+        TaskMessage on the platform. Agent- or system-authored event
+        payloads are still forwarded but must not produce a user-visible
+        message row on this path, to avoid duplicating the agent's own
+        writes.
+        """
+        await create_or_get_agent(agent_repository, sample_agent)
+        created_task = await task_service.create_task(
+            agent=sample_agent, task_name="event-ordering-task-non-user"
+        )
+
+        agent_content = DataContentEntity(
+            type=TaskMessageContentType.DATA,
+            author=MessageAuthor.AGENT,
+            style=MessageStyle.STATIC,
+            data={"event": "system_signal"},
+        )
+
+        async def mock_async_call(*args, **kwargs):
+            payload = kwargs.get("payload", {})
+            return {
+                "jsonrpc": "2.0",
+                "result": {"status": "event_sent", "event_id": "event-sys"},
+                "id": payload.get("id", ""),
+            }
+
+        mock_http_gateway.async_call.side_effect = mock_async_call
+
+        await agents_acp_use_case._handle_event_send(
+            agent=sample_agent,
+            params=SendEventRequest(
+                task_id=created_task.id,
+                content=agent_content,
+            ),
+            acp_url=sample_agent.acp_url,
+        )
+
+        messages = await task_message_service.get_messages(
+            task_id=created_task.id,
+            limit=10,
+            page_number=1,
+            order_direction="asc",
+        )
+        assert messages == [], (
+            "Agent-authored event payloads must not be persisted as "
+            "TaskMessages by the platform; the agent runtime owns those "
+            "writes."
+        )
 
     async def test_handle_message_send_sync_with_task_name(
         self,


### PR DESCRIPTION
## Problem

In the custom-agents UI, the first turn of a brand-new task sometimes
renders an agent-authored message above the user's first message. The
expected order is user-input first, then everything the agent does in
response to it.

For agentic / async agents, the user's first input arrives as an
`event/send` RPC. Today the agent runtime is the one that materializes
that input into a `TaskMessage` after it processes the forwarded event.
That write races against any messages the agent emits from its
task-create handler (e.g. a startup "creating sandbox..." data row):

- BSON `Date` is millisecond-precision, so two writes in the same
  millisecond have no defined order.
- Even when the writes happen in the "right" order, the agent's startup
  row can be timestamped earlier than the user row because the event has
  to round-trip from the platform to the agent before the agent persists
  the user message.

The UI sorts by `(created_at, _id)` and renders strictly in that order,
so the agent visibly speaks before the user.

## Fix

In `_handle_event_send`, when the event payload is user-authored,
persist it as a `TaskMessage` on the platform side **before** forwarding
the event to ACP, with `created_at` clamped to:

```
max(datetime.now(UTC), latest_existing_message.created_at + 1ms)
```

The 1ms bump matches the staggering used by `append_messages` so the
stored ordering is durable against BSON's millisecond precision, and
the synchronous platform-side write closes the round-trip window — the
user row is in the DB before the agent ever sees the event.

Only user-authored payloads are persisted on this path. Agent- /
system-authored event payloads still flow through `create_event_and_forward_to_acp`
without producing a platform-side message row, so the agent runtime
remains the owner of agent message writes.

## Tests

Added three unit tests under `TestAgentsACPUseCase` exercising the new
behavior against real Postgres + MongoDB testcontainers:

- `test_handle_event_send_persists_user_message_with_clamped_created_at`:
  pre-seeds an agent-authored "sandbox create" row stamped at *now*,
  then sends a user-authored event at the same instant, and asserts the
  user row is timestamped strictly after the agent row by at least 1ms.
- `test_handle_event_send_persists_user_message_when_task_is_empty`:
  no pre-existing messages — the user message is stamped with
  wall-clock, no clamp bump needed, and is the only message present.
- `test_handle_event_send_skips_persistence_for_agent_authored_event`:
  an `author=AGENT` event payload is forwarded normally but does NOT
  produce a platform-side `TaskMessage`.

## Out of scope / follow-ups

- Per-task monotonic sequence number for messages with a dual sort key
  (schema change + backfill).
- Resumable SSE via `Last-Event-ID` + removing the cache-skip on
  reconnect (separate ticket — fixes a sibling reconciliation bug).
- Single reconciliation function in the UI to replace the ad-hoc merges
  in `use-task-messages` / `use-task-subscription`.
- Server-side guarantee that `streaming_status` transitions to a
  terminal state on worker death / cancel.

## Validation

- Self-reviewed staged diff.
- Did not run lint / typecheck / full test suite locally — relying on
  CI to enforce.

## Test plan for reviewer

- [ ] CI passes (ruff, mypy, unit + integration).
- [ ] Manually create 20+ new tasks against an agentic agent that emits
      a startup data row and confirm the user message is always rendered
      first.
- [ ] Confirm existing pagination, infinite scroll up, and tool-pair
      grouping behavior is unchanged for non-first-turn cases.
- [ ] Confirm agent runtimes that previously persisted their own user
      message do not produce duplicate user rows (default `AsyncBaseACP`
      template does not; custom handlers should be audited).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a race condition in the custom-agents UI where an agent's startup message could appear before the user's first message by persisting the user-authored event payload as a `TaskMessage` on the platform side — with a `max(now, latest + 1ms)` clamped timestamp — before forwarding the event to ACP.

- `_handle_event_send` now calls a new `_append_user_event_message` helper for `author=USER` payloads only; agent/system payloads are unchanged and still flow through `create_event_and_forward_to_acp` without producing a platform-side row.
- Three new integration tests using real testcontainers verify the clamped timestamp, the empty-task case, and that agent-authored events are not persisted by the platform.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with awareness of the partial-failure scenario introduced on the new persistence path.

The core ordering fix is sound and well-tested. However, the new MongoDB write in `_handle_event_send` is not atomic with the subsequent Postgres event creation and ACP forward — if either of those steps fails, the user message row is durably written with no event sent to the agent, and a client retry will write a second user message. This is a real regression in the error path that was clean before this change.

The `_handle_event_send` method in `agents_acp_use_case.py` warrants a second look around error handling for the new MongoDB write step.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/agents_acp_use_case.py | Adds platform-side user message persistence in `_handle_event_send` before ACP forwarding; introduces a partial-failure window where the MongoDB write succeeds but the subsequent ACP forward can fail, leaving an orphaned user message that duplicates on retry. |
| agentex/tests/unit/use_cases/test_agents_acp_use_case.py | Adds three integration-style tests covering the clamped timestamp, empty-task, and agent-authored event cases; tests use real Postgres + MongoDB testcontainers and correctly assert ordering invariants. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Platform as _handle_event_send
    participant MongoDB
    participant Postgres
    participant ACP as Agent (ACP)

    Client->>Platform: "event/send (author=USER)"
    Platform->>MongoDB: _append_user_event_message (created_at clamped)
    MongoDB-->>Platform: TaskMessage persisted
    Platform->>Postgres: create_event_and_forward_to_acp
    Postgres-->>Platform: EventEntity created
    Platform->>ACP: send_event
    ACP-->>Platform: ack
    Platform-->>Client: EventEntity

    note over MongoDB,Postgres: If ACP forward fails, MongoDB row is orphaned and a client retry creates a duplicate user message
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Platform as _handle_event_send
    participant MongoDB
    participant Postgres
    participant ACP as Agent (ACP)

    Client->>Platform: "event/send (author=USER)"
    Platform->>MongoDB: _append_user_event_message (created_at clamped)
    MongoDB-->>Platform: TaskMessage persisted
    Platform->>Postgres: create_event_and_forward_to_acp
    Postgres-->>Platform: EventEntity created
    Platform->>ACP: send_event
    ACP-->>Platform: ack
    Platform-->>Client: EventEntity

    note over MongoDB,Postgres: If ACP forward fails, MongoDB row is orphaned and a client retry creates a duplicate user message
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agents-acp): persist user event mess..."](https://github.com/scaleapi/scale-agentex/commit/0390c7d0d470202ed46d2ccde3254bd04a551797) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39180355)</sub>

<!-- /greptile_comment -->