### PR TITLE
fix: forward event request context to agents

### DIFF
--- a/agentex/src/domain/services/agent_acp_service.py
+++ b/agentex/src/domain/services/agent_acp_service.py
@@ -271,20 +271,33 @@ class AgentACPService(TaskMessageMixin):
             agent_identity=getattr(state, "agent_identity", None),
         )
 
+    def get_request_context_headers(
+        self,
+        agent: AgentEntity,
+        request_headers: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        """Headers safe to expose to agent handler request context."""
+        filtered_request_headers = filter_request_headers(request_headers)
+        delegation_headers = self.get_delegation_headers(agent)
+        return {
+            **filtered_request_headers,
+            **delegation_headers,
+        }
+
     async def get_headers(
         self,
         agent: AgentEntity,
         request_headers: dict[str, str] | None = None,
     ) -> dict[str, str]:
-        filtered_request_headers = filter_request_headers(request_headers)
-        delegation_headers = self.get_delegation_headers(agent)
+        request_context_headers = self.get_request_context_headers(
+            agent, request_headers
+        )
         auth_headers = await self.get_agent_auth_headers(agent)
         request_id = ctx_var_request_id.get(uuid4().hex)
 
         # Later keys win. Client passthrough and delegation first; agent auth last.
         return {
-            **filtered_request_headers,
-            **delegation_headers,
+            **request_context_headers,
             **auth_headers,
             "x-request-id": request_id,
         }
@@ -420,12 +433,15 @@ class AgentACPService(TaskMessageMixin):
         request_headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Send an event to a running task"""
+        request_context_headers = self.get_request_context_headers(
+            agent, request_headers
+        )
 
         params = SendEventParams(
             agent=agent,
             task=task,
             event=event,
-            request=None,
+            request={"headers": request_context_headers},
         )
 
         headers = await self.get_headers(agent, request_headers)

--- a/agentex/tests/unit/services/test_agent_acp_service.py
+++ b/agentex/tests/unit/services/test_agent_acp_service.py
@@ -333,10 +333,84 @@ class TestAgentACPService:
             },
         )
 
-        http_headers = mock_http_gateway.async_call.call_args[1]["default_headers"]
+        call_args = mock_http_gateway.async_call.call_args
+        payload = call_args[1]["payload"]
+        request_context_headers = payload["params"]["request"]["headers"]
+        assert request_context_headers["x-acting-user-api-key"] == "user-delegation-key"
+        assert request_context_headers["x-trace-id"] == "trace-456"
+        assert "x-api-key" not in request_context_headers
+        assert "x-agent-api-key" not in request_context_headers
+
+        http_headers = call_args[1]["default_headers"]
         assert http_headers["x-acting-user-api-key"] == "user-delegation-key"
         assert http_headers["x-trace-id"] == "trace-456"
         assert "x-api-key" not in http_headers
+
+    async def test_send_event_request_context_exposes_delegated_headers_not_agent_auth(
+        self,
+        mock_http_gateway,
+        mock_request,
+        sample_agent,
+        sample_task,
+        sample_event,
+    ):
+        """EVENT_SEND params.request exposes user delegation, not agent auth."""
+        mock_request.state.principal_context = type(
+            "Principal",
+            (),
+            {"user_id": "user-1", "account_id": "acct-1"},
+        )()
+        mock_request.state.agent_identity = None
+        mock_request.headers = {
+            "x-api-key": "user-delegation-key",
+            "x-selected-account-id": "acct-1",
+        }
+        mock_agent_api_key_repository = MagicMock()
+        mock_agent_api_key_repository.get_internal_api_key_by_agent_id = AsyncMock(
+            return_value=MagicMock(api_key="agent-internal-key")
+        )
+        service = AgentACPService(
+            agent_repository=MagicMock(),
+            agent_api_key_repository=mock_agent_api_key_repository,
+            http_gateway=mock_http_gateway,
+            request=mock_request,
+        )
+
+        from src.domain.entities.agents_rpc import AgentRPCMethod
+
+        expected_request_id = f"{AgentRPCMethod.EVENT_SEND}-{sample_task.id}"
+        mock_http_gateway.async_call.return_value = {
+            "jsonrpc": "2.0",
+            "result": {"status": "event_sent", "event_id": sample_event.id},
+            "id": expected_request_id,
+        }
+
+        await service.send_event(
+            agent=sample_agent,
+            event=sample_event,
+            task=sample_task,
+            acp_url="http://test-acp.example.com",
+            request_headers={
+                "x-api-key": "must-not-forward",
+                "x-trace-id": "trace-456",
+            },
+        )
+
+        call_args = mock_http_gateway.async_call.call_args
+        request_context_headers = call_args[1]["payload"]["params"]["request"][
+            "headers"
+        ]
+        assert request_context_headers == {
+            "x-trace-id": "trace-456",
+            "x-acting-user-api-key": "user-delegation-key",
+            "x-selected-account-id": "acct-1",
+        }
+        assert "x-api-key" not in request_context_headers
+        assert "x-agent-api-key" not in request_context_headers
+
+        http_headers = call_args[1]["default_headers"]
+        assert http_headers["x-agent-api-key"] == "agent-internal-key"
+        assert http_headers["x-acting-user-api-key"] == "user-delegation-key"
 
     async def test_send_message_includes_cookie_delegation_headers(
         self,
@@ -719,12 +793,17 @@ class TestAgentACPService:
 
         call_args = mock_http_gateway.async_call.call_args
         payload = call_args[1]["payload"]
-        assert payload["params"]["request"] is None
+        request_context_headers = payload["params"]["request"]["headers"]
+        assert request_context_headers == {
+            "x-user-id": "user-123",
+            "x-trace-id": "trace-456",
+        }
 
         http_headers = call_args[1]["default_headers"]
         assert http_headers["x-user-id"] == "user-123"
         assert http_headers["x-trace-id"] == "trace-456"
         assert http_headers["x-agent-api-key"] == "test-api-key"
+        assert "x-agent-api-key" not in request_context_headers
         assert "x-api-key" not in http_headers
         assert "user-agent" not in http_headers
         assert "authorization" not in http_headers
@@ -765,14 +844,12 @@ class TestAgentACPService:
         assert result["status"] == "event_sent"
         assert result["event_id"] == sample_event.id
 
-        # Verify call was made and request field is None when headers not provided
+        # Verify request context is present but empty when headers are not provided.
         mock_http_gateway.async_call.assert_called_once()
         call_args = mock_http_gateway.async_call.call_args
         payload = call_args[1]["payload"]
         assert "params" in payload
-        # Request field should be None or not included when headers not provided
-        if "request" in payload["params"]:
-            assert payload["params"]["request"] is None
+        assert payload["params"]["request"] == {"headers": {}}
 
     async def test_jsonrpc_error_handling(
         self,


### PR DESCRIPTION
## Summary
- include safe request context headers in EVENT_SEND JSON-RPC params
- expose Agentex-generated delegated user headers to agent handlers via params.request.headers
- keep x-agent-api-key out of params.request while still sending it as the ACP HTTP auth header

## Why
The lineage supervisor receives EVENT_SEND over Temporal and reads delegated credentials from SendEventParams.request. Agentex was sending the delegated credentials as HTTP headers to the pod, but serialized SendEventParams with request=None, so the workflow could not call /v5/builds with user credentials and hit 401.

## Validation
- python3 -m py_compile agentex/src/domain/services/agent_acp_service.py agentex/tests/unit/services/test_agent_acp_service.py
- uv run ruff check agentex/src/domain/services/agent_acp_service.py agentex/tests/unit/services/test_agent_acp_service.py
- uv run ruff format --check agentex/src/domain/services/agent_acp_service.py agentex/tests/unit/services/test_agent_acp_service.py
- uv run --group test pytest tests/unit/services/test_agent_acp_service.py::TestAgentACPService::test_send_event_request_context_exposes_delegated_headers_not_agent_auth -q

Note: the full test_agent_acp_service.py file requires Docker/testcontainers locally; Docker is not available on this machine, so the full file could not complete here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 401 error in the lineage supervisor by forwarding the Agentex-generated delegated user headers into `SendEventParams.request.headers` so that the Temporal workflow can read them when calling downstream APIs with user credentials.

- **Service refactor**: `get_request_context_headers` is extracted as a new synchronous method returning the safe subset of headers (filtered passthrough + delegation, excluding `x-agent-api-key`); `get_headers` now delegates to it before adding auth headers on top.
- **`send_event` fix**: `params.request` is now populated with `{"headers": request_context_headers}` instead of `None`, making delegated credentials available to the serialized `SendEventParams` that Temporal reads.
- **Tests**: Existing tests updated to assert `params.request.headers` is present; a new isolated unit test (no Docker dependency) verifies agent auth key is kept out of `params.request` while still reaching the agent pod as an HTTP header.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix is narrow and well-tested, credentials are correctly segregated between params and HTTP headers.

The logic is sound: x-agent-api-key stays out of params.request while delegation headers flow into both the JSON-RPC body and the HTTP headers. The only nit is that get_request_context_headers is computed twice inside send_event (once explicitly, once inside get_headers), which is wasteful but harmless since request state is immutable per call.

agentex/src/domain/services/agent_acp_service.py — the double-computation of context headers in send_event is worth a quick look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/services/agent_acp_service.py | Extracts get_request_context_headers (sync) from get_headers (async) and populates SendEventParams.request with safe delegation headers; get_request_context_headers is called twice in send_event (once directly, once inside get_headers) — minor redundancy but no correctness impact. |
| agentex/tests/unit/services/test_agent_acp_service.py | Tests updated and extended to assert params.request.headers is now populated; new isolated unit test (no Docker) covers the agent-auth-key exclusion invariant clearly. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant AgentACPService
    participant get_request_context_headers
    participant get_headers
    participant AgentPod

    Caller->>AgentACPService: send_event(agent, event, task, request_headers)
    AgentACPService->>get_request_context_headers: filter passthrough + delegation headers
    get_request_context_headers-->>AgentACPService: request_context_headers (no agent-api-key)
    Note over AgentACPService: Build SendEventParams<br/>params.request.headers = request_context_headers
    AgentACPService->>get_headers: get_headers(agent, request_headers)
    Note over get_headers: re-calls get_request_context_headers internally
    get_headers-->>AgentACPService: request_context_headers + x-agent-api-key + x-request-id
    AgentACPService->>AgentPod: "POST /api (JSON-RPC EVENT_SEND)<br/>HTTP headers: delegation + x-agent-api-key<br/>params.request.headers: delegation only (no x-agent-api-key)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant AgentACPService
    participant get_request_context_headers
    participant get_headers
    participant AgentPod

    Caller->>AgentACPService: send_event(agent, event, task, request_headers)
    AgentACPService->>get_request_context_headers: filter passthrough + delegation headers
    get_request_context_headers-->>AgentACPService: request_context_headers (no agent-api-key)
    Note over AgentACPService: Build SendEventParams<br/>params.request.headers = request_context_headers
    AgentACPService->>get_headers: get_headers(agent, request_headers)
    Note over get_headers: re-calls get_request_context_headers internally
    get_headers-->>AgentACPService: request_context_headers + x-agent-api-key + x-request-id
    AgentACPService->>AgentPod: "POST /api (JSON-RPC EVENT_SEND)<br/>HTTP headers: delegation + x-agent-api-key<br/>params.request.headers: delegation only (no x-agent-api-key)"
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Fdomain%2Fservices%2Fagent_acp_service.py%3A436-447%0A%60get_request_context_headers%60%20is%20called%20twice%20in%20%60send_event%60%20%E2%80%94%20once%20explicitly%2C%20and%20again%20inside%20%60get_headers%60.%20Both%20calls%20invoke%20%60get_delegation_headers%60%2C%20which%20re-reads%20%60self._request.state%60%20and%20re-runs%20%60build_delegation_headers%60.%20The%20result%20is%20identical%20both%20times%2C%20so%20there%20is%20no%20correctness%20issue%2C%20but%20the%20double%20work%20is%20avoidable%20by%20passing%20the%20already-computed%20headers%20into%20%60get_headers%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20request_context_headers%20%3D%20self.get_request_context_headers%28%0A%20%20%20%20%20%20%20%20%20%20%20%20agent%2C%20request_headers%0A%20%20%20%20%20%20%20%20%29%0A%0A%20%20%20%20%20%20%20%20params%20%3D%20SendEventParams%28%0A%20%20%20%20%20%20%20%20%20%20%20%20agent%3Dagent%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20task%3Dtask%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20event%3Devent%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20request%3D%7B%22headers%22%3A%20request_context_headers%7D%2C%0A%20%20%20%20%20%20%20%20%29%0A%0A%20%20%20%20%20%20%20%20auth_headers%20%3D%20await%20self.get_agent_auth_headers%28agent%29%0A%20%20%20%20%20%20%20%20request_id%20%3D%20ctx_var_request_id.get%28uuid4%28%29.hex%29%0A%20%20%20%20%20%20%20%20headers%20%3D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20**request_context_headers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20**auth_headers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22x-request-id%22%3A%20request_id%2C%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Fdomain%2Fservices%2Fagent_acp_service.py%3A436-447%0A%60get_request_context_headers%60%20is%20called%20twice%20in%20%60send_event%60%20%E2%80%94%20once%20explicitly%2C%20and%20again%20inside%20%60get_headers%60.%20Both%20calls%20invoke%20%60get_delegation_headers%60%2C%20which%20re-reads%20%60self._request.state%60%20and%20re-runs%20%60build_delegation_headers%60.%20The%20result%20is%20identical%20both%20times%2C%20so%20there%20is%20no%20correctness%20issue%2C%20but%20the%20double%20work%20is%20avoidable%20by%20passing%20the%20already-computed%20headers%20into%20%60get_headers%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20request_context_headers%20%3D%20self.get_request_context_headers%28%0A%20%20%20%20%20%20%20%20%20%20%20%20agent%2C%20request_headers%0A%20%20%20%20%20%20%20%20%29%0A%0A%20%20%20%20%20%20%20%20params%20%3D%20SendEventParams%28%0A%20%20%20%20%20%20%20%20%20%20%20%20agent%3Dagent%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20task%3Dtask%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20event%3Devent%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20request%3D%7B%22headers%22%3A%20request_context_headers%7D%2C%0A%20%20%20%20%20%20%20%20%29%0A%0A%20%20%20%20%20%20%20%20auth_headers%20%3D%20await%20self.get_agent_auth_headers%28agent%29%0A%20%20%20%20%20%20%20%20request_id%20%3D%20ctx_var_request_id.get%28uuid4%28%29.hex%29%0A%20%20%20%20%20%20%20%20headers%20%3D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20**request_context_headers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20**auth_headers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22x-request-id%22%3A%20request_id%2C%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22codex%2Fagentex-forward-event-request-context%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fagentex-forward-event-request-context%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex%2Fsrc%2Fdomain%2Fservices%2Fagent_acp_service.py%3A436-447%0A%60get_request_context_headers%60%20is%20called%20twice%20in%20%60send_event%60%20%E2%80%94%20once%20explicitly%2C%20and%20again%20inside%20%60get_headers%60.%20Both%20calls%20invoke%20%60get_delegation_headers%60%2C%20which%20re-reads%20%60self._request.state%60%20and%20re-runs%20%60build_delegation_headers%60.%20The%20result%20is%20identical%20both%20times%2C%20so%20there%20is%20no%20correctness%20issue%2C%20but%20the%20double%20work%20is%20avoidable%20by%20passing%20the%20already-computed%20headers%20into%20%60get_headers%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20request_context_headers%20%3D%20self.get_request_context_headers%28%0A%20%20%20%20%20%20%20%20%20%20%20%20agent%2C%20request_headers%0A%20%20%20%20%20%20%20%20%29%0A%0A%20%20%20%20%20%20%20%20params%20%3D%20SendEventParams%28%0A%20%20%20%20%20%20%20%20%20%20%20%20agent%3Dagent%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20task%3Dtask%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20event%3Devent%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20request%3D%7B%22headers%22%3A%20request_context_headers%7D%2C%0A%20%20%20%20%20%20%20%20%29%0A%0A%20%20%20%20%20%20%20%20auth_headers%20%3D%20await%20self.get_agent_auth_headers%28agent%29%0A%20%20%20%20%20%20%20%20request_id%20%3D%20ctx_var_request_id.get%28uuid4%28%29.hex%29%0A%20%20%20%20%20%20%20%20headers%20%3D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20**request_context_headers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20**auth_headers%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22x-request-id%22%3A%20request_id%2C%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=scaleapi%2Fscale-agentex&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex/src/domain/services/agent_acp_service.py:436-447
`get_request_context_headers` is called twice in `send_event` — once explicitly, and again inside `get_headers`. Both calls invoke `get_delegation_headers`, which re-reads `self._request.state` and re-runs `build_delegation_headers`. The result is identical both times, so there is no correctness issue, but the double work is avoidable by passing the already-computed headers into `get_headers`.

```suggestion
        request_context_headers = self.get_request_context_headers(
            agent, request_headers
        )

        params = SendEventParams(
            agent=agent,
            task=task,
            event=event,
            request={"headers": request_context_headers},
        )

        auth_headers = await self.get_agent_auth_headers(agent)
        request_id = ctx_var_request_id.get(uuid4().hex)
        headers = {
            **request_context_headers,
            **auth_headers,
            "x-request-id": request_id,
        }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: forward event request context to ag..."](https://github.com/scaleapi/scale-agentex/commit/ef5190b80d972f410d696fdb93d2264b14023499) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42523380)</sub>

<!-- /greptile_comment -->