### PR TITLE
fix(schedules): backfill agent_run_schedules deleted_at/version on early-deployed envs

### DIFF
--- a/agentex/database/migrations/alembic/versions/2026_06_29_1930_backfill_agent_run_schedules_soft_delete_columns_e7f8a9b0c1d2.py
+++ b/agentex/database/migrations/alembic/versions/2026_06_29_1930_backfill_agent_run_schedules_soft_delete_columns_e7f8a9b0c1d2.py
@@ -1,0 +1,47 @@
+"""backfill agent_run_schedules deleted_at/version columns
+
+Revision ID: e7f8a9b0c1d2
+Revises: 3b1c9d2e4f6a
+Create Date: 2026-06-29 19:30:00.000000
+
+Forward-fix for environments where revision 3b1c9d2e4f6a ran in an *earlier*
+form of its file, before ``deleted_at`` and ``version`` were added to its
+``create_table``. Those environments have the table stamped at 3b1c9d2e4f6a but
+are missing the two columns, so the ORM (which selects both) fails with
+``UndefinedColumnError``. Per the repo migration policy we do not rewrite the
+already-applied revision; we add the columns here, idempotently.
+
+Schema-only and idempotent: ``ADD COLUMN IF NOT EXISTS`` is a no-op on
+environments that ran the final ``create_table`` (columns already present) and
+repairs the ones that didn't. Both columns add with a constant/non-volatile
+default (or are nullable), so on modern Postgres this is a metadata-only change
+with no table rewrite.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e7f8a9b0c1d2"
+down_revision: str | None = "3b1c9d2e4f6a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Soft-delete marker: NULL = active, set = tombstoned for audit.
+    op.execute(
+        "ALTER TABLE agent_run_schedules "
+        "ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE"
+    )
+    # Monotonic record version reserved for future optimistic concurrency.
+    op.execute(
+        "ALTER TABLE agent_run_schedules "
+        "ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agent_run_schedules DROP COLUMN IF EXISTS version")
+    op.execute("ALTER TABLE agent_run_schedules DROP COLUMN IF EXISTS deleted_at")

--- a/agentex/database/migrations/alembic/versions/2026_06_29_1930_backfill_agent_run_schedules_soft_delete_columns_e7f8a9b0c1d2.py
+++ b/agentex/database/migrations/alembic/versions/2026_06_29_1930_backfill_agent_run_schedules_soft_delete_columns_e7f8a9b0c1d2.py
@@ -43,5 +43,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute("ALTER TABLE agent_run_schedules DROP COLUMN IF EXISTS version")
-    op.execute("ALTER TABLE agent_run_schedules DROP COLUMN IF EXISTS deleted_at")
+    # Intentionally a no-op. ``deleted_at`` and ``version`` belong to the final
+    # form of the parent revision (3b1c9d2e4f6a); this revision only re-adds them
+    # where that revision ran in an earlier form that omitted them. Because we
+    # cannot tell whether this migration or the parent created the columns,
+    # dropping them on downgrade would strip parent-owned columns from
+    # environments that created the table whole — reintroducing the
+    # UndefinedColumnError this migration exists to fix. So we leave them in place.
+    pass


### PR DESCRIPTION
## What

Adds a follow-up Alembic revision (`e7f8a9b0c1d2`, child of `3b1c9d2e4f6a`) that adds the `deleted_at` and `version` columns to `agent_run_schedules` with `ADD COLUMN IF NOT EXISTS`.

## Why

Revision `3b1c9d2e4f6a` (the `agent_run_schedules` create_table) was amended **after** it had already been applied in some environments — `deleted_at` and `version` were added to its `create_table` after the fact. Alembic tracks applied revisions by id, not by content, so any environment already stamped at `3b1c9d2e4f6a` never re-runs the revision and never picks up the added columns. The ORM selects both columns, so reads fail with:

```
asyncpg.exceptions.UndefinedColumnError: column agent_run_schedules.deleted_at does not exist
```

Environments that first applied the **final** `create_table` (i.e. created the table in one shot with all columns) are unaffected.

## Fix

A new revision is the only thing Alembic will execute on already-stamped environments. It adds both columns idempotently:

- no-op where `create_table` already created them (healthy envs)
- repair where it didn't (envs that ran an earlier form of `3b1c9d2e4f6a`)

Schema-only and metadata-cheap — both columns add with a constant/non-volatile default (or nullable), so no table rewrite and no backfill. Passes the migration linter (`no findings`).

## Notes

- Does **not** edit `3b1c9d2e4f6a` — editing an already-applied revision does nothing for the environments that already ran it.
- The stray `initial_input_method` column (dropped from the revision in a later edit) may persist as an unused, harmless extra column on early-deploy envs; the ORM doesn't reference it, so it's left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the follow-up migration for `agent_run_schedules` repair columns. The main changes are:

- Adds `deleted_at` when missing on early-deployed databases.
- Adds `version` with a default of `1` when missing.
- Makes the downgrade a no-op so parent-owned columns are not removed.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: the migration is narrowly scoped, idempotent for already-healthy databases, and avoids destructive downgrade behavior.

The change adds only missing repair columns with guarded DDL and leaves existing parent-owned schema intact, matching the described Alembic recovery scenario.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the base state to confirm the migration file was absent and the schema lacked deleted\_at and version before the upgrade.
- Validated the head revision e7f8a9b0c1d2, which has down\_revision 3b1c9d2e4f6a, and confirmed it executes ALTER TABLE agent\_run\_schedules ADD COLUMN IF NOT EXISTS for deleted\_at TIMESTAMP WITH TIME ZONE and version INTEGER NOT NULL DEFAULT 1 to repair the missing-column schema while preserving an already-healthy schema (PRESERVED: True).
- Inspected the log artifacts captured during the migration run to verify the before and after states.

<a href="https://app.greptile.com/trex/runs/12688641/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(schedules): make backfill migration ..."](https://github.com/scaleapi/scale-agentex/commit/9e7f28b10fab3efd10c5fc990fb3ff4b835d1826) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40634565)</sub>

<!-- /greptile_comment -->