### PR TITLE
fix(schedules): use stable handles for run schedules

### DIFF
--- a/agentex/database/migrations/alembic/versions/2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py
+++ b/agentex/database/migrations/alembic/versions/2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py
@@ -1,0 +1,46 @@
+"""move run schedule identity to row id
+
+Revision ID: 9a4b8c7d6e5f
+Revises: e7f8a9b0c1d2
+Create Date: 2026-07-08 16:26:00.000000
+
+Switches schedule names from reserved external handles to mutable labels by
+making the name uniqueness constraint apply only to active rows. Schema-only and
+idempotent: index creation/drop use CONCURRENTLY with IF EXISTS / IF NOT EXISTS.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9a4b8c7d6e5f"
+down_revision: str | None = "e7f8a9b0c1d2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            "uq_agent_run_schedules_active_agent_name "
+            "ON agent_run_schedules (agent_id, name) "
+            "WHERE deleted_at IS NULL"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS uq_agent_run_schedules_agent_name"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            "uq_agent_run_schedules_agent_name "
+            "ON agent_run_schedules (agent_id, name)"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "uq_agent_run_schedules_active_agent_name"
+        )

--- a/agentex/database/migrations/alembic/versions/2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py
+++ b/agentex/database/migrations/alembic/versions/2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py
@@ -11,6 +11,7 @@ idempotent: index creation/drop use CONCURRENTLY with IF EXISTS / IF NOT EXISTS.
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -34,6 +35,22 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    connection = op.get_bind()
+    duplicate = connection.execute(
+        sa.text(
+            "SELECT 1 FROM agent_run_schedules "
+            "GROUP BY agent_id, name "
+            "HAVING COUNT(*) > 1 "
+            "LIMIT 1"
+        )
+    ).scalar()
+    if duplicate is not None:
+        raise RuntimeError(
+            "Downgrade is unsafe after schedule name reuse. Clean up duplicate "
+            "(agent_id, name) rows before recreating "
+            "uq_agent_run_schedules_agent_name."
+        )
+
     with op.get_context().autocommit_block():
         op.execute(
             "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -3320,13 +3320,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /agents/{agent_id}/schedules/{name}:
+  /agents/{agent_id}/schedules/name/{name}:
     get:
       tags:
       - Schedules
-      summary: Get Run Schedule
-      description: Get a run schedule by its name.
-      operationId: get_run_schedule_agents__agent_id__schedules__name__get
+      summary: Get Run Schedule By Name
+      description: Get a run schedule by its active name.
+      operationId: get_run_schedule_by_name_agents__agent_id__schedules_name__name__get
       parameters:
       - name: agent_id
         in: path
@@ -3356,10 +3356,9 @@ paths:
     patch:
       tags:
       - Schedules
-      summary: Update Run Schedule
-      description: Partially update a run schedule's definition (cadence, window,
-        input, etc.).
-      operationId: update_run_schedule_agents__agent_id__schedules__name__patch
+      summary: Update Run Schedule By Name
+      description: Partially update a run schedule's definition by its active name.
+      operationId: update_run_schedule_by_name_agents__agent_id__schedules_name__name__patch
       parameters:
       - name: agent_id
         in: path
@@ -3395,9 +3394,9 @@ paths:
     delete:
       tags:
       - Schedules
-      summary: Delete Run Schedule
-      description: Delete a run schedule permanently.
-      operationId: delete_run_schedule_agents__agent_id__schedules__name__delete
+      summary: Delete Run Schedule By Name
+      description: Delete a run schedule by its active name.
+      operationId: delete_run_schedule_by_name_agents__agent_id__schedules_name__name__delete
       parameters:
       - name: agent_id
         in: path
@@ -3424,14 +3423,118 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /agents/{agent_id}/schedules/{name}/trigger:
+  /agents/{agent_id}/schedules/{schedule_id}:
+    get:
+      tags:
+      - Schedules
+      summary: Get Run Schedule
+      description: Get a run schedule by its id.
+      operationId: get_run_schedule_agents__agent_id__schedules__schedule_id__get
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Agent Id
+      - name: schedule_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Schedule Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentRunScheduleResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    patch:
+      tags:
+      - Schedules
+      summary: Update Run Schedule
+      description: Partially update a run schedule's definition (cadence, window,
+        input, etc.).
+      operationId: update_run_schedule_agents__agent_id__schedules__schedule_id__patch
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Agent Id
+      - name: schedule_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Schedule Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAgentRunScheduleRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentRunScheduleResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Schedules
+      summary: Delete Run Schedule
+      description: Delete a run schedule permanently.
+      operationId: delete_run_schedule_agents__agent_id__schedules__schedule_id__delete
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Agent Id
+      - name: schedule_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Schedule Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /agents/{agent_id}/schedules/name/{name}/trigger:
     post:
       tags:
       - Schedules
-      summary: Trigger Run Schedule
-      description: Trigger an immediate, out-of-band run of the schedule (in addition
-        to its cadence).
-      operationId: trigger_run_schedule_agents__agent_id__schedules__name__trigger_post
+      summary: Trigger Run Schedule By Name
+      description: Trigger an immediate, out-of-band run of the schedule by its active
+        name.
+      operationId: trigger_run_schedule_by_name_agents__agent_id__schedules_name__name__trigger_post
       parameters:
       - name: agent_id
         in: path
@@ -3458,13 +3561,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /agents/{agent_id}/schedules/{name}/pause:
+  /agents/{agent_id}/schedules/{schedule_id}/trigger:
     post:
       tags:
       - Schedules
-      summary: Pause Run Schedule
-      description: Pause a run schedule so it stops firing.
-      operationId: pause_run_schedule_agents__agent_id__schedules__name__pause_post
+      summary: Trigger Run Schedule
+      description: Trigger an immediate, out-of-band run of the schedule (in addition
+        to its cadence).
+      operationId: trigger_run_schedule_agents__agent_id__schedules__schedule_id__trigger_post
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Agent Id
+      - name: schedule_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Schedule Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentRunScheduleResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /agents/{agent_id}/schedules/name/{name}/pause:
+    post:
+      tags:
+      - Schedules
+      summary: Pause Run Schedule By Name
+      description: Pause a run schedule by its active name.
+      operationId: pause_run_schedule_by_name_agents__agent_id__schedules_name__name__pause_post
       parameters:
       - name: agent_id
         in: path
@@ -3499,13 +3636,54 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /agents/{agent_id}/schedules/{name}/resume:
+  /agents/{agent_id}/schedules/{schedule_id}/pause:
     post:
       tags:
       - Schedules
-      summary: Resume Run Schedule
-      description: Resume a paused run schedule so it fires again.
-      operationId: resume_run_schedule_agents__agent_id__schedules__name__resume_post
+      summary: Pause Run Schedule
+      description: Pause a run schedule so it stops firing.
+      operationId: pause_run_schedule_agents__agent_id__schedules__schedule_id__pause_post
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Agent Id
+      - name: schedule_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Schedule Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/PauseRunScheduleRequest'
+              - type: 'null'
+              title: Request
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentRunScheduleResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /agents/{agent_id}/schedules/name/{name}/resume:
+    post:
+      tags:
+      - Schedules
+      summary: Resume Run Schedule By Name
+      description: Resume a paused run schedule by its active name.
+      operationId: resume_run_schedule_by_name_agents__agent_id__schedules_name__name__resume_post
       parameters:
       - name: agent_id
         in: path
@@ -3519,6 +3697,47 @@ paths:
         schema:
           type: string
           title: Name
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/ResumeRunScheduleRequest'
+              - type: 'null'
+              title: Request
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentRunScheduleResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /agents/{agent_id}/schedules/{schedule_id}/resume:
+    post:
+      tags:
+      - Schedules
+      summary: Resume Run Schedule
+      description: Resume a paused run schedule so it fires again.
+      operationId: resume_run_schedule_agents__agent_id__schedules__schedule_id__resume_post
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Agent Id
+      - name: schedule_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Schedule Id
       requestBody:
         content:
           application/json:
@@ -4047,7 +4266,7 @@ components:
         name:
           type: string
           title: Name
-          description: Schedule name, unique per agent.
+          description: Human-readable schedule name.
         description:
           anyOf:
           - type: string
@@ -4521,7 +4740,8 @@ components:
           minLength: 1
           pattern: ^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$
           title: Schedule Name
-          description: Human-readable name, unique per agent (e.g. 'daily-granola-summary').
+          description: Human-readable name, unique among active schedules for the
+            agent.
         description:
           anyOf:
           - type: string
@@ -6751,6 +6971,16 @@ components:
       description: Delta for tool response updates
     UpdateAgentRunScheduleRequest:
       properties:
+        name:
+          anyOf:
+          - type: string
+            maxLength: 64
+            minLength: 1
+            pattern: ^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$
+          - type: 'null'
+          title: Schedule Name
+          description: Human-readable name, unique among active schedules for the
+            agent.
         description:
           anyOf:
           - type: string
@@ -6820,12 +7050,12 @@ components:
       description: 'Partial update for a scheduled agent run.
 
 
-        Only fields present in the request body are changed; the schedule ``name``
-        is
+        Only fields present in the request body are changed. Setting
 
-        immutable (it is the natural key). Setting ``cron_expression`` clears
+        ``cron_expression`` clears ``interval_seconds`` and vice versa; providing
+        both
 
-        ``interval_seconds`` and vice versa; providing both is rejected.'
+        is rejected.'
     UpdateAgentTaskTrackerRequest:
       properties:
         last_processed_event_id:

--- a/agentex/src/adapters/orm.py
+++ b/agentex/src/adapters/orm.py
@@ -219,21 +219,20 @@ class AgentRunScheduleORM(BaseORM):
     updated_at = Column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
-    # Soft-delete marker: NULL = active, set = tombstoned for audit. Deleted rows
-    # keep their (agent_id, name) so names are not reusable.
+    # Soft-delete marker: NULL = active, set = tombstoned for audit.
     deleted_at = Column(DateTime(timezone=True), nullable=True)
     # Monotonic record version reserved for future optimistic concurrency /
     # change history. Not enforced yet — no read-modify-write path increments it.
     version = Column(Integer, nullable=False, server_default="1")
 
     __table_args__ = (
-        # Schedule names are unique per agent (the get/pause/resume/delete
-        # endpoints address a schedule by agent_id + name).
+        # Schedule names are mutable labels, unique only among active schedules.
         Index(
-            "uq_agent_run_schedules_agent_name",
+            "uq_agent_run_schedules_active_agent_name",
             "agent_id",
             "name",
             unique=True,
+            postgresql_where=(deleted_at.is_(None)),
         ),
         Index("idx_agent_run_schedules_agent", "agent_id"),
     )

--- a/agentex/src/api/routes/agent_run_schedules.py
+++ b/agentex/src/api/routes/agent_run_schedules.py
@@ -129,13 +129,16 @@ async def _resolve_name_alias_and_check(
     # and then authorize/operate on the immutable schedule id. Acting on the id,
     # not the name, keeps it the stable auth and mutation target even if the
     # label changes, and closes the rename/recreate race where a check on the old
-    # row could precede a write that lands on a new one. Absent names 404; denied
-    # resources collapse to 404.
+    # row could precede a write that lands on a new one. Both the absent-name and
+    # the denied-resource paths raise this same name-based 404 so an unauthorized
+    # caller can neither distinguish the two nor read back the resolved id.
+    not_found_message = f"Run schedule '{name}' for agent '{agent_id}' does not exist."
     schedule_id = await run_schedules_use_case.get_schedule_id_by_name(agent_id, name)
     await _check_schedule_or_collapse_to_404(
         authorization,
         build_run_schedule_authz_selector(agent_id, schedule_id),
         operation,
+        not_found_message=not_found_message,
     )
     return schedule_id
 

--- a/agentex/src/api/routes/agent_run_schedules.py
+++ b/agentex/src/api/routes/agent_run_schedules.py
@@ -118,130 +118,301 @@ async def list_run_schedules(
     )
 
 
+async def _resolve_name_alias_and_check(
+    agent_id: str,
+    name: str,
+    operation: AuthorizedOperationType,
+    run_schedules_use_case: DAgentRunSchedulesUseCase,
+    authorization: DAuthorizationService,
+) -> str:
+    # Name aliases are per-agent labels, so resolve them under the agent first
+    # and then authorize/operate on the immutable schedule id. Acting on the id,
+    # not the name, keeps it the stable auth and mutation target even if the
+    # label changes, and closes the rename/recreate race where a check on the old
+    # row could precede a write that lands on a new one. Absent names 404; denied
+    # resources collapse to 404.
+    schedule_id = await run_schedules_use_case.get_schedule_id_by_name(agent_id, name)
+    await _check_schedule_or_collapse_to_404(
+        authorization,
+        build_run_schedule_authz_selector(agent_id, schedule_id),
+        operation,
+    )
+    return schedule_id
+
+
 @router.get(
-    "/{name}",
+    "/name/{name}",
     response_model=AgentRunScheduleResponse,
-    summary="Get Run Schedule",
-    description="Get a run schedule by its name.",
+    summary="Get Run Schedule By Name",
+    description="Get a run schedule by its active name.",
 )
-async def get_run_schedule(
+async def get_run_schedule_by_name(
     agent_id: str,
     name: str,
     run_schedules_use_case: DAgentRunSchedulesUseCase,
     authorization: DAuthorizationService,
 ) -> AgentRunScheduleResponse:
+    schedule_id = await _resolve_name_alias_and_check(
+        agent_id,
+        name,
+        AuthorizedOperationType.read,
+        run_schedules_use_case,
+        authorization,
+    )
+    return await run_schedules_use_case.get_schedule(agent_id, schedule_id)
+
+
+@router.get(
+    "/{schedule_id}",
+    response_model=AgentRunScheduleResponse,
+    summary="Get Run Schedule",
+    description="Get a run schedule by its id.",
+)
+async def get_run_schedule(
+    agent_id: str,
+    schedule_id: str,
+    run_schedules_use_case: DAgentRunSchedulesUseCase,
+    authorization: DAuthorizationService,
+) -> AgentRunScheduleResponse:
     await _check_schedule_or_collapse_to_404(
         authorization,
-        build_run_schedule_authz_selector(agent_id, name),
+        build_run_schedule_authz_selector(agent_id, schedule_id),
         AuthorizedOperationType.read,
     )
-    return await run_schedules_use_case.get_schedule(agent_id, name)
+    return await run_schedules_use_case.get_schedule(agent_id, schedule_id)
 
 
 @router.patch(
-    "/{name}",
+    "/name/{name}",
     response_model=AgentRunScheduleResponse,
-    summary="Update Run Schedule",
-    description="Partially update a run schedule's definition (cadence, window, input, etc.).",
+    summary="Update Run Schedule By Name",
+    description="Partially update a run schedule's definition by its active name.",
 )
-async def update_run_schedule(
+async def update_run_schedule_by_name(
     agent_id: str,
     name: str,
     request: UpdateAgentRunScheduleRequest,
     run_schedules_use_case: DAgentRunSchedulesUseCase,
     authorization: DAuthorizationService,
 ) -> AgentRunScheduleResponse:
+    schedule_id = await _resolve_name_alias_and_check(
+        agent_id,
+        name,
+        AuthorizedOperationType.update,
+        run_schedules_use_case,
+        authorization,
+    )
+    return await run_schedules_use_case.update_schedule(agent_id, schedule_id, request)
+
+
+@router.patch(
+    "/{schedule_id}",
+    response_model=AgentRunScheduleResponse,
+    summary="Update Run Schedule",
+    description="Partially update a run schedule's definition (cadence, window, input, etc.).",
+)
+async def update_run_schedule(
+    agent_id: str,
+    schedule_id: str,
+    request: UpdateAgentRunScheduleRequest,
+    run_schedules_use_case: DAgentRunSchedulesUseCase,
+    authorization: DAuthorizationService,
+) -> AgentRunScheduleResponse:
     await _check_schedule_or_collapse_to_404(
         authorization,
-        build_run_schedule_authz_selector(agent_id, name),
+        build_run_schedule_authz_selector(agent_id, schedule_id),
         AuthorizedOperationType.update,
     )
-    return await run_schedules_use_case.update_schedule(agent_id, name, request)
+    return await run_schedules_use_case.update_schedule(agent_id, schedule_id, request)
 
 
 @router.post(
-    "/{name}/trigger",
+    "/name/{name}/trigger",
+    response_model=AgentRunScheduleResponse,
+    summary="Trigger Run Schedule By Name",
+    description="Trigger an immediate, out-of-band run of the schedule by its active name.",
+)
+async def trigger_run_schedule_by_name(
+    agent_id: str,
+    name: str,
+    run_schedules_use_case: DAgentRunSchedulesUseCase,
+    authorization: DAuthorizationService,
+) -> AgentRunScheduleResponse:
+    schedule_id = await _resolve_name_alias_and_check(
+        agent_id,
+        name,
+        AuthorizedOperationType.update,
+        run_schedules_use_case,
+        authorization,
+    )
+    return await run_schedules_use_case.trigger_schedule(agent_id, schedule_id)
+
+
+@router.post(
+    "/{schedule_id}/trigger",
     response_model=AgentRunScheduleResponse,
     summary="Trigger Run Schedule",
     description="Trigger an immediate, out-of-band run of the schedule (in addition to its cadence).",
 )
 async def trigger_run_schedule(
     agent_id: str,
-    name: str,
+    schedule_id: str,
     run_schedules_use_case: DAgentRunSchedulesUseCase,
     authorization: DAuthorizationService,
 ) -> AgentRunScheduleResponse:
     await _check_schedule_or_collapse_to_404(
         authorization,
-        build_run_schedule_authz_selector(agent_id, name),
+        build_run_schedule_authz_selector(agent_id, schedule_id),
         AuthorizedOperationType.update,
     )
-    return await run_schedules_use_case.trigger_schedule(agent_id, name)
+    return await run_schedules_use_case.trigger_schedule(agent_id, schedule_id)
 
 
 @router.post(
-    "/{name}/pause",
+    "/name/{name}/pause",
     response_model=AgentRunScheduleResponse,
-    summary="Pause Run Schedule",
-    description="Pause a run schedule so it stops firing.",
+    summary="Pause Run Schedule By Name",
+    description="Pause a run schedule by its active name.",
 )
-async def pause_run_schedule(
+async def pause_run_schedule_by_name(
     agent_id: str,
     name: str,
     run_schedules_use_case: DAgentRunSchedulesUseCase,
     authorization: DAuthorizationService,
     request: PauseRunScheduleRequest | None = None,
 ) -> AgentRunScheduleResponse:
-    await _check_schedule_or_collapse_to_404(
-        authorization,
-        build_run_schedule_authz_selector(agent_id, name),
+    schedule_id = await _resolve_name_alias_and_check(
+        agent_id,
+        name,
         AuthorizedOperationType.update,
+        run_schedules_use_case,
+        authorization,
     )
     note = request.note if request else None
-    return await run_schedules_use_case.pause_schedule(agent_id, name, note=note)
+    return await run_schedules_use_case.pause_schedule(agent_id, schedule_id, note=note)
 
 
 @router.post(
-    "/{name}/resume",
+    "/{schedule_id}/pause",
     response_model=AgentRunScheduleResponse,
-    summary="Resume Run Schedule",
-    description="Resume a paused run schedule so it fires again.",
+    summary="Pause Run Schedule",
+    description="Pause a run schedule so it stops firing.",
 )
-async def resume_run_schedule(
+async def pause_run_schedule(
+    agent_id: str,
+    schedule_id: str,
+    run_schedules_use_case: DAgentRunSchedulesUseCase,
+    authorization: DAuthorizationService,
+    request: PauseRunScheduleRequest | None = None,
+) -> AgentRunScheduleResponse:
+    await _check_schedule_or_collapse_to_404(
+        authorization,
+        build_run_schedule_authz_selector(agent_id, schedule_id),
+        AuthorizedOperationType.update,
+    )
+    note = request.note if request else None
+    return await run_schedules_use_case.pause_schedule(agent_id, schedule_id, note=note)
+
+
+@router.post(
+    "/name/{name}/resume",
+    response_model=AgentRunScheduleResponse,
+    summary="Resume Run Schedule By Name",
+    description="Resume a paused run schedule by its active name.",
+)
+async def resume_run_schedule_by_name(
     agent_id: str,
     name: str,
     run_schedules_use_case: DAgentRunSchedulesUseCase,
     authorization: DAuthorizationService,
     request: ResumeRunScheduleRequest | None = None,
 ) -> AgentRunScheduleResponse:
+    schedule_id = await _resolve_name_alias_and_check(
+        agent_id,
+        name,
+        AuthorizedOperationType.update,
+        run_schedules_use_case,
+        authorization,
+    )
+    note = request.note if request else None
+    return await run_schedules_use_case.resume_schedule(
+        agent_id, schedule_id, note=note
+    )
+
+
+@router.post(
+    "/{schedule_id}/resume",
+    response_model=AgentRunScheduleResponse,
+    summary="Resume Run Schedule",
+    description="Resume a paused run schedule so it fires again.",
+)
+async def resume_run_schedule(
+    agent_id: str,
+    schedule_id: str,
+    run_schedules_use_case: DAgentRunSchedulesUseCase,
+    authorization: DAuthorizationService,
+    request: ResumeRunScheduleRequest | None = None,
+) -> AgentRunScheduleResponse:
     await _check_schedule_or_collapse_to_404(
         authorization,
-        build_run_schedule_authz_selector(agent_id, name),
+        build_run_schedule_authz_selector(agent_id, schedule_id),
         AuthorizedOperationType.update,
     )
     note = request.note if request else None
-    return await run_schedules_use_case.resume_schedule(agent_id, name, note=note)
+    return await run_schedules_use_case.resume_schedule(
+        agent_id, schedule_id, note=note
+    )
 
 
 @router.delete(
-    "/{name}",
+    "/name/{name}",
+    response_model=DeleteResponse,
+    summary="Delete Run Schedule By Name",
+    description="Delete a run schedule by its active name.",
+)
+async def delete_run_schedule_by_name(
+    agent_id: str,
+    name: str,
+    run_schedules_use_case: DAgentRunSchedulesUseCase,
+    authorization: DAuthorizationService,
+) -> DeleteResponse:
+    schedule_id = await _resolve_name_alias_and_check(
+        agent_id,
+        name,
+        AuthorizedOperationType.delete,
+        run_schedules_use_case,
+        authorization,
+    )
+    deleted_schedule_id = await run_schedules_use_case.delete_schedule(
+        agent_id, schedule_id
+    )
+    return DeleteResponse(
+        id=deleted_schedule_id,
+        message=f"Run schedule '{name}' deleted successfully",
+    )
+
+
+@router.delete(
+    "/{schedule_id}",
     response_model=DeleteResponse,
     summary="Delete Run Schedule",
     description="Delete a run schedule permanently.",
 )
 async def delete_run_schedule(
     agent_id: str,
-    name: str,
+    schedule_id: str,
     run_schedules_use_case: DAgentRunSchedulesUseCase,
     authorization: DAuthorizationService,
 ) -> DeleteResponse:
     await _check_schedule_or_collapse_to_404(
         authorization,
-        build_run_schedule_authz_selector(agent_id, name),
+        build_run_schedule_authz_selector(agent_id, schedule_id),
         AuthorizedOperationType.delete,
     )
-    schedule_id = await run_schedules_use_case.delete_schedule(agent_id, name)
+    deleted_schedule_id = await run_schedules_use_case.delete_schedule(
+        agent_id, schedule_id
+    )
     return DeleteResponse(
-        id=schedule_id,
-        message=f"Run schedule '{name}' deleted successfully",
+        id=deleted_schedule_id,
+        message=f"Run schedule '{schedule_id}' deleted successfully",
     )

--- a/agentex/src/api/schemas/agent_run_schedules.py
+++ b/agentex/src/api/schemas/agent_run_schedules.py
@@ -52,7 +52,7 @@ class CreateAgentRunScheduleRequest(BaseModel):
     name: str = Field(
         ...,
         title="Schedule Name",
-        description="Human-readable name, unique per agent (e.g. 'daily-granola-summary').",
+        description="Human-readable name, unique among active schedules for the agent.",
         pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$",
         min_length=1,
         max_length=64,
@@ -110,7 +110,7 @@ class AgentRunScheduleResponse(BaseModel):
 
     id: str = Field(..., description="The unique identifier of the run schedule.")
     agent_id: str = Field(..., description="The agent this schedule belongs to.")
-    name: str = Field(..., description="Schedule name, unique per agent.")
+    name: str = Field(..., description="Human-readable schedule name.")
     description: str | None = Field(None, description="Optional description.")
     cron_expression: str | None = Field(
         None, description="Cron cadence, if cron-based."
@@ -171,11 +171,19 @@ class AgentRunScheduleListResponse(BaseModel):
 class UpdateAgentRunScheduleRequest(BaseModel):
     """Partial update for a scheduled agent run.
 
-    Only fields present in the request body are changed; the schedule ``name`` is
-    immutable (it is the natural key). Setting ``cron_expression`` clears
-    ``interval_seconds`` and vice versa; providing both is rejected.
+    Only fields present in the request body are changed. Setting
+    ``cron_expression`` clears ``interval_seconds`` and vice versa; providing both
+    is rejected.
     """
 
+    name: str | None = Field(
+        None,
+        title="Schedule Name",
+        description="Human-readable name, unique among active schedules for the agent.",
+        pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$",
+        min_length=1,
+        max_length=64,
+    )
     description: str | None = Field(
         None, description="Optional description of what this schedule does."
     )

--- a/agentex/src/domain/entities/agent_run_schedules.py
+++ b/agentex/src/domain/entities/agent_run_schedules.py
@@ -44,9 +44,7 @@ class AgentRunScheduleEntity(BaseModel):
 
     id: str = Field(..., description="The unique identifier of the run schedule.")
     agent_id: str = Field(..., description="The agent this schedule belongs to.")
-    name: str = Field(
-        ..., description="Human-readable schedule name, unique per agent."
-    )
+    name: str = Field(..., description="Human-readable schedule name.")
     description: str | None = Field(
         None, description="Optional description of the schedule."
     )

--- a/agentex/src/domain/repositories/agent_run_schedule_repository.py
+++ b/agentex/src/domain/repositories/agent_run_schedule_repository.py
@@ -55,10 +55,10 @@ class AgentRunScheduleRepository(
     async def get_by_agent_id_and_name(
         self, agent_id: str, name: str, include_deleted: bool = False
     ) -> AgentRunScheduleEntity | None:
-        """Get a run schedule by its (agent_id, name) natural key, or None.
+        """Get a run schedule by its active display name, or None.
 
         Soft-deleted schedules are excluded unless ``include_deleted`` is set
-        (used by create to keep a deleted name reserved — names are not reusable).
+        (used by tests / diagnostics; create and rename only check active names).
         """
         async with self.start_async_db_session(allow_writes=False) as session:
             query = select(AgentRunScheduleORM).where(
@@ -71,16 +71,31 @@ class AgentRunScheduleRepository(
             row = result.scalars().first()
             return AgentRunScheduleEntity.model_validate(row) if row else None
 
-    async def get_by_agent_id_and_name_or_raise(
-        self, agent_id: str, name: str, include_deleted: bool = False
+    async def get_by_agent_id_and_id(
+        self, agent_id: str, schedule_id: str, include_deleted: bool = False
+    ) -> AgentRunScheduleEntity | None:
+        """Get a run schedule by immutable id scoped to its agent, or None."""
+        async with self.start_async_db_session(allow_writes=False) as session:
+            query = select(AgentRunScheduleORM).where(
+                AgentRunScheduleORM.agent_id == agent_id,
+                AgentRunScheduleORM.id == schedule_id,
+            )
+            if not include_deleted:
+                query = query.where(AgentRunScheduleORM.deleted_at.is_(None))
+            result = await session.execute(query)
+            row = result.scalars().first()
+            return AgentRunScheduleEntity.model_validate(row) if row else None
+
+    async def get_by_agent_id_and_id_or_raise(
+        self, agent_id: str, schedule_id: str, include_deleted: bool = False
     ) -> AgentRunScheduleEntity:
-        """Get a run schedule by (agent_id, name) or raise ItemDoesNotExist."""
-        schedule = await self.get_by_agent_id_and_name(
-            agent_id, name, include_deleted=include_deleted
+        """Get a run schedule by (agent_id, id) or raise ItemDoesNotExist."""
+        schedule = await self.get_by_agent_id_and_id(
+            agent_id, schedule_id, include_deleted=include_deleted
         )
         if schedule is None:
             raise ItemDoesNotExist(
-                f"Run schedule '{name}' for agent '{agent_id}' does not exist."
+                f"Run schedule '{schedule_id}' for agent '{agent_id}' does not exist."
             )
         return schedule
 

--- a/agentex/src/domain/services/agent_run_schedule_service.py
+++ b/agentex/src/domain/services/agent_run_schedule_service.py
@@ -48,24 +48,14 @@ def build_run_schedule_temporal_id(schedule_row_id: str) -> str:
     return f"{RUN_SCHEDULE_TEMPORAL_ID_PREFIX}:{schedule_row_id}"
 
 
-def build_run_schedule_authz_selector(agent_id: str, name: str) -> str:
+def build_run_schedule_authz_selector(agent_id: str, schedule_id: str) -> str:
     """Authorization selector for a run schedule's ``schedule`` resource.
 
-    Derivable from the (agent_id, name) path params so the CRUD endpoints can
-    authorize without a prior DB lookup. The ``run-schedule::`` prefix namespaces
-    the selector within the ``schedule`` resource type.
-
-    Design note: ``name`` currently doubles as the external identity — URL
-    handle, unique key, and this authz selector — which is why a soft-deleted
-    name stays reserved (no reuse). The row's immutable ``id`` is the better
-    long-term handle (it is already returned in responses and is what Temporal
-    keys off), so moving the external identity to ``id`` with ``name`` as a
-    mutable label is a planned fast-follow that makes name reuse a non-issue and
-    keeps audit unambiguous. Deferred here to keep this change's scope contained;
-    the move is additive (id-based routes/selector alongside the name ones)
-    rather than a breaking reshape.
+    Derivable from the (agent_id, schedule_id) path params so the CRUD endpoints
+    can authorize without a prior DB lookup. The ``run-schedule::`` prefix
+    namespaces the selector within the ``schedule`` resource type.
     """
-    return f"run-schedule::{agent_id}::{name}"
+    return f"run-schedule::{agent_id}::{schedule_id}"
 
 
 class AgentRunScheduleService:
@@ -94,9 +84,8 @@ class AgentRunScheduleService:
         request: CreateAgentRunScheduleRequest,
         creator_principal: dict[str, Any],
     ) -> AgentRunScheduleResponse:
-        # include_deleted: a soft-deleted name stays reserved (no reuse in v1).
         existing = await self.schedule_repository.get_by_agent_id_and_name(
-            agent.id, request.name, include_deleted=True
+            agent.id, request.name
         )
         if existing is not None:
             raise ClientError(
@@ -128,7 +117,7 @@ class AgentRunScheduleService:
             ) from exc
 
         temporal_id = build_run_schedule_temporal_id(created.id)
-        authz_selector = build_run_schedule_authz_selector(agent.id, created.name)
+        authz_selector = build_run_schedule_authz_selector(agent.id, created.id)
         # Register (fail-closed, before the Temporal write) and create the schedule
         # under one rollback scope: if EITHER the auth registration or the Temporal
         # create fails, the persisted row is removed so a failed create leaves
@@ -193,7 +182,7 @@ class AgentRunScheduleService:
         for row in rows:
             if len(items) >= limit:
                 break
-            selector = build_run_schedule_authz_selector(agent_id, row.name)
+            selector = build_run_schedule_authz_selector(agent_id, row.id)
             if authorized is not None and selector not in authorized:
                 continue
             temporal_id = build_run_schedule_temporal_id(row.id)
@@ -208,34 +197,44 @@ class AgentRunScheduleService:
             )
         return AgentRunScheduleListResponse(run_schedules=items, total=len(items))
 
-    async def get_schedule(self, agent_id: str, name: str) -> AgentRunScheduleResponse:
-        row = await self.schedule_repository.get_by_agent_id_and_name_or_raise(
-            agent_id, name
+    async def get_schedule(
+        self, agent_id: str, schedule_id: str
+    ) -> AgentRunScheduleResponse:
+        row = await self.schedule_repository.get_by_agent_id_and_id_or_raise(
+            agent_id, schedule_id
         )
         agent = await self.agent_repository.get(id=agent_id)
         return await self._to_response(
             row, agent=agent, temporal_id=build_run_schedule_temporal_id(row.id)
         )
 
+    async def get_schedule_id_by_name(self, agent_id: str, name: str) -> str:
+        row = await self.schedule_repository.get_by_agent_id_and_name(agent_id, name)
+        if row is None:
+            raise ItemDoesNotExist(
+                f"Run schedule '{name}' for agent '{agent_id}' does not exist."
+            )
+        return row.id
+
     async def pause_schedule(
-        self, agent_id: str, name: str, note: str | None = None
+        self, agent_id: str, schedule_id: str, note: str | None = None
     ) -> AgentRunScheduleResponse:
-        return await self._set_paused(agent_id, name, paused=True, note=note)
+        return await self._set_paused(agent_id, schedule_id, paused=True, note=note)
 
     async def resume_schedule(
-        self, agent_id: str, name: str, note: str | None = None
+        self, agent_id: str, schedule_id: str, note: str | None = None
     ) -> AgentRunScheduleResponse:
-        return await self._set_paused(agent_id, name, paused=False, note=note)
+        return await self._set_paused(agent_id, schedule_id, paused=False, note=note)
 
-    async def delete_schedule(self, agent_id: str, name: str) -> str:
-        row = await self.schedule_repository.get_by_agent_id_and_name_or_raise(
-            agent_id, name
+    async def delete_schedule(self, agent_id: str, schedule_id: str) -> str:
+        row = await self.schedule_repository.get_by_agent_id_and_id_or_raise(
+            agent_id, schedule_id
         )
         temporal_id = build_run_schedule_temporal_id(row.id)
         # Temporal is the recurring clock; delete it first so no further fires can
         # occur, then soft-delete the row and drop the auth entry. The Postgres row
         # is tombstoned (deleted_at set) rather than removed so the schedule remains
-        # auditable and its (agent_id, name) stays reserved (names are not reusable).
+        # auditable.
         # A missing Temporal schedule is treated as success (the clock is already
         # gone) so a prior partial delete — Temporal removed but the row write
         # failed — can still be cleaned up through this path rather than stranded.
@@ -249,12 +248,12 @@ class AgentRunScheduleService:
         row.deleted_at = datetime.now(UTC)
         await self.schedule_repository.update(row)
         await self._deregister_schedule_from_auth(
-            authz_selector=build_run_schedule_authz_selector(agent_id, row.name)
+            authz_selector=build_run_schedule_authz_selector(agent_id, row.id)
         )
         return row.id
 
     async def update_schedule(
-        self, agent_id: str, name: str, request: UpdateAgentRunScheduleRequest
+        self, agent_id: str, schedule_id: str, request: UpdateAgentRunScheduleRequest
     ) -> AgentRunScheduleResponse:
         """Apply a partial update to a schedule's definition and Temporal spec.
 
@@ -262,10 +261,19 @@ class AgentRunScheduleService:
         cron_expression / interval_seconds clears the other; the merged result
         must still have exactly one cadence.
         """
-        row = await self.schedule_repository.get_by_agent_id_and_name_or_raise(
-            agent_id, name
+        row = await self.schedule_repository.get_by_agent_id_and_id_or_raise(
+            agent_id, schedule_id
         )
         provided = request.model_dump(exclude_unset=True)
+        if "name" in provided and request.name is not None and request.name != row.name:
+            existing = await self.schedule_repository.get_by_agent_id_and_name(
+                agent_id, request.name
+            )
+            if existing is not None and existing.id != row.id:
+                raise ClientError(
+                    f"Run schedule '{request.name}' already exists for agent '{agent_id}'"
+                )
+            row.name = request.name
         if "description" in provided:
             row.description = request.description
         if "cron_expression" in provided:
@@ -330,16 +338,21 @@ class AgentRunScheduleService:
                 "run_schedule_temporal_missing_on_update",
                 extra={"temporal_id": temporal_id, "schedule_id": row.id},
             )
-        updated = await self.schedule_repository.update(row)
+        try:
+            updated = await self.schedule_repository.update(row)
+        except DuplicateItemError as exc:
+            raise ClientError(
+                f"Run schedule '{row.name}' already exists for agent '{agent_id}'"
+            ) from exc
         agent = await self.agent_repository.get(id=agent_id)
         return await self._to_response(updated, agent=agent, temporal_id=temporal_id)
 
     async def trigger_schedule(
-        self, agent_id: str, name: str
+        self, agent_id: str, schedule_id: str
     ) -> AgentRunScheduleResponse:
         """Trigger an immediate, out-of-band fire of the schedule."""
-        row = await self.schedule_repository.get_by_agent_id_and_name_or_raise(
-            agent_id, name
+        row = await self.schedule_repository.get_by_agent_id_and_id_or_raise(
+            agent_id, schedule_id
         )
         temporal_id = build_run_schedule_temporal_id(row.id)
         triggered_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
@@ -357,10 +370,10 @@ class AgentRunScheduleService:
     # -- internals ---------------------------------------------------------
 
     async def _set_paused(
-        self, agent_id: str, name: str, *, paused: bool, note: str | None
+        self, agent_id: str, schedule_id: str, *, paused: bool, note: str | None
     ) -> AgentRunScheduleResponse:
-        row = await self.schedule_repository.get_by_agent_id_and_name_or_raise(
-            agent_id, name
+        row = await self.schedule_repository.get_by_agent_id_and_id_or_raise(
+            agent_id, schedule_id
         )
         temporal_id = build_run_schedule_temporal_id(row.id)
         # A missing Temporal schedule is logged rather than raised: the persisted

--- a/agentex/src/domain/use_cases/agent_run_schedules_use_case.py
+++ b/agentex/src/domain/use_cases/agent_run_schedules_use_case.py
@@ -48,33 +48,42 @@ class AgentRunSchedulesUseCase:
             limit=limit,
         )
 
-    async def get_schedule(self, agent_id: str, name: str) -> AgentRunScheduleResponse:
-        return await self.run_schedule_service.get_schedule(agent_id, name)
+    async def get_schedule(
+        self, agent_id: str, schedule_id: str
+    ) -> AgentRunScheduleResponse:
+        return await self.run_schedule_service.get_schedule(agent_id, schedule_id)
+
+    async def get_schedule_id_by_name(self, agent_id: str, name: str) -> str:
+        return await self.run_schedule_service.get_schedule_id_by_name(agent_id, name)
 
     async def pause_schedule(
-        self, agent_id: str, name: str, note: str | None = None
+        self, agent_id: str, schedule_id: str, note: str | None = None
     ) -> AgentRunScheduleResponse:
-        return await self.run_schedule_service.pause_schedule(agent_id, name, note=note)
+        return await self.run_schedule_service.pause_schedule(
+            agent_id, schedule_id, note=note
+        )
 
     async def resume_schedule(
-        self, agent_id: str, name: str, note: str | None = None
+        self, agent_id: str, schedule_id: str, note: str | None = None
     ) -> AgentRunScheduleResponse:
         return await self.run_schedule_service.resume_schedule(
-            agent_id, name, note=note
+            agent_id, schedule_id, note=note
         )
 
     async def update_schedule(
-        self, agent_id: str, name: str, request: UpdateAgentRunScheduleRequest
+        self, agent_id: str, schedule_id: str, request: UpdateAgentRunScheduleRequest
     ) -> AgentRunScheduleResponse:
-        return await self.run_schedule_service.update_schedule(agent_id, name, request)
+        return await self.run_schedule_service.update_schedule(
+            agent_id, schedule_id, request
+        )
 
     async def trigger_schedule(
-        self, agent_id: str, name: str
+        self, agent_id: str, schedule_id: str
     ) -> AgentRunScheduleResponse:
-        return await self.run_schedule_service.trigger_schedule(agent_id, name)
+        return await self.run_schedule_service.trigger_schedule(agent_id, schedule_id)
 
-    async def delete_schedule(self, agent_id: str, name: str) -> str:
-        return await self.run_schedule_service.delete_schedule(agent_id, name)
+    async def delete_schedule(self, agent_id: str, schedule_id: str) -> str:
+        return await self.run_schedule_service.delete_schedule(agent_id, schedule_id)
 
 
 DAgentRunSchedulesUseCase = Annotated[

--- a/agentex/src/utils/schedule_authorization.py
+++ b/agentex/src/utils/schedule_authorization.py
@@ -12,11 +12,18 @@ async def _check_schedule_or_collapse_to_404(
     authorization: AuthorizationService,
     schedule_id: str,
     operation: AuthorizedOperationType,
+    not_found_message: str | None = None,
 ) -> None:
-    """Check an agent_schedule resource while hiding unreadable schedules."""
+    """Check an agent_schedule resource while hiding unreadable schedules.
+
+    ``not_found_message`` overrides the collapsed-404 body. Name-addressed routes
+    pass a name-based message so a denied resource is indistinguishable from an
+    absent one and the resolved id is never echoed back to an unauthorized caller.
+    """
     await check_resource_or_collapse_unreadable_to_404(
         authorization=authorization,
         resource=AgentexResource.schedule(schedule_id),
         operation=operation,
-        not_found_message=f"Item with id '{schedule_id}' does not exist.",
+        not_found_message=not_found_message
+        or f"Item with id '{schedule_id}' does not exist.",
     )

--- a/agentex/tests/unit/api/test_agent_run_schedules_authz.py
+++ b/agentex/tests/unit/api/test_agent_run_schedules_authz.py
@@ -150,6 +150,29 @@ class TestSingleResourceRouteAuthz:
         assert called["operation"] == AuthorizedOperationType.read
         use_case.get_schedule.assert_awaited_once_with("agent-1", "schedule-1")
 
+    async def test_get_by_name_denied_404_hides_existence_and_resolved_id(self):
+        # A denied name-alias request must 404 with a name-based body identical to
+        # the absent-name case, and must never echo the resolved schedule id — else
+        # an unauthorized caller could probe existence / read back the id.
+        authorization = MagicMock()
+        authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))
+        use_case = MagicMock()
+        use_case.get_schedule_id_by_name = AsyncMock(return_value="secret-id")
+        use_case.get_schedule = AsyncMock()
+
+        with pytest.raises(ItemDoesNotExist) as exc_info:
+            await get_run_schedule_by_name(
+                agent_id="agent-1",
+                name="nightly",
+                run_schedules_use_case=use_case,
+                authorization=authorization,
+            )
+
+        message = str(exc_info.value)
+        assert message == "Run schedule 'nightly' for agent 'agent-1' does not exist."
+        assert "secret-id" not in message
+        use_case.get_schedule.assert_not_called()
+
     async def test_get_denied_collapses_to_404_and_skips_use_case(self):
         authorization = MagicMock()
         authorization.check = AsyncMock(side_effect=AuthorizationError("denied"))

--- a/agentex/tests/unit/api/test_agent_run_schedules_authz.py
+++ b/agentex/tests/unit/api/test_agent_run_schedules_authz.py
@@ -15,6 +15,7 @@ from src.api.routes.agent_run_schedules import (
     create_run_schedule,
     delete_run_schedule,
     get_run_schedule,
+    get_run_schedule_by_name,
     list_run_schedules,
     pause_run_schedule,
     resume_run_schedule,
@@ -43,8 +44,8 @@ def _dep_callable(annotation):
     return annotation.__metadata__[0].dependency
 
 
-def _authz_selector(agent_id: str = "agent-1", name: str = "nightly") -> str:
-    return build_run_schedule_authz_selector(agent_id, name)
+def _authz_selector(agent_id: str = "agent-1", schedule_id: str = "schedule-1") -> str:
+    return build_run_schedule_authz_selector(agent_id, schedule_id)
 
 
 @pytest.mark.unit
@@ -119,7 +120,7 @@ class TestSingleResourceRouteAuthz:
 
         await get_run_schedule(
             agent_id="agent-1",
-            name="nightly",
+            schedule_id="schedule-1",
             run_schedules_use_case=use_case,
             authorization=authorization,
         )
@@ -127,7 +128,27 @@ class TestSingleResourceRouteAuthz:
         called = authorization.check.await_args.kwargs
         assert called["resource"] == AgentexResource.schedule(_authz_selector())
         assert called["operation"] == AuthorizedOperationType.read
-        use_case.get_schedule.assert_awaited_once_with("agent-1", "nightly")
+        use_case.get_schedule.assert_awaited_once_with("agent-1", "schedule-1")
+
+    async def test_get_by_name_resolves_id_then_checks_read(self):
+        authorization = MagicMock()
+        authorization.check = AsyncMock(return_value=True)
+        use_case = MagicMock()
+        use_case.get_schedule_id_by_name = AsyncMock(return_value="schedule-1")
+        use_case.get_schedule = AsyncMock(return_value=MagicMock())
+
+        await get_run_schedule_by_name(
+            agent_id="agent-1",
+            name="nightly",
+            run_schedules_use_case=use_case,
+            authorization=authorization,
+        )
+
+        use_case.get_schedule_id_by_name.assert_awaited_once_with("agent-1", "nightly")
+        called = authorization.check.await_args.kwargs
+        assert called["resource"] == AgentexResource.schedule(_authz_selector())
+        assert called["operation"] == AuthorizedOperationType.read
+        use_case.get_schedule.assert_awaited_once_with("agent-1", "schedule-1")
 
     async def test_get_denied_collapses_to_404_and_skips_use_case(self):
         authorization = MagicMock()
@@ -138,7 +159,7 @@ class TestSingleResourceRouteAuthz:
         with pytest.raises(ItemDoesNotExist):
             await get_run_schedule(
                 agent_id="agent-1",
-                name="nightly",
+                schedule_id="schedule-1",
                 run_schedules_use_case=use_case,
                 authorization=authorization,
             )
@@ -161,7 +182,7 @@ class TestSingleResourceRouteAuthz:
 
         await route(
             agent_id="agent-1",
-            name="nightly",
+            schedule_id="schedule-1",
             run_schedules_use_case=use_case,
             authorization=authorization,
         )
@@ -180,7 +201,7 @@ class TestSingleResourceRouteAuthz:
 
         await update_run_schedule(
             agent_id="agent-1",
-            name="nightly",
+            schedule_id="schedule-1",
             request=request,
             run_schedules_use_case=use_case,
             authorization=authorization,
@@ -189,7 +210,9 @@ class TestSingleResourceRouteAuthz:
         called = authorization.check.await_args.kwargs
         assert called["resource"] == AgentexResource.schedule(_authz_selector())
         assert called["operation"] == AuthorizedOperationType.update
-        use_case.update_schedule.assert_awaited_once_with("agent-1", "nightly", request)
+        use_case.update_schedule.assert_awaited_once_with(
+            "agent-1", "schedule-1", request
+        )
 
     async def test_delete_uses_delete_op_and_denial_skips_delete(self):
         authorization = MagicMock()
@@ -200,7 +223,7 @@ class TestSingleResourceRouteAuthz:
         with pytest.raises(ItemDoesNotExist):
             await delete_run_schedule(
                 agent_id="agent-1",
-                name="nightly",
+                schedule_id="schedule-1",
                 run_schedules_use_case=use_case,
                 authorization=authorization,
             )
@@ -318,13 +341,13 @@ class TestListOwnershipFiltering:
         await list_run_schedules(
             agent_id="agent-1",
             run_schedules_use_case=use_case,
-            authorized_schedule_ids=[_authz_selector("agent-1", "mine")],
+            authorized_schedule_ids=[_authz_selector("agent-1", "schedule-1")],
             limit=5,
         )
 
         use_case.list_schedules.assert_awaited_once_with(
             "agent-1",
-            authorized_schedule_ids=[_authz_selector("agent-1", "mine")],
+            authorized_schedule_ids=[_authz_selector("agent-1", "schedule-1")],
             limit=5,
         )
 

--- a/agentex/tests/unit/services/test_agent_run_schedule_service.py
+++ b/agentex/tests/unit/services/test_agent_run_schedule_service.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import pytest
 from pydantic import ValidationError
+from src.adapters.crud_store.exceptions import DuplicateItemError, ItemDoesNotExist
 from src.adapters.temporal.exceptions import TemporalScheduleNotFoundError
 from src.api.schemas.agent_run_schedules import (
     CreateAgentRunScheduleRequest,
@@ -87,8 +88,8 @@ class TestRunScheduleIdHelpers:
     def test_authz_selector_distinct_from_bare_schedule(self):
         # Bare schedules key the shared `schedule` resource as `{agent}--{name}`;
         # run schedules must not collide with that namespace.
-        selector = build_run_schedule_authz_selector("agent-123", "daily-summary")
-        assert selector == "run-schedule::agent-123::daily-summary"
+        selector = build_run_schedule_authz_selector("agent-123", "schedule-456")
+        assert selector == "run-schedule::agent-123::schedule-456"
         assert selector != "agent-123--daily-summary"
 
 
@@ -116,7 +117,7 @@ class TestAgentRunScheduleServiceCreate:
         # Ownership is written to both auth paths before the Temporal write:
         # Spark resource registration for the future path, and a legacy grant
         # for current SGP list/check behavior.
-        authz_selector = build_run_schedule_authz_selector(agent.id, persisted.name)
+        authz_selector = build_run_schedule_authz_selector(agent.id, persisted.id)
         schedule_resource = AgentexResource.schedule(authz_selector)
         service.authorization_service.register_resource.assert_called_once_with(
             resource=schedule_resource,
@@ -151,7 +152,7 @@ class TestAgentRunScheduleServiceCreate:
             await service.create_schedule(agent, request, {"user_id": "u1"})
 
         # The orphaned row and both auth entries are compensated.
-        authz_selector = build_run_schedule_authz_selector(agent.id, persisted.name)
+        authz_selector = build_run_schedule_authz_selector(agent.id, persisted.id)
         schedule_resource = AgentexResource.schedule(authz_selector)
         service.schedule_repository.delete.assert_called_once_with(id=persisted.id)
         service.authorization_service.revoke.assert_called_once_with(
@@ -223,7 +224,7 @@ class TestAgentRunScheduleServiceList:
         service.agent_repository.get.return_value = agent
 
         # Authorize only sched-a's selector.
-        authorized = [build_run_schedule_authz_selector(agent.id, "sched-a")]
+        authorized = [build_run_schedule_authz_selector(agent.id, rows[0].id)]
         result = await service.list_schedules(
             agent.id, authorized_schedule_ids=authorized
         )
@@ -243,7 +244,7 @@ class TestAgentRunScheduleServiceList:
         service.schedule_repository.list_by_agent_id.return_value = rows
         service.agent_repository.get.return_value = agent
 
-        authorized = [build_run_schedule_authz_selector(agent.id, "mine")]
+        authorized = [build_run_schedule_authz_selector(agent.id, rows[2].id)]
         result = await service.list_schedules(
             agent.id, authorized_schedule_ids=authorized, limit=1
         )
@@ -281,6 +282,27 @@ class TestAgentRunScheduleServiceList:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+class TestAgentRunScheduleServiceNameLookup:
+    async def test_get_schedule_id_by_name_returns_active_row_id(self, service, agent):
+        row = _persisted(agent.id, _request())
+        service.schedule_repository.get_by_agent_id_and_name.return_value = row
+
+        result = await service.get_schedule_id_by_name(agent.id, row.name)
+
+        assert result == row.id
+        service.schedule_repository.get_by_agent_id_and_name.assert_awaited_once_with(
+            agent.id, row.name
+        )
+
+    async def test_get_schedule_id_by_name_raises_when_absent(self, service, agent):
+        service.schedule_repository.get_by_agent_id_and_name.return_value = None
+
+        with pytest.raises(ItemDoesNotExist):
+            await service.get_schedule_id_by_name(agent.id, "missing")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 class TestAgentRunScheduleServiceDelete:
     async def test_delete_tolerates_missing_temporal_schedule(self, service, agent):
         # Delete soft-deletes (tombstones) the row for audit rather than removing
@@ -288,13 +310,13 @@ class TestAgentRunScheduleServiceDelete:
         # (Temporal gone, row survived) must still be cleanable, treating a
         # missing clock as success.
         row = _persisted(agent.id, _request())
-        service.schedule_repository.get_by_agent_id_and_name_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
         service.schedule_repository.update.return_value = row
         service.temporal_adapter.delete_schedule.side_effect = (
             TemporalScheduleNotFoundError(message="gone", detail="gone")
         )
 
-        result = await service.delete_schedule(agent.id, row.name)
+        result = await service.delete_schedule(agent.id, row.id)
 
         assert result == row.id
         # Soft delete: the row is tombstoned via update, not hard-removed.
@@ -302,7 +324,7 @@ class TestAgentRunScheduleServiceDelete:
         service.schedule_repository.update.assert_called_once()
         tombstoned = service.schedule_repository.update.call_args.args[0]
         assert tombstoned.deleted_at is not None
-        authz_selector = build_run_schedule_authz_selector(agent.id, row.name)
+        authz_selector = build_run_schedule_authz_selector(agent.id, row.id)
         schedule_resource = AgentexResource.schedule(authz_selector)
         service.authorization_service.revoke.assert_called_once_with(
             resource=schedule_resource
@@ -315,14 +337,14 @@ class TestAgentRunScheduleServiceDelete:
 class TestAgentRunScheduleServicePauseResume:
     async def test_pause_tolerates_missing_temporal_schedule(self, service, agent):
         row = _persisted(agent.id, _request())
-        service.schedule_repository.get_by_agent_id_and_name_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
         service.schedule_repository.update.return_value = row
         service.agent_repository.get.return_value = agent
         service.temporal_adapter.pause_schedule.side_effect = (
             TemporalScheduleNotFoundError(message="gone", detail="gone")
         )
 
-        response = await service.pause_schedule(agent.id, row.name)
+        response = await service.pause_schedule(agent.id, row.id)
 
         # The persisted paused flag is still flipped even though the clock is gone.
         assert row.paused is True
@@ -335,12 +357,12 @@ class TestAgentRunScheduleServicePauseResume:
 class TestAgentRunScheduleServiceUpdate:
     async def test_update_swaps_cron_for_interval(self, service, agent):
         row = _persisted(agent.id, _request())  # cron-based
-        service.schedule_repository.get_by_agent_id_and_name_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
         service.schedule_repository.update.return_value = row
         service.agent_repository.get.return_value = agent
 
         await service.update_schedule(
-            agent.id, row.name, UpdateAgentRunScheduleRequest(interval_seconds=120)
+            agent.id, row.id, UpdateAgentRunScheduleRequest(interval_seconds=120)
         )
 
         # Setting interval clears cron, and the new cadence is pushed to Temporal.
@@ -352,19 +374,19 @@ class TestAgentRunScheduleServiceUpdate:
 
     async def test_update_rejects_clearing_all_cadences(self, service, agent):
         row = _persisted(agent.id, _request())  # cron-based, no interval
-        service.schedule_repository.get_by_agent_id_and_name_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
 
         # Explicitly nulling cron without supplying an interval leaves no cadence.
         with pytest.raises(ClientError):
             await service.update_schedule(
-                agent.id, row.name, UpdateAgentRunScheduleRequest(cron_expression=None)
+                agent.id, row.id, UpdateAgentRunScheduleRequest(cron_expression=None)
             )
 
         service.temporal_adapter.update_schedule.assert_not_called()
 
     async def test_update_tolerates_missing_temporal_schedule(self, service, agent):
         row = _persisted(agent.id, _request())
-        service.schedule_repository.get_by_agent_id_and_name_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
         service.schedule_repository.update.return_value = row
         service.agent_repository.get.return_value = agent
         service.temporal_adapter.update_schedule.side_effect = (
@@ -372,7 +394,7 @@ class TestAgentRunScheduleServiceUpdate:
         )
 
         response = await service.update_schedule(
-            agent.id, row.name, UpdateAgentRunScheduleRequest(description="new")
+            agent.id, row.id, UpdateAgentRunScheduleRequest(description="new")
         )
 
         assert response.description == "new"
@@ -382,15 +404,57 @@ class TestAgentRunScheduleServiceUpdate:
         # outage) must abort before the row is persisted, so the DB can never
         # diverge from the clock. Unlike NotFound, this error propagates.
         row = _persisted(agent.id, _request())
-        service.schedule_repository.get_by_agent_id_and_name_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
         service.temporal_adapter.update_schedule.side_effect = RuntimeError("boom")
 
         with pytest.raises(RuntimeError):
             await service.update_schedule(
-                agent.id, row.name, UpdateAgentRunScheduleRequest(description="new")
+                agent.id, row.id, UpdateAgentRunScheduleRequest(description="new")
             )
 
         service.schedule_repository.update.assert_not_called()
+
+    async def test_update_allows_name_change(self, service, agent):
+        row = _persisted(agent.id, _request(name="old-name"))
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_name.return_value = None
+        service.schedule_repository.update.return_value = row
+        service.agent_repository.get.return_value = agent
+
+        response = await service.update_schedule(
+            agent.id, row.id, UpdateAgentRunScheduleRequest(name="new-name")
+        )
+
+        assert row.name == "new-name"
+        assert response.name == "new-name"
+        service.schedule_repository.get_by_agent_id_and_name.assert_awaited_once_with(
+            agent.id, "new-name"
+        )
+
+    async def test_update_rejects_duplicate_active_name(self, service, agent):
+        row = _persisted(agent.id, _request(name="old-name"))
+        duplicate = _persisted(agent.id, _request(name="new-name"))
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_name.return_value = duplicate
+
+        with pytest.raises(ClientError):
+            await service.update_schedule(
+                agent.id, row.id, UpdateAgentRunScheduleRequest(name="new-name")
+            )
+
+        service.temporal_adapter.update_schedule.assert_not_called()
+        service.schedule_repository.update.assert_not_called()
+
+    async def test_update_converts_duplicate_index_error(self, service, agent):
+        row = _persisted(agent.id, _request(name="old-name"))
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_name.return_value = None
+        service.schedule_repository.update.side_effect = DuplicateItemError("duplicate")
+
+        with pytest.raises(ClientError):
+            await service.update_schedule(
+                agent.id, row.id, UpdateAgentRunScheduleRequest(name="new-name")
+            )
 
 
 @pytest.mark.unit
@@ -398,10 +462,10 @@ class TestAgentRunScheduleServiceUpdate:
 class TestAgentRunScheduleServiceTrigger:
     async def test_trigger_starts_manual_workflow(self, service, agent):
         row = _persisted(agent.id, _request())
-        service.schedule_repository.get_by_agent_id_and_name_or_raise.return_value = row
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
         service.agent_repository.get.return_value = agent
 
-        await service.trigger_schedule(agent.id, row.name)
+        await service.trigger_schedule(agent.id, row.id)
 
         temporal_id = build_run_schedule_temporal_id(row.id)
         service.temporal_adapter.trigger_schedule.assert_not_called()

--- a/agentex/tests/unit/use_cases/test_agent_run_schedules_use_case.py
+++ b/agentex/tests/unit/use_cases/test_agent_run_schedules_use_case.py
@@ -67,27 +67,39 @@ class TestAgentRunSchedulesUseCase:
 
         mock_service.create_schedule.assert_called_once()
 
+    async def test_get_schedule_id_by_name_delegates(self, use_case, mock_service):
+        mock_service.get_schedule_id_by_name.return_value = "schedule-123"
+
+        result = await use_case.get_schedule_id_by_name("agent-1", "daily-summary")
+
+        assert result == "schedule-123"
+        mock_service.get_schedule_id_by_name.assert_called_once_with(
+            "agent-1", "daily-summary"
+        )
+
     async def test_pause_resume_delete_delegate(self, use_case, mock_service, agent):
-        await use_case.pause_schedule(agent.id, "daily-summary", note="n")
+        schedule_id = "schedule-123"
+
+        await use_case.pause_schedule(agent.id, schedule_id, note="n")
         mock_service.pause_schedule.assert_called_once_with(
-            agent.id, "daily-summary", note="n"
+            agent.id, schedule_id, note="n"
         )
 
-        await use_case.resume_schedule(agent.id, "daily-summary")
+        await use_case.resume_schedule(agent.id, schedule_id)
         mock_service.resume_schedule.assert_called_once_with(
-            agent.id, "daily-summary", note=None
+            agent.id, schedule_id, note=None
         )
 
-        await use_case.delete_schedule(agent.id, "daily-summary")
-        mock_service.delete_schedule.assert_called_once_with(agent.id, "daily-summary")
+        await use_case.delete_schedule(agent.id, schedule_id)
+        mock_service.delete_schedule.assert_called_once_with(agent.id, schedule_id)
 
     async def test_update_delegates(self, use_case, mock_service, agent):
         request = UpdateAgentRunScheduleRequest(interval_seconds=120)
-        await use_case.update_schedule(agent.id, "daily-summary", request)
+        await use_case.update_schedule(agent.id, "schedule-123", request)
         mock_service.update_schedule.assert_called_once_with(
-            agent.id, "daily-summary", request
+            agent.id, "schedule-123", request
         )
 
     async def test_trigger_delegates(self, use_case, mock_service, agent):
-        await use_case.trigger_schedule(agent.id, "daily-summary")
-        mock_service.trigger_schedule.assert_called_once_with(agent.id, "daily-summary")
+        await use_case.trigger_schedule(agent.id, "schedule-123")
+        mock_service.trigger_schedule.assert_called_once_with(agent.id, "schedule-123")


### PR DESCRIPTION
## Summary
- Use immutable schedule row ids as the stable handle for run-schedule authorization and mutations.
- Keep name-based routes as explicit convenience aliases under `/name/{name}` while making `name` a mutable active-row label.
- Add a safe index migration so active schedule names remain unique per agent while deleted names can be reused. Addressing comment by @NiteshDhanpal here https://github.com/scaleapi/scale-agentex/pull/335#discussion_r3477363668

## Test plan
- `uv run pytest tests/unit/services/test_agent_run_schedule_service.py tests/unit/api/test_agent_run_schedules_authz.py tests/unit/use_cases/test_agent_run_schedules_use_case.py`
- Pre-commit hooks: ruff, ruff-format, OpenAPI generation, migration safety lint


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the planned fast-follow from the earlier schedules PR: schedule identity is moved from the human-readable `name` to the immutable row `id`, making name a mutable label and closing the rename/auth-race the previous design could not support.

- **Auth selector + primary routes** are rebased onto `schedule_id` (`run-schedule::{agent_id}::{schedule_id}`); all existing service methods are updated from name-based to ID-based signatures with matching test coverage.
- **`/name/{name}` convenience aliases** are added for every mutating and read route; a shared `_resolve_name_alias_and_check` helper resolves name → id, then performs the authz check on the stable id, and equalises the 404 body on both absent-name and access-denied paths so the resolved id is never leaked to an unauthorized caller.
- **Schedule rename** is enabled via a new `name` field on `UpdateAgentRunScheduleRequest`, guarded by an application-level conflict pre-check plus a `DuplicateItemError` backstop at the DB layer.
- **Migration** replaces the full `(agent_id, name)` unique index with a partial index scoped to active rows (`deleted_at IS NULL`), making deleted names reusable; the downgrade path pre-checks for duplicate names before attempting to recreate the old constraint and raises a descriptive `RuntimeError` if cleanup is required.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the auth selector migration, route expansion, and rename feature are all internally consistent and well-tested.

All primary operations (create, get, update, delete, pause, resume, trigger) now resolve through stable row IDs. The name-alias resolver correctly equalises absent-name and denied-resource error paths, preventing id/existence probing. The migration is online-safe (CONCURRENTLY with IF NOT EXISTS / IF EXISTS guards), and the downgrade proactively guards against data states that would violate the old constraint. The Temporal-before-DB ordering on updates is unchanged from the pre-existing pattern and is explicitly documented. Unit tests cover the new rename paths, the TOCTOU backstop, and the id-leak-prevention invariant.

The migration downgrade path in `2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py` deserves a second look before any rollback attempt — it will raise if name reuse has already occurred, so a data-cleanup runbook should be prepared alongside this deploy.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agentex/database/migrations/alembic/versions/2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py | Adds partial unique index on active schedules (deleted_at IS NULL) and drops the old full-table index; downgrade pre-checks for duplicate names but will raise RuntimeError after any name reuse, requiring manual data cleanup before rollback. |
| agentex/src/api/routes/agent_run_schedules.py | Doubles route count by adding /name/{name} alias endpoints alongside the refactored /{schedule_id} primary routes; name resolution uses _resolve_name_alias_and_check which equalizes error messages on both absent-name and denied-access paths to prevent id/existence leakage. |
| agentex/src/domain/services/agent_run_schedule_service.py | Switches auth selector key from name to immutable row id, adds get_schedule_id_by_name helper, and extends update_schedule to support name rename with a TOCTOU-safe pre-check plus DuplicateItemError catch as a backstop. |
| agentex/src/domain/repositories/agent_run_schedule_repository.py | Adds get_by_agent_id_and_id / get_by_agent_id_and_id_or_raise for ID-keyed lookups; renames the existing name-based or_raise variant accordingly; existing get_by_agent_id_and_name is retained for name-alias resolution. |
| agentex/src/api/schemas/agent_run_schedules.py | Adds optional name field to UpdateAgentRunScheduleRequest (enabling renames) and updates docstring/description strings to reflect that name is now a mutable label rather than an immutable natural key. |
| agentex/src/utils/schedule_authorization.py | Adds not_found_message override parameter so name-addressed routes can substitute a name-based 404 body, preventing an unauthorized caller from distinguishing a denied resource from an absent one. |
| agentex/src/adapters/orm.py | Updates ORM index definition to use the partial index name matching the migration and adds postgresql_where clause to enforce uniqueness only among active rows. |
| agentex/tests/unit/api/test_agent_run_schedules_authz.py | Adds tests for the name-alias resolution flow including the denied-access case that verifies the resolved id is never echoed back to an unauthorized caller. |
| agentex/tests/unit/services/test_agent_run_schedule_service.py | Covers new rename scenarios: allowed rename, duplicate active name rejection, and DuplicateItemError-to-ClientError conversion; also adds TestAgentRunScheduleServiceNameLookup for the new get_schedule_id_by_name helper. |
| agentex/tests/unit/use_cases/test_agent_run_schedules_use_case.py | Adds delegation test for get_schedule_id_by_name and updates all existing tests to use schedule IDs instead of names as the primary handle. |
| agentex/src/domain/use_cases/agent_run_schedules_use_case.py | Mechanically updates all method signatures from name-based to schedule_id-based and adds get_schedule_id_by_name delegation; no logic changes. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router
    participant NameResolver as _resolve_name_alias_and_check
    participant UseCase as AgentRunSchedulesUseCase
    participant Service as AgentRunScheduleService
    participant Repo as AgentRunScheduleRepository
    participant Auth as AuthorizationService
    participant Temporal

    Note over Client,Temporal: ID-based route (stable handle)
    Client->>Router: "GET /schedules/{schedule_id}"
    Router->>Auth: "check(resource=schedule(selector), op=read)"
    Auth-->>Router: ok
    Router->>UseCase: get_schedule(agent_id, schedule_id)
    UseCase->>Service: get_schedule(agent_id, schedule_id)
    Service->>Repo: get_by_agent_id_and_id_or_raise(agent_id, schedule_id)
    Repo-->>Service: AgentRunScheduleEntity
    Service->>Temporal: describe_schedule(temporal_id)
    Temporal-->>Service: ScheduleDescription
    Service-->>Client: AgentRunScheduleResponse

    Note over Client,Temporal: Name-alias route (resolves to ID first)
    Client->>Router: "GET /schedules/name/{name}"
    Router->>NameResolver: "resolve(agent_id, name, op=read)"
    NameResolver->>UseCase: get_schedule_id_by_name(agent_id, name)
    UseCase->>Service: get_schedule_id_by_name(agent_id, name)
    Service->>Repo: get_by_agent_id_and_name(agent_id, name)
    alt schedule not found
        Repo-->>NameResolver: None - raise ItemDoesNotExist(name-message)
        NameResolver-->>Client: 404 (name-based message)
    else schedule found
        Repo-->>NameResolver: schedule_id
        NameResolver->>Auth: "check(resource=schedule(selector by id), op=read)"
        alt denied
            Auth-->>NameResolver: AuthorizationError
            NameResolver-->>Client: 404 (same name-based message, hides id)
        else allowed
            NameResolver-->>Router: schedule_id
            Router->>UseCase: get_schedule(agent_id, schedule_id)
            UseCase-->>Client: AgentRunScheduleResponse
        end
    end

    Note over Client,Temporal: Schedule rename
    Client->>Router: "PATCH /schedules/{schedule_id} name=new-name"
    Router->>Auth: "check(op=update)"
    Router->>UseCase: update_schedule(agent_id, schedule_id, request)
    UseCase->>Service: update_schedule(...)
    Service->>Repo: get_by_agent_id_and_id_or_raise
    Service->>Repo: get_by_agent_id_and_name(new-name) conflict check
    alt name conflict
        Service-->>Client: 400 ClientError
    else name available
        Service->>Temporal: update_schedule(temporal_id, cadence/window)
        Service->>Repo: update(row with new name)
        Repo-->>Client: AgentRunScheduleResponse
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router
    participant NameResolver as _resolve_name_alias_and_check
    participant UseCase as AgentRunSchedulesUseCase
    participant Service as AgentRunScheduleService
    participant Repo as AgentRunScheduleRepository
    participant Auth as AuthorizationService
    participant Temporal

    Note over Client,Temporal: ID-based route (stable handle)
    Client->>Router: "GET /schedules/{schedule_id}"
    Router->>Auth: "check(resource=schedule(selector), op=read)"
    Auth-->>Router: ok
    Router->>UseCase: get_schedule(agent_id, schedule_id)
    UseCase->>Service: get_schedule(agent_id, schedule_id)
    Service->>Repo: get_by_agent_id_and_id_or_raise(agent_id, schedule_id)
    Repo-->>Service: AgentRunScheduleEntity
    Service->>Temporal: describe_schedule(temporal_id)
    Temporal-->>Service: ScheduleDescription
    Service-->>Client: AgentRunScheduleResponse

    Note over Client,Temporal: Name-alias route (resolves to ID first)
    Client->>Router: "GET /schedules/name/{name}"
    Router->>NameResolver: "resolve(agent_id, name, op=read)"
    NameResolver->>UseCase: get_schedule_id_by_name(agent_id, name)
    UseCase->>Service: get_schedule_id_by_name(agent_id, name)
    Service->>Repo: get_by_agent_id_and_name(agent_id, name)
    alt schedule not found
        Repo-->>NameResolver: None - raise ItemDoesNotExist(name-message)
        NameResolver-->>Client: 404 (name-based message)
    else schedule found
        Repo-->>NameResolver: schedule_id
        NameResolver->>Auth: "check(resource=schedule(selector by id), op=read)"
        alt denied
            Auth-->>NameResolver: AuthorizationError
            NameResolver-->>Client: 404 (same name-based message, hides id)
        else allowed
            NameResolver-->>Router: schedule_id
            Router->>UseCase: get_schedule(agent_id, schedule_id)
            UseCase-->>Client: AgentRunScheduleResponse
        end
    end

    Note over Client,Temporal: Schedule rename
    Client->>Router: "PATCH /schedules/{schedule_id} name=new-name"
    Router->>Auth: "check(op=update)"
    Router->>UseCase: update_schedule(agent_id, schedule_id, request)
    UseCase->>Service: update_schedule(...)
    Service->>Repo: get_by_agent_id_and_id_or_raise
    Service->>Repo: get_by_agent_id_and_name(new-name) conflict check
    alt name conflict
        Service-->>Client: 400 ClientError
    else name available
        Service->>Temporal: update_schedule(temporal_id, cadence/window)
        Service->>Repo: update(row with new name)
        Repo-->>Client: AgentRunScheduleResponse
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `agentex/database/migrations/alembic/versions/2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py`, line 42-52 ([link](https://github.com/scaleapi/scale-agentex/blob/34dc76ff1fa4b3caafbde8f4a024f2a38af8b150/agentex/database/migrations/alembic/versions/2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py#L42-L52)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Downgrade will fail after name reuse**

   The `downgrade()` function tries to build a full (non-partial) unique index on `(agent_id, name)` covering all rows, including soft-deleted ones. Once the system runs under the new partial index, it becomes possible for a deleted row and an active row to share the same `(agent_id, name)` — for example, after a schedule is deleted and then re-created under the same name. In that state `CREATE UNIQUE INDEX CONCURRENTLY … ON agent_run_schedules (agent_id, name)` will fail with a uniqueness violation, leaving the database without any `(agent_id, name)` uniqueness constraint while the partial index has not yet been dropped. A data-cleanup step would be needed before a safe rollback can be performed.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: agentex/database/migrations/alembic/versions/2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py
   Line: 42-52

   Comment:
   **Downgrade will fail after name reuse**

   The `downgrade()` function tries to build a full (non-partial) unique index on `(agent_id, name)` covering all rows, including soft-deleted ones. Once the system runs under the new partial index, it becomes possible for a deleted row and an active row to share the same `(agent_id, name)` — for example, after a schedule is deleted and then re-created under the same name. In that state `CREATE UNIQUE INDEX CONCURRENTLY … ON agent_run_schedules (agent_id, name)` will fail with a uniqueness violation, leaving the database without any `(agent_id, name)` uniqueness constraint while the partial index has not yet been dropped. A data-cleanup step would be needed before a safe rollback can be performed.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fdatabase%2Fmigrations%2Falembic%2Fversions%2F2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py%0ALine%3A%2042-52%0A%0AComment%3A%0A**Downgrade%20will%20fail%20after%20name%20reuse**%0A%0AThe%20%60downgrade%28%29%60%20function%20tries%20to%20build%20a%20full%20%28non-partial%29%20unique%20index%20on%20%60%28agent_id%2C%20name%29%60%20covering%20all%20rows%2C%20including%20soft-deleted%20ones.%20Once%20the%20system%20runs%20under%20the%20new%20partial%20index%2C%20it%20becomes%20possible%20for%20a%20deleted%20row%20and%20an%20active%20row%20to%20share%20the%20same%20%60%28agent_id%2C%20name%29%60%20%E2%80%94%20for%20example%2C%20after%20a%20schedule%20is%20deleted%20and%20then%20re-created%20under%20the%20same%20name.%20In%20that%20state%20%60CREATE%20UNIQUE%20INDEX%20CONCURRENTLY%20%E2%80%A6%20ON%20agent_run_schedules%20%28agent_id%2C%20name%29%60%20will%20fail%20with%20a%20uniqueness%20violation%2C%20leaving%20the%20database%20without%20any%20%60%28agent_id%2C%20name%29%60%20uniqueness%20constraint%20while%20the%20partial%20index%20has%20not%20yet%20been%20dropped.%20A%20data-cleanup%20step%20would%20be%20needed%20before%20a%20safe%20rollback%20can%20be%20performed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fdatabase%2Fmigrations%2Falembic%2Fversions%2F2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py%0ALine%3A%2042-52%0A%0AComment%3A%0A**Downgrade%20will%20fail%20after%20name%20reuse**%0A%0AThe%20%60downgrade%28%29%60%20function%20tries%20to%20build%20a%20full%20%28non-partial%29%20unique%20index%20on%20%60%28agent_id%2C%20name%29%60%20covering%20all%20rows%2C%20including%20soft-deleted%20ones.%20Once%20the%20system%20runs%20under%20the%20new%20partial%20index%2C%20it%20becomes%20possible%20for%20a%20deleted%20row%20and%20an%20active%20row%20to%20share%20the%20same%20%60%28agent_id%2C%20name%29%60%20%E2%80%94%20for%20example%2C%20after%20a%20schedule%20is%20deleted%20and%20then%20re-created%20under%20the%20same%20name.%20In%20that%20state%20%60CREATE%20UNIQUE%20INDEX%20CONCURRENTLY%20%E2%80%A6%20ON%20agent_run_schedules%20%28agent_id%2C%20name%29%60%20will%20fail%20with%20a%20uniqueness%20violation%2C%20leaving%20the%20database%20without%20any%20%60%28agent_id%2C%20name%29%60%20uniqueness%20constraint%20while%20the%20partial%20index%20has%20not%20yet%20been%20dropped.%20A%20data-cleanup%20step%20would%20be%20needed%20before%20a%20safe%20rollback%20can%20be%20performed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22jerome%2Fschedule-id-handles%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22jerome%2Fschedule-id-handles%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fdatabase%2Fmigrations%2Falembic%2Fversions%2F2026_07_08_1626_schedule_identity_id_handles_9a4b8c7d6e5f.py%0ALine%3A%2042-52%0A%0AComment%3A%0A**Downgrade%20will%20fail%20after%20name%20reuse**%0A%0AThe%20%60downgrade%28%29%60%20function%20tries%20to%20build%20a%20full%20%28non-partial%29%20unique%20index%20on%20%60%28agent_id%2C%20name%29%60%20covering%20all%20rows%2C%20including%20soft-deleted%20ones.%20Once%20the%20system%20runs%20under%20the%20new%20partial%20index%2C%20it%20becomes%20possible%20for%20a%20deleted%20row%20and%20an%20active%20row%20to%20share%20the%20same%20%60%28agent_id%2C%20name%29%60%20%E2%80%94%20for%20example%2C%20after%20a%20schedule%20is%20deleted%20and%20then%20re-created%20under%20the%20same%20name.%20In%20that%20state%20%60CREATE%20UNIQUE%20INDEX%20CONCURRENTLY%20%E2%80%A6%20ON%20agent_run_schedules%20%28agent_id%2C%20name%29%60%20will%20fail%20with%20a%20uniqueness%20violation%2C%20leaving%20the%20database%20without%20any%20%60%28agent_id%2C%20name%29%60%20uniqueness%20constraint%20while%20the%20partial%20index%20has%20not%20yet%20been%20dropped.%20A%20data-cleanup%20step%20would%20be%20needed%20before%20a%20safe%20rollback%20can%20be%20performed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into jerome/schedule..."](https://github.com/scaleapi/scale-agentex/commit/07548599835ff2f02b21107156ee67033257a79e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42773859)</sub>

<!-- /greptile_comment -->