### PR TITLE
docs(guides): tracing, framework-agent, and local-sandbox guides

### DIFF
--- a/agentex/docs/docs/development_guides/claude_code_agents.md
+++ b/agentex/docs/docs/development_guides/claude_code_agents.md
@@ -1,0 +1,69 @@
+# Claude Code Agents
+
+A Claude Code agent wraps the `claude` CLI as a local subprocess and streams its output through the [unified harness](streaming_patterns.md#unified-harness-surface-framework-agents). You spawn the CLI, feed the prompt on stdin, and hand its newline-delimited JSON stream to a `ClaudeCodeTurn`. The `UnifiedEmitter` then delivers the canonical `StreamTaskMessage*` events and derives tracing spans automatically, exactly like any other harness framework.
+
+Scaffold one with `agentex init` by picking the **Claude Code** framework option (available for Sync, Async-base, and Temporal).
+
+## Prerequisites
+
+- The `claude` CLI installed and on your `PATH`.
+- An `ANTHROPIC_API_KEY` (or equivalent credential) in the environment. The CLI authenticates with this key directly; it is not routed through LiteLLM.
+
+## How it works
+
+The template spawns the CLI in streaming-JSON mode and writes the prompt to stdin:
+
+```python
+proc = await asyncio.create_subprocess_exec(
+    "claude", "-p", "--output-format", "stream-json", "--verbose",
+    stdin=asyncio.subprocess.PIPE,
+    stdout=asyncio.subprocess.PIPE,
+    stderr=asyncio.subprocess.PIPE,
+)
+proc.stdin.write(prompt.encode())
+await proc.stdin.drain()
+proc.stdin.close()
+```
+
+`ClaudeCodeTurn(lines)` wraps the iterator of stdout lines (raw JSON strings or pre-parsed dicts). Under the hood it runs the `convert_claude_code_to_agentex_events` tap, which converts the CLI's events into the canonical stream (text, reasoning, tool requests, and tool responses). The turn exposes a `session_id` property so you can resume a conversation on the next turn.
+
+## Sync delivery (HTTP yield)
+
+```python
+import agentex.lib.adk as adk
+from agentex.lib.adk import UnifiedEmitter, ClaudeCodeTurn
+
+@acp.on_message_send
+async def handle_message_send(params: SendMessageParams):
+    task_id = params.task.id
+    async with adk.tracing.span(
+        trace_id=task_id, task_id=task_id, name="message",
+        input={"message": prompt},
+        data={"__span_type__": "AGENT_WORKFLOW"},
+    ) as turn_span:
+        emitter = UnifiedEmitter(
+            task_id=task_id, trace_id=task_id,
+            parent_span_id=turn_span.id if turn_span else None,
+        )
+        turn = ClaudeCodeTurn(_spawn_claude(prompt))  # iterator of CLI stdout lines
+        async for event in emitter.yield_turn(turn):
+            yield event
+```
+
+## Async and Temporal delivery
+
+For Async-base and Temporal agents the body is the same, except you call `auto_send_turn` (which pushes to Redis and returns a `TurnResult`) instead of `yield_turn`. Under Temporal, run the subprocess inside an activity and pass `created_at=workflow.now()`:
+
+```python
+result = await emitter.auto_send_turn(turn, created_at=workflow.now())
+# result.final_text, result.usage
+```
+
+Always tear the subprocess down in a `finally` block so a cancelled or failed turn does not leak a `claude` process.
+
+## See also
+
+- [Unified Harness Surface](streaming_patterns.md#unified-harness-surface-framework-agents)
+- [Observability & Tracing](observability_and_tracing.md)
+- [Claude Code starter tutorials](tutorials.md) (Sync, Async-base, Temporal)
+- [Codex Agents](codex_agents.md) for the OpenAI coding CLI equivalent

--- a/agentex/docs/docs/development_guides/codex_agents.md
+++ b/agentex/docs/docs/development_guides/codex_agents.md
@@ -1,0 +1,90 @@
+# Codex Agents
+
+A Codex agent wraps the `codex` CLI as a local subprocess and streams its output through the [unified harness](streaming_patterns.md#unified-harness-surface-framework-agents). It is the OpenAI coding-CLI counterpart to a [Claude Code agent](claude_code_agents.md): you spawn the CLI, feed the prompt on stdin, and hand its newline-delimited JSON events to a `CodexTurn`. The `UnifiedEmitter` delivers the canonical `StreamTaskMessage*` events and derives tracing spans automatically.
+
+Scaffold one with `agentex init` by picking the **Codex** framework option (available for Sync, Async-base, and Temporal).
+
+## Prerequisites
+
+- The `codex` CLI installed and on your `PATH` (`npm install -g @openai/codex`).
+- An `OPENAI_API_KEY` in the environment. The CLI authenticates with this key directly.
+- Optionally set `CODEX_MODEL` to choose the model (defaults to `o4-mini`).
+
+## How it works
+
+The template spawns the CLI in JSON-event mode and writes the prompt to stdin:
+
+```python
+cmd = [
+    "codex", "exec", "--json",
+    "--skip-git-repo-check",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "--model", model,
+    "-",  # read the prompt from stdin
+]
+process = await asyncio.create_subprocess_exec(
+    *cmd,
+    stdin=asyncio.subprocess.PIPE,
+    stdout=asyncio.subprocess.PIPE,
+    stderr=asyncio.subprocess.DEVNULL,
+    env={**os.environ},
+)
+```
+
+`--dangerously-bypass-approvals-and-sandbox` skips the CLI's interactive approval prompts, which is required when running headless in a server. `CodexTurn(events, model=..., duration_ms=..., cost_usd=...)` wraps the iterator of stdout events. The tap `convert_codex_to_agentex_events` converts the codex events into the canonical stream and exposes a `session_id` (the codex `thread_id`) for resuming a conversation with `codex exec resume <thread_id>`.
+
+Codex does not report wall-clock time in its event stream, so set `turn.duration_ms` yourself after the stream finishes if you want it in usage.
+
+## Sync delivery (HTTP yield)
+
+```python
+import time
+import agentex.lib.adk as adk
+from agentex.lib.adk import UnifiedEmitter, CodexTurn
+
+@acp.on_message_send
+async def handle_message_send(params: SendMessageParams):
+    task_id = params.task.id
+    start_ms = int(time.monotonic() * 1000)
+    async with adk.tracing.span(
+        trace_id=task_id, task_id=task_id, name="message",
+        input={"message": user_message},
+        data={"__span_type__": "AGENT_WORKFLOW"},
+    ) as turn_span:
+        process = await _spawn_codex(MODEL)
+        process.stdin.write(user_message.encode("utf-8"))
+        await process.stdin.drain()
+        process.stdin.close()
+
+        turn = CodexTurn(events=_process_stdout(process), model=MODEL)
+        emitter = UnifiedEmitter(
+            task_id=task_id, trace_id=task_id,
+            parent_span_id=turn_span.id if turn_span else None,
+        )
+        try:
+            async for event in emitter.yield_turn(turn):
+                yield event
+        finally:
+            if process.returncode is None:
+                process.kill()
+            await process.wait()
+        turn.duration_ms = int(time.monotonic() * 1000) - start_ms
+```
+
+## Async and Temporal delivery
+
+For Async-base and Temporal agents the body is the same, except you call `auto_send_turn` instead of `yield_turn`. Under Temporal, run the subprocess inside an activity and pass `created_at=workflow.now()`; pass the stored `thread_id` to resume the codex session across turns:
+
+```python
+result = await emitter.auto_send_turn(turn, created_at=workflow.now())
+# result.final_text, result.usage; persist turn.session_id to resume next turn
+```
+
+Always tear the subprocess down in a `finally` block so a cancelled or failed turn does not leak a `codex` process.
+
+## See also
+
+- [Unified Harness Surface](streaming_patterns.md#unified-harness-surface-framework-agents)
+- [Observability & Tracing](observability_and_tracing.md)
+- [Codex starter tutorials](tutorials.md) (Sync, Async-base, Temporal)
+- [Claude Code Agents](claude_code_agents.md) for the Anthropic coding CLI equivalent

--- a/agentex/docs/docs/development_guides/codex_agents.md
+++ b/agentex/docs/docs/development_guides/codex_agents.md
@@ -38,9 +38,12 @@ Codex does not report wall-clock time in its event stream, so set `turn.duration
 ## Sync delivery (HTTP yield)
 
 ```python
+import os
 import time
 import agentex.lib.adk as adk
 from agentex.lib.adk import UnifiedEmitter, CodexTurn
+
+MODEL = os.environ.get("CODEX_MODEL", "o4-mini")
 
 @acp.on_message_send
 async def handle_message_send(params: SendMessageParams):

--- a/agentex/docs/docs/development_guides/local_sandbox.md
+++ b/agentex/docs/docs/development_guides/local_sandbox.md
@@ -43,7 +43,7 @@ def create_agent() -> SandboxAgent:
 
 def create_run_config() -> RunConfig:
     return RunConfig(
-        sandbox=Sandbox(
+        sandbox=SandboxRunConfig(
             client=UnixLocalSandboxClient(),
             options=UnixLocalSandboxClientOptions(),
         ),

--- a/agentex/docs/docs/development_guides/local_sandbox.md
+++ b/agentex/docs/docs/development_guides/local_sandbox.md
@@ -1,0 +1,68 @@
+# OpenAI Agents SDK + Local Sandbox
+
+The **Local Sandbox** variant is the OpenAI Agents SDK starter wired to run tool calls inside the OpenAI Agents SDK's local (`unix_local`) sandbox. Instead of registering hand-written Python functions as tools, you grant the agent **capabilities** (for example `Shell`) and the SDK runtime turns them into real tools that execute on the host machine where the agent runs. No Docker, Kubernetes, or remote sandbox is involved.
+
+Scaffold one with `agentex init` and pick **Sync ACP + OpenAI Agents SDK + Local Sandbox**. It shares the same harness wiring and tutorial base as the plain [OpenAI Agents SDK](tutorials.md#sync-acp-simple-agents) starter; there is no separate tutorial for it.
+
+## When to use it
+
+- Local development and quick prototyping where an agent needs real shell access (run a command, inspect the filesystem, check a version) without standing up container infrastructure.
+- Lightweight agents that introspect the host environment.
+
+Reach for a **remote** sandbox (`DockerSandboxClient`, `K8sSandboxClient`) instead when you need filesystem isolation, resource limits, or a production-grade security boundary. The local sandbox runs commands on the host with no isolation.
+
+## Prerequisites
+
+- A **Unix** host (Linux or macOS). The `unix_local` sandbox raises `ImportError` on Windows; use a remote sandbox there.
+- `LITELLM_API_KEY` (or `OPENAI_API_KEY`) in the environment. The template copies `LITELLM_API_KEY` into `OPENAI_API_KEY` for SDK compatibility when only the former is set.
+
+## How it differs from the plain OpenAI Agents starter
+
+| | Plain `sync-openai-agents` | `sync-openai-agents-local-sandbox` |
+|---|---|---|
+| Agent class | `Agent` | `SandboxAgent` |
+| Tools | hand-written `@function_tool` functions | `capabilities=[Shell(), ...]` converted by the runtime |
+| Execution | your Python functions | real shell commands on the host via `UnixLocalSandboxClient` |
+
+## How it works
+
+The scaffold splits across three files: `acp.py` (the ACP handler), `agent.py` (the agent and run config), and `tools.py` (the capability list). The agent is built with capabilities, and a `RunConfig` points the runner at the local sandbox backend:
+
+```python
+# tools.py
+def get_capabilities() -> list:
+    return [Shell()]  # add Filesystem(), Memory(), etc. as needed
+
+# agent.py
+def create_agent() -> SandboxAgent:
+    return SandboxAgent(
+        model="gpt-4o-mini",
+        instructions="Use your shell tools to answer; do not guess.",
+        capabilities=get_capabilities(),
+    )
+
+def create_run_config() -> RunConfig:
+    return RunConfig(
+        sandbox=Sandbox(
+            client=UnixLocalSandboxClient(),
+            options=UnixLocalSandboxClientOptions(),
+        ),
+    )
+
+async def run_agent(user_message: str) -> str:
+    result = await Runner.run(
+        create_agent(), user_message,
+        run_config=create_run_config(), max_turns=10,
+    )
+    return result.final_output
+```
+
+When the model decides to run a command, the OpenAI Agents SDK tool loop calls the sandbox session's `exec` (or `read`/`write` for filesystem capabilities) on the host and feeds the output back to the model. You never call the sandbox client directly.
+
+The ACP handler is the standard sync pattern: it runs the agent and returns a single `TextContent`. Because `Runner.run` returns one final answer rather than a token stream, this variant ships as a Sync ACP agent.
+
+## See also
+
+- [Choose Your Agent Type](../getting_started/choose_your_agent_type.md#pick-a-framework-harness)
+- [OpenAI Agents SDK starter tutorials](tutorials.md#sync-acp-simple-agents)
+- [Temporal OpenAI Agents Integration](../temporal_development/openai_integration.md) for the durable, tool-rich path

--- a/agentex/docs/docs/development_guides/observability_and_tracing.md
+++ b/agentex/docs/docs/development_guides/observability_and_tracing.md
@@ -1,0 +1,90 @@
+# Observability & Tracing
+
+Agentex derives tracing spans **automatically** from the canonical message stream. When you deliver a turn through the [unified harness](streaming_patterns.md#unified-harness-surface-framework-agents), the `UnifiedEmitter` watches the same `StreamTaskMessage*` events it sends to the client and opens/closes tool and reasoning spans as a side effect. There is no per-framework tracing handler to wire up (the old `create_<framework>_tracing_handler` helpers have been removed).
+
+## How spans are derived
+
+The emitter runs a small reducer (`SpanDeriver`) over the canonical stream and emits span signals that a `SpanTracer` turns into `adk.tracing` child spans:
+
+- **Tool spans** open when a `ToolRequestContent` index completes and close on the matching `ToolResponseContent`, paired by `tool_call_id`. The span carries the tool arguments as input and the tool result as output, and records `is_error` when the framework reports a failure.
+- **Reasoning spans** open on the `Start` of a `ReasoningContent` block and close on that index's `Done`.
+
+Because derivation reads the canonical stream rather than any framework-specific event shape, every harness framework (LangGraph, Pydantic AI, OpenAI Agents, Claude Code, Codex) gets the same spans for free.
+
+## The three tracing modes
+
+`UnifiedEmitter` accepts a `tracer` argument that selects how tracing behaves:
+
+| `tracer=` value | Behavior |
+|---|---|
+| `None` (default) | Auto-construct a `SpanTracer` when `trace_id` is set. This is the normal path. |
+| `False` | Disable span derivation entirely, even when `trace_id` is set. |
+| a `SpanTracer` instance | Use the tracer you supply (useful for tests or a custom backend). |
+
+```python
+from agentex.lib.core.harness import UnifiedEmitter
+
+# Default: tracing on whenever trace_id is present.
+emitter = UnifiedEmitter(task_id=task_id, trace_id=task_id, parent_span_id=None)
+
+# Off: deliver the turn but derive no spans.
+emitter = UnifiedEmitter(task_id=task_id, trace_id=task_id, parent_span_id=None, tracer=False)
+```
+
+## Nesting derived spans under a turn span
+
+Derived tool and reasoning spans are leaves. To group them under a single parent for each turn, open a span with the `adk.tracing.span` context manager and pass its id as `parent_span_id`:
+
+```python
+import agentex.lib.adk as adk
+from agentex.lib.adk import UnifiedEmitter, LangGraphTurn
+
+async with adk.tracing.span(
+    trace_id=task_id, task_id=task_id, name="message",
+    input={"message": user_message},
+    data={"__span_type__": "AGENT_WORKFLOW"},
+) as turn_span:
+    emitter = UnifiedEmitter(
+        task_id=task_id, trace_id=task_id,
+        parent_span_id=turn_span.id if turn_span else None,
+    )
+    turn = LangGraphTurn(graph.astream(...))
+    async for event in emitter.yield_turn(turn):
+        yield event
+
+    if turn_span:
+        turn_span.output = {"final_output": turn.usage().model_dump()}
+```
+
+Use `adk.tracing.span` for spans the stream cannot infer (the top-level turn, sub-agent calls, custom business logic). Let the emitter handle tool and reasoning spans.
+
+## Turn usage
+
+Both delivery calls expose normalized usage. `auto_send_turn` returns a `TurnResult` with `final_text` and a `usage` object; for `yield_turn`, read `turn.usage()` after the stream is exhausted. `TurnUsage` carries `model`, `input_tokens`, `output_tokens`, `cached_input_tokens`, `reasoning_tokens`, `total_tokens`, `cost_usd`, `duration_ms`, `num_llm_calls`, `num_tool_calls`, and `num_reasoning_blocks`.
+
+## Sending spans to Scale GenAI Platform
+
+Span derivation produces spans; **tracing processors** decide where they go. Register a processor once at module load time (before any request is handled) and every derived span fans out to it:
+
+```python
+import os
+from agentex.lib.core.tracing.tracing_processor_manager import add_tracing_processor_config
+from agentex.lib.types.tracing import SGPTracingProcessorConfig
+
+add_tracing_processor_config(
+    SGPTracingProcessorConfig(
+        sgp_api_key=os.environ.get("SGP_API_KEY", ""),
+        sgp_account_id=os.environ.get("SGP_ACCOUNT_ID", ""),
+        sgp_base_url=os.environ.get("SGP_CLIENT_BASE_URL", ""),
+    )
+)
+```
+
+With a processor registered and `trace_id` set on the emitter, tool and reasoning spans appear in the SGP traces UI with no further wiring. To run an agent without emitting spans, either omit the processor or construct the emitter with `tracer=False`.
+
+## Key takeaways
+
+- Tool and reasoning spans are derived from the canonical stream automatically; no per-framework tracing handler.
+- `tracer=None` traces when `trace_id` is set, `tracer=False` disables, a `SpanTracer` instance customizes.
+- Pass `parent_span_id` from an `adk.tracing.span` to nest derived spans under a turn span.
+- Register an `SGPTracingProcessorConfig` once at module load to ship spans to Scale GenAI Platform.

--- a/agentex/docs/mkdocs.yml
+++ b/agentex/docs/mkdocs.yml
@@ -69,6 +69,11 @@ nav:
       - Tutorials: development_guides/tutorials.md
       - Jupyter Notebooks (dev.ipynb): development_guides/jupyter_notebooks.md
       - Streaming Patterns: development_guides/streaming_patterns.md
+      - Observability & Tracing: development_guides/observability_and_tracing.md
+      - Framework Agents:
+          - Claude Code: development_guides/claude_code_agents.md
+          - Codex: development_guides/codex_agents.md
+          - OpenAI Local Sandbox: development_guides/local_sandbox.md
       - Race Conditions: development_guides/race_conditions.md
       - Message Handling: development_guides/message_handling.md
       - Events vs Messages: development_guides/events_vs_messages.md

--- a/agentex/docs/requirements.txt
+++ b/agentex/docs/requirements.txt
@@ -5,7 +5,7 @@
 #
 # agentex-sdk floats by design (docs track the latest SDK release); the mkdocs
 # toolchain is pinned for reproducible builds — Dependabot keeps the pins current.
-agentex-sdk>=0.12.0
+agentex-sdk>=0.15.0
 
 mkdocs==1.6.1
 mkdocs-material==9.7.6


### PR DESCRIPTION
## Summary

Follow-up to #337. That PR documented the unified harness surface; this one fills the doc gaps for SDK capabilities that ship today but had no page yet. Stacked on `declan-scale/docs-unified-harness` because it cross-links the harness section introduced there.

## New pages (all under Development Guides in the nav)

- **Observability & Tracing** (`development_guides/observability_and_tracing.md`) — how `UnifiedEmitter` derives tool/reasoning spans from the canonical stream via `SpanDeriver`/`SpanTracer`, the three `tracer=` modes (auto / `False` / custom), nesting derived spans under an `adk.tracing.span`, `TurnUsage` fields, and registering an `SGPTracingProcessorConfig`.
- **Claude Code Agents** (`development_guides/claude_code_agents.md`) — wrapping the `claude` CLI subprocess in a `ClaudeCodeTurn` and delivering via `UnifiedEmitter`, sync + async/Temporal, prerequisites (`claude` on PATH, `ANTHROPIC_API_KEY`).
- **Codex Agents** (`development_guides/codex_agents.md`) — the OpenAI coding-CLI equivalent with `CodexTurn`, `codex exec --json`, session resume, `OPENAI_API_KEY` / `CODEX_MODEL`.
- **OpenAI Local Sandbox** (`development_guides/local_sandbox.md`) — the `SandboxAgent` capabilities model, host execution via `UnixLocalSandboxClient`, Unix-only constraint, and when to choose local vs a remote sandbox. Resolves the open question from #337's review about the Local Sandbox init option.

## Verification

- `mkdocs build` runs clean (as CI does). No new link warnings reference any of the four new pages, so all cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds documentation for tracing and several framework-agent guides. The main changes are:

- New guides for Claude Code and Codex CLI agents.
- A new OpenAI Local Sandbox guide.
- A new Observability & Tracing guide for unified harness spans.
- Navigation updates for the new Development Guides pages.
- A docs dependency floor update for `agentex-sdk`.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The documentation content is mostly self-contained, but the docs dependency change can prevent the docs build from installing its environment.

The changed guide pages and navigation are straightforward, while the dependency floor introduces a concrete build-blocking risk in the docs setup.

agentex/docs/requirements.txt
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a clean Python virtual environment and attempted a docs dependency install; pip failed before MkDocs due to no matching distribution found for agentex-sdk\>=0.15.0.
- Tried a Python 3.12-targeted pip resolver; it reported agentex-sdk versions only up to 0.14.0 and could not satisfy \>=0.15.0.
- Attempted the exact python3.12 virtualenv path, but this runner does not have python3.12 installed.
- Validated the docs-guides navigation status before and after the changes, confirming the baseline had nav=False and file\_exists=False for all four routes, and the head revision had nav=True and file\_exists=True for all four routes.

<a href="https://app.greptile.com/trex/runs/12205257/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **New SDK guides document framework harness APIs that are absent from the published SDK surface**

   - **Bug**
     - The new Development Guides instruct users to import and use `UnifiedEmitter`, `ClaudeCodeTurn`, and `CodexTurn` from `agentex.lib.adk`, and `UnifiedEmitter` from `agentex.lib.core.harness`. Installing the docs-declared SDK dependency (`agentex-sdk==0.12.0`, the latest available version) and importing those paths shows `agentex.lib.adk` is importable only after a Python 3.11 compatibility shim but does not export `UnifiedEmitter`, `ClaudeCodeTurn`, or `CodexTurn`; `agentex.lib.core.harness` is not importable at all. This makes the newly added guides direct users to non-shipped APIs.
   - **Cause**
     - The documentation added in `agentex/docs/docs/development_guides/observability_and_tracing.md`, `claude_code_agents.md`, and `codex_agents.md` appears to describe SDK surfaces that are not present in the published `agentex-sdk` version consumed by the docs build requirements (`agentex-sdk>=0.12.0`).
   - **Fix**
     - Update the guides to use import paths/classes that are actually exported by the shipped SDK, or publish/update the SDK and docs requirements so `UnifiedEmitter`, `ClaudeCodeTurn`, `CodexTurn`, and the documented harness module paths are available before merging these docs.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Docs build is not buildable in the available environment after pinning agentex-sdk=0.14.0**

   - **Bug**
     - At head, the docs fallback build cannot install `agentex/docs/requirements.txt` with the available Python 3.11.6 because `agentex-sdk>=0.14.0` has no compatible distribution for that interpreter. As a result, the docs site is not buildable in this runtime and the generated HTML pages for the four new Development Guides entries are absent. The documented `make build-docs` command also cannot run here because `uv` is not installed, but the same-command fallback demonstrates the head-specific dependency failure.
   - **Cause**
     - `agentex/docs/requirements.txt` now requires `agentex-sdk>=0.14.0`, whose available releases require Python >=3.12, while this validation environment only has Python 3.11.6. The docs build command does not bootstrap a compatible Python interpreter when `uv` is unavailable.
   - **Fix**
     - Either ensure the documented docs build path provisions Python 3.12/uv reliably, or constrain/docs-pin dependencies so the docs build works with the supported validation/runtime Python. If Python 3.12 is required for docs, document and enforce that prerequisite in the build instructions/CI image.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Three claimed new pages are not present as direct Development Guides nav entries**

   - **Bug**
     - At head, `mkdocs.yml` contains `Observability & Tracing` and a nested `Framework Agents` group with `Claude Code`, `Codex`, and `OpenAI Local Sandbox`. The validation expected four claimed pages/nav entries under Development Guides: `Claude Code Agents`, `Codex Agents`, `Local Sandbox`, and `Observability and Tracing`. The source files exist, but the literal claimed nav entries are not present for three of the four pages, and the build failure prevents confirming the rendered navigation.
   - **Cause**
     - `agentex/docs/mkdocs.yml` adds shortened/nested labels (`Claude Code`, `Codex`, `OpenAI Local Sandbox`, `Observability & Tracing`) rather than the claimed page names as direct Development Guides entries.
   - **Fix**
     - Update `agentex/docs/mkdocs.yml` to match the promised navigation contract, or update the PR contract to explicitly state that the pages are nested under `Development Guides > Framework Agents` with the shorter labels.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fdocs%2Frequirements.txt%3A8%0A**Docs%20dependency%20blocks%20builds**%0A%0ARaising%20the%20docs%20dependency%20to%20%60agentex-sdk%3E%3D0.15.0%60%20makes%20the%20isolated%20docs%20environment%20fail%20dependency%20resolution.%20The%20docs%20CI%20job%20installs%20this%20file%20under%20Python%203.12%20before%20running%20%60mkdocs%20build%60%2C%20but%20the%20package%20index%20available%20to%20that%20job%20currently%20resolves%20%60agentex-sdk%60%20only%20through%20%600.14.0%60%20for%20Python%203.12.%20When%20this%20requirement%20is%20installed%2C%20the%20build%20fails%20before%20MkDocs%20starts.%20Publish%20%600.15.0%60%20to%20the%20CI%20package%20index%20first%2C%20or%20keep%20the%20requirement%20at%20the%20latest%20available%20version.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex/docs/requirements.txt:8
**Docs dependency blocks builds**

Raising the docs dependency to `agentex-sdk>=0.15.0` makes the isolated docs environment fail dependency resolution. The docs CI job installs this file under Python 3.12 before running `mkdocs build`, but the package index available to that job currently resolves `agentex-sdk` only through `0.14.0` for Python 3.12. When this requirement is installed, the build fails before MkDocs starts. Publish `0.15.0` to the CI package index first, or keep the requirement at the latest available version.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["docs(guides): pin docs SDK to &gt;=0.15.0 a..."](https://github.com/scaleapi/scale-agentex/commit/f5955364cff00912e9dd4e7e579727d1f69b4662) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39627553)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->