### PR TITLE
fix(deps): cap fastapi <0.137.0 to stop OPTIONS preflight 500s

### DIFF
--- a/agentex/pyproject.toml
+++ b/agentex/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Felix Su", email = "felix.su@scale.com" }]
 requires-python = ">=3.12,<3.13"
 readme = "README.md"
 dependencies = [
-    "fastapi>=0.115.0",
+    "fastapi>=0.115.0,<0.137.0",  # <0.137.0 keeps app.routes flat; 0.137.0's _IncludedRouter (no .path) crashes injected OTel instrumentation on OPTIONS preflights -> 500
     "litellm>=1.84.0,<2",  # >=1.84.0 clears CVE-2026-49468 (CRITICAL auth bypass)
     "python-dotenv>=1.2.2,<2",
     "temporalio>=1.18.0,<2",

--- a/agentex/tests/unit/api/test_otel_route_compat.py
+++ b/agentex/tests/unit/api/test_otel_route_compat.py
@@ -49,7 +49,14 @@ class TestOtelRouteCompat:
             "path": "/agents",
             "headers": [],
         }
+        matched = 0
         for route in fastapi_app.routes:
             match, _ = route.matches(scope)
             if match in (Match.FULL, Match.PARTIAL):
+                matched += 1
                 assert route.path is not None
+        assert matched > 0, (
+            "No route matched the OPTIONS /agents preflight scope, so the "
+            "`.path` assertion never ran. The test would pass vacuously even "
+            "on a broken FastAPI version. Pick a path served by app.routes."
+        )

--- a/agentex/tests/unit/api/test_otel_route_compat.py
+++ b/agentex/tests/unit/api/test_otel_route_compat.py
@@ -1,0 +1,55 @@
+"""
+Regression test for the OPTIONS/CORS preflight 500 caused by FastAPI's
+``_IncludedRouter`` change.
+
+FastAPI 0.137.0 made ``app.routes`` a tree that can contain ``_IncludedRouter``
+wrapper objects (one per ``include_router()`` call). Those wrappers do NOT
+expose a ``.path`` attribute. The OpenTelemetry FastAPI auto-instrumentation
+(injected at runtime by the observability operator, so it is not a dependency we
+can bump here) reads ``route.path`` on a ``Match.PARTIAL`` while building the
+request span. A browser CORS preflight (``OPTIONS``) has no declared endpoint,
+so it only PARTIAL-matches the ``_IncludedRouter`` -> ``AttributeError`` raised
+inside the ASGI layer (outside FastAPI's exception handlers) -> HTTP 500.
+
+The only lever we control is the FastAPI version we ship, so we pin
+``fastapi < 0.137.0`` to keep ``app.routes`` a flat list of routes that all
+expose ``.path``. Pinning *up* does not help: 0.137.1/0.137.2/0.138.0 keep the
+``_IncludedRouter`` and only add a new ``iter_route_contexts()`` helper that the
+pinned injected instrumentation does not use.
+
+If this test fails, FastAPI has been bumped to a version that reintroduces the
+preflight-crash regression for the injected OTel instrumentation.
+"""
+
+import pytest
+from src.api.app import fastapi_app
+from starlette.routing import Match
+
+
+@pytest.mark.unit
+class TestOtelRouteCompat:
+    def test_every_route_exposes_path(self):
+        """Every entry in app.routes must expose ``.path`` (what OTel reads)."""
+        missing = [
+            type(route).__name__
+            for route in fastapi_app.routes
+            if not hasattr(route, "path")
+        ]
+        assert not missing, (
+            "Routes without a `.path` attribute would crash the injected OTel "
+            f"FastAPI instrumentation on OPTIONS preflights: {missing}. "
+            "This usually means FastAPI was bumped to >= 0.137.0."
+        )
+
+    def test_options_preflight_route_matching_does_not_crash(self):
+        """Simulate OTel `_get_route_details` over an OPTIONS preflight scope."""
+        scope = {
+            "type": "http",
+            "method": "OPTIONS",
+            "path": "/agents",
+            "headers": [],
+        }
+        for route in fastapi_app.routes:
+            match, _ = route.matches(scope)
+            if match in (Match.FULL, Match.PARTIAL):
+                assert route.path is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,12 @@ environments = [
 # carries the fixes for CVE-2026-48818 / CVE-2026-54283 (and CVE-2025-62727).
 # python-multipart>=0.0.32 clears CVE-2026-53539. Keep these floors at the patched
 # minimums so a re-resolve can't regress below them.
+# fastapi is capped <0.137.0: 0.137.0 made app.routes a tree of _IncludedRouter
+# wrappers (no .path), which crashes the injected OTel FastAPI instrumentation on
+# OPTIONS/CORS preflights (-> 500). 0.137.1/0.137.2/0.138.0 do not restore the flat
+# list. The starlette>=1.3.1 floor below keeps the CVE fixes regardless of this cap.
 override-dependencies = [
-    "fastapi>=0.135.0",
+    "fastapi>=0.135.0,<0.137.0",
     "starlette>=1.3.1",
     "httpx[http2]>=0.28.1,<0.29",
     "langchain-core>=1.3.3",

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ members = [
     "agentex-backend",
 ]
 overrides = [
-    { name = "fastapi", specifier = ">=0.135.0" },
+    { name = "fastapi", specifier = ">=0.135.0,<0.137.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1,<0.29" },
     { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "mako", specifier = ">=1.3.12" },
@@ -116,7 +116,7 @@ requires-dist = [
     { name = "datadog", specifier = ">=0.52.1" },
     { name = "ddtrace", specifier = ">=3.13.0" },
     { name = "docker", specifier = ">=7.1.0,<8" },
-    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastapi", specifier = ">=0.115.0,<0.137.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.2" },
     { name = "json-log-formatter", specifier = ">=1.1.1" },
     { name = "kubernetes-asyncio", specifier = ">=31.1.0,<32" },
@@ -728,7 +728,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.137.1"
+version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -737,9 +737,9 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/b1/e5b92c59d2c37817e77c1a8c2fc1f79cdcc04c68253e5406b43e3204cba7/fastapi-0.137.1.tar.gz", hash = "sha256:822360704230d9533d8d9475399613525968aa2f0b5bd2a3ccc9f18c88fd541c", size = 408293, upload-time = "2026-06-15T11:28:20.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/35/380b9a5922f4340e51c309cde09e5bd32e62f02302971bee30dc15aa0624/fastapi-0.137.1-py3-none-any.whl", hash = "sha256:64f6983c59e45c4b9fdc44e57cb8035c2451ee91ea8e8ec042aca37de7cf6b69", size = 121877, upload-time = "2026-06-15T11:28:19.523Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Browser CORS preflight (`OPTIONS`) requests to agentex routes return **HTTP 500**, which prevents the Agents UI from loading. This is **not** a CORS configuration issue (`ALLOWED_ORIGINS` is correct) and **not** an agentex code bug.

Root cause is a FastAPI regression interacting with the OTel FastAPI auto-instrumentation:

- **FastAPI 0.137.0** changed `include_router()` so `app.routes` becomes a tree containing `_IncludedRouter` wrapper objects that **do not expose a `.path` attribute**, instead of a flat list where each route has `.path`.
- The OpenTelemetry FastAPI auto-instrumentation (injected at runtime by the observability operator, so it is **not** a Python dependency this repo can bump) reads `route.path` on a `Match.PARTIAL` while building the request span. An `OPTIONS` preflight has no declared endpoint, so it only PARTIAL-matches the `_IncludedRouter` → `AttributeError` raised in the ASGI layer (outside FastAPI's exception handlers) → HTTP 500. A normal `GET` fully matches a concrete route (has `.path`) and is handled fine.

The version actually resolved by the workspace is governed by the root `pyproject.toml` `[tool.uv] override-dependencies`, which floored `fastapi>=0.135.0` with **no ceiling** and so resolved to 0.137+.

## Fix

Cap FastAPI below the regressed line:

- Root `pyproject.toml` override: `fastapi>=0.135.0` → `fastapi>=0.135.0,<0.137.0` (this is what actually controls resolution; `override-dependencies` replaces member-level specs).
- `agentex/pyproject.toml` package dep: `fastapi>=0.115.0` → `fastapi>=0.115.0,<0.137.0` (defense-in-depth for standalone installs).
- `uv.lock` re-resolved to **fastapi 0.136.3**; `starlette` stays at 1.3.1.

Pinning *up* does not help: 0.137.1 / 0.137.2 / 0.138.0 all keep `_IncludedRouter` and only add a new `iter_route_contexts()` helper that the pinned injected instrumentation does not use. The separate `starlette>=1.3.1` override preserves the existing CVE fixes regardless of this cap.

## Tests

- New regression test `agentex/tests/unit/api/test_otel_route_compat.py` asserts every `app.routes` entry exposes `.path` and that OPTIONS-preflight route matching cannot crash. It fails on FastAPI ≥0.137.0, so a future bump that reintroduces the regression fails CI.
- Reproduced the crash on the previously-resolved 0.137.x (`_IncludedRouter` match=PARTIAL → `.path` AttributeError); after the fix the live app has **0** routes without `.path` (was 13).
- `tests/unit/api/`: 108 passed. (Docker-backed unit tests are skipped where no daemon is available; unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Caps FastAPI below `0.137.0` in the root workspace override and the `agentex` package dependency.
- Re-resolves `uv.lock` to FastAPI `0.136.3` while preserving the Starlette override.
- Adds regression coverage for the OTel preflight route-matching compatibility issue.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The dependency cap is narrowly scoped and covered by a targeted regression test for the route compatibility behavior.

The change updates only dependency constraints, the lockfile, and focused unit coverage for the reported FastAPI/OTel interaction, with no review comments needed.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the pre-change environment showed missing\_path\_count 13 and an AttributeError on a \_IncludedRouter path during a Match.PARTIAL route, with an OPTIONS request returning 200 OK but without instrumentation.
- Verified the head environment resolved to FastAPI 0.136.3 and Starlette 1.3.1, with missing\_path\_count 0, found fastapi.routing.APIRoute Match.PARTIAL at /agents, otel\_style\_path\_access\_raised False, script exit code 0, and an OPTIONS request returning 200 OK.

<a href="https://app.greptile.com/trex/runs/12065415/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["test: assert OPTIONS-preflight test matc..."](https://github.com/scaleapi/scale-agentex/commit/87b22850b18be0447a3312dd00c469f325b1f896) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39353381)</sub>

<!-- /greptile_comment -->