### PR TITLE
fix(tasks): preserve task_metadata in combined update and forward merge_params by name

### DIFF
--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -214,7 +214,9 @@ async def update_task_by_name(
     task_use_case: DTaskUseCase,
 ) -> Task:
     updated_task_entity = await task_use_case.update_mutable_fields_on_task(
-        name=task_name, task_metadata=request.task_metadata
+        name=task_name,
+        task_metadata=request.task_metadata,
+        merge_params=request.merge_params,
     )
     return Task.model_validate(updated_task_entity)
 

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -113,13 +113,12 @@ class TasksUseCase:
         if task_metadata is None and merge_params is None:
             return task_entity
 
-        if task_metadata is not None:
-            task_entity.task_metadata = task_metadata
-
         # `merge_params` is a separate atomic JSONB shallow-merge so concurrent
         # callers don't overwrite each other's fields (vs reading→mutating→writing
-        # the whole params dict on task_entity). Falls through to a normal save
-        # only when task_metadata also changed.
+        # the whole params dict on task_entity). Run it first so the refreshed
+        # entity it returns becomes the base we apply `task_metadata` on top of;
+        # otherwise the `task_entity = merged` reassignment would discard an
+        # in-memory metadata change made before the merge.
         if merge_params:
             merged = await self.task_service.merge_task_params(
                 task_entity.id, merge_params
@@ -128,6 +127,7 @@ class TasksUseCase:
                 task_entity = merged
 
         if task_metadata is not None:
+            task_entity.task_metadata = task_metadata
             task_entity = await self.task_service.update_task(task=task_entity)
 
         return task_entity

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -911,6 +911,87 @@ class TestTasksAPIIntegration:
         assert response_data["task_metadata"]["configuration"]["version"] == "2.0.0"
         assert response_data["task_metadata"]["metrics"]["complexity_score"] == 75
 
+    async def test_update_task_by_name_forwards_merge_params(
+        self, isolated_client, isolated_repositories
+    ):
+        """PUT /tasks/name/{task_name} must forward merge_params, not drop it."""
+        # Given - a task with existing params
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="merge-params-by-name-agent",
+            description="Agent for merge_params by name testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-merge-params-by-name",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for merge_params by name endpoint",
+            params={"model": "gpt-4", "temperature": 0.2},
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        # When - update by name supplying only merge_params
+        update_payload = {"merge_params": {"temperature": 0.9, "max_tokens": 1024}}
+        response = await isolated_client.put(
+            f"/tasks/name/{created_task.name}", json=update_payload
+        )
+
+        # Then - the patch is shallow-merged into the existing params
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["params"] == {
+            "model": "gpt-4",
+            "temperature": 0.9,
+            "max_tokens": 1024,
+        }
+
+    async def test_update_task_metadata_and_merge_params_together(
+        self, isolated_client, isolated_repositories
+    ):
+        """Supplying both task_metadata and merge_params must persist both."""
+        # Given - a task with existing params and metadata
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="merge-params-and-metadata-agent",
+            description="Agent for combined update testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-combined-update",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for combined update endpoint",
+            params={"model": "gpt-4"},
+            task_metadata={"initial": "metadata"},
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        # When - update by id supplying both fields at once
+        update_payload = {
+            "task_metadata": {"stage": "tuned"},
+            "merge_params": {"temperature": 0.7},
+        }
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json=update_payload
+        )
+
+        # Then - neither field is silently discarded
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["task_metadata"] == {"stage": "tuned"}
+        assert response_data["params"] == {"model": "gpt-4", "temperature": 0.7}
+
     async def test_list_tasks_includes_task_metadata_field(
         self, isolated_client, isolated_repositories
     ):

--- a/agentex/tests/unit/use_cases/test_tasks_use_case.py
+++ b/agentex/tests/unit/use_cases/test_tasks_use_case.py
@@ -432,6 +432,33 @@ class TestTasksUseCaseMetadataUpdate:
         # Then
         assert updated.task_metadata == {"via": "name"}
 
+    async def test_update_metadata_and_merge_params_both_persist(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """Supplying both task_metadata and merge_params must persist both fields.
+
+        Regression: the merge previously reassigned task_entity to the merged
+        result, discarding the in-memory task_metadata before the final write.
+        """
+        # Given
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent,
+            task_name="combined-update-test",
+            task_params={"model": "gpt-4"},
+        )
+
+        # When
+        updated = await tasks_use_case.update_mutable_fields_on_task(
+            id=task.id,
+            task_metadata={"stage": "tuned"},
+            merge_params={"temperature": 0.7},
+        )
+
+        # Then
+        assert updated.task_metadata == {"stage": "tuned"}
+        assert updated.params == {"model": "gpt-4", "temperature": 0.7}
+
     async def test_update_metadata_on_deleted_task_raises(
         self, tasks_use_case, task_service, agent_repository, sample_agent
     ):


### PR DESCRIPTION
Follow-up to #309, addressing two defects flagged in review (and called out in the merge thread).

## Defects fixed

1. **`task_metadata` silently discarded on combined update.** In `update_mutable_fields_on_task`, when both `task_metadata` and `merge_params` were supplied, the `task_entity = merged` reassignment overwrote the in-memory `task_metadata` change before the final `update_task` write, so the caller's metadata update was dropped. Fix: run the JSONB `merge_params` merge first so its refreshed entity becomes the base, then apply `task_metadata` on top and write.

2. **`merge_params` dropped on the by-name endpoint.** The `update_task_by_name` route handler did not forward `merge_params` to the use case, silently dropping it for callers of `PUT /tasks/name/{task_name}`. The by-id handler already forwarded it. Fix: forward `request.merge_params`.

## Tests

- `test_update_task_by_name_forwards_merge_params` — integration test verifying the by-name endpoint shallow-merges `merge_params`.
- `test_update_task_metadata_and_merge_params_together` — integration test verifying a combined `task_metadata` + `merge_params` update persists both.
- `test_update_metadata_and_merge_params_both_persist` — use-case unit test for the combined case (regression for defect 1).

No schema changes (`merge_params` already shipped in #309), so `openapi.yaml` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two defects from PR #309 — `task_metadata` being silently discarded during a combined `task_metadata` + `merge_params` update, and `merge_params` not being forwarded by the by-name route handler. Both fixes are accompanied by new integration and unit tests.

- **`tasks_use_case.py`**: Reorders the `merge_params` JSONB merge to run before the `task_metadata` assignment, so the refreshed entity from the DB becomes the base rather than overwriting the in-memory metadata change.
- **`tasks.py`**: Adds the missing `merge_params=request.merge_params` forwarding to `update_mutable_fields_on_task` in the `update_task_by_name` handler (the by-id handler already forwarded it).
- **Tests**: Three new tests cover both scenarios — one unit-level regression and two integration tests exercising the by-id and by-name endpoints.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are narrow, targeted bug fixes with dedicated regression tests; no logic is removed and no new code paths are introduced beyond what was already in the by-id handler.

The reordering in `tasks_use_case.py` directly fixes the described discard bug and is covered by both a unit regression test and an integration test. The missing `merge_params` forwarding in the route handler is a one-line addition that makes the by-name endpoint consistent with the by-id handler. All three new tests are well-structured and exercise realistic scenarios against real repositories.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/tasks_use_case.py | Reorders merge_params and task_metadata writes to fix silent metadata discard; logic is correct and the comment explains the ordering rationale clearly. |
| agentex/src/api/routes/tasks.py | Adds missing merge_params forwarding to update_task_by_name, bringing it in line with the by-id handler. |
| agentex/tests/integration/api/tasks/test_tasks_api.py | Adds two well-structured integration tests covering both fixed bugs end-to-end against real repositories. |
| agentex/tests/unit/use_cases/test_tasks_use_case.py | Adds a clear regression unit test for the combined task_metadata + merge_params use case with a descriptive docstring explaining the original bug. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as tasks.py (route)
    participant UC as TasksUseCase
    participant Svc as TaskService

    Client->>Router: "PUT /tasks/name/{name}<br/>{task_metadata, merge_params}"
    Router->>UC: update_mutable_fields_on_task(name, task_metadata, merge_params)
    UC->>Svc: "get_task(name=name)"
    Svc-->>UC: task_entity

    alt merge_params provided
        UC->>Svc: merge_task_params(task_entity.id, merge_params)
        Note over Svc: Atomic JSONB shallow-merge in DB
        Svc-->>UC: merged entity (refreshed from DB)
        UC->>UC: "task_entity = merged"
    end

    alt task_metadata provided
        UC->>UC: "task_entity.task_metadata = task_metadata"
        UC->>Svc: update_task(task_entity)
        Svc-->>UC: saved entity
    end

    UC-->>Router: task_entity
    Router-->>Client: Task response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as tasks.py (route)
    participant UC as TasksUseCase
    participant Svc as TaskService

    Client->>Router: "PUT /tasks/name/{name}<br/>{task_metadata, merge_params}"
    Router->>UC: update_mutable_fields_on_task(name, task_metadata, merge_params)
    UC->>Svc: "get_task(name=name)"
    Svc-->>UC: task_entity

    alt merge_params provided
        UC->>Svc: merge_task_params(task_entity.id, merge_params)
        Note over Svc: Atomic JSONB shallow-merge in DB
        Svc-->>UC: merged entity (refreshed from DB)
        UC->>UC: "task_entity = merged"
    end

    alt task_metadata provided
        UC->>UC: "task_entity.task_metadata = task_metadata"
        UC->>Svc: update_task(task_entity)
        Svc-->>UC: saved entity
    end

    UC-->>Router: task_entity
    Router-->>Client: Task response
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tasks): preserve task\_metadata in co..."](https://github.com/scaleapi/scale-agentex/commit/753ded8847fcf4831bcac8aaf49460ed0eff39a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39396579)</sub>

<!-- /greptile_comment -->