### PR TITLE
feat(agentex-ui): account picker via same-origin BFF proxy

### DIFF
--- a/agentex-ui/DOCKER.md
+++ b/agentex-ui/DOCKER.md
@@ -91,13 +91,13 @@ The application runs with the following default environment variables:
 - `PORT=3000`
 - `HOSTNAME=0.0.0.0`
 
-To configure public runtime variables, pass them when running the container:
+To configure runtime variables, pass them when running the container:
 
 ```bash
 # Explicit env flags
 docker run --rm -p 3000:3000 \
-  -e NEXT_PUBLIC_AGENTEX_API_BASE_URL=http://localhost:5003 \
-  -e NEXT_PUBLIC_SGP_APP_URL=https://egp.dashboard.scale.com \
+  -e AGENTEX_API_URL=http://localhost:5003 \
+  -e NEXT_PUBLIC_SGP_APP_URL=https://app.example.com \
   agentex-ui:latest
 
 # Or via an env file

--- a/agentex-ui/README.md
+++ b/agentex-ui/README.md
@@ -96,8 +96,8 @@ cp example.env.development .env.development
 Edit `.env.development` with your configuration:
 
 ```bash
-# Backend API endpoint
-NEXT_PUBLIC_AGENTEX_API_BASE_URL=http://localhost:5003
+# Backend API endpoint — server-only upstream for the /api/agentex BFF proxy
+AGENTEX_API_URL=http://localhost:5003
 ```
 
 ### 3. Install Dependencies

--- a/agentex-ui/app/api/_lib/bff.ts
+++ b/agentex-ui/app/api/_lib/bff.ts
@@ -1,0 +1,30 @@
+/**
+ * Server-only platform API upstream, shared by the platform-backed BFF routes
+ * (/api/feedback, /api/user-info). SGP_API_URL preferred; falls back to the dashboard
+ * app origin's /api.
+ */
+export const SGP_BASE_URL =
+  process.env.SGP_API_URL ??
+  (process.env.NEXT_PUBLIC_SGP_APP_URL
+    ? `${process.env.NEXT_PUBLIC_SGP_APP_URL}/api`
+    : undefined);
+
+/**
+ * Apply BFF credentials to an outgoing upstream request's `headers`, in place, so no
+ * credential reaches client JS. Shared by every /api/* proxy (agentex, platform):
+ *   - `x-selected-account-id` from the client (sourced from the account_id query param);
+ *     forwarded as-is — the upstream authorizes the principal's access to the account.
+ *   - the request cookies are forwarded for the upstream's own cookie auth.
+ */
+export async function applyBffCredentials(
+  req: Request,
+  headers: Headers
+): Promise<void> {
+  const accountId = req.headers.get('x-selected-account-id');
+  if (accountId) headers.set('x-selected-account-id', accountId);
+  else headers.delete('x-selected-account-id');
+
+  const cookie = req.headers.get('cookie');
+  if (cookie) headers.set('cookie', cookie);
+  else headers.delete('cookie');
+}

--- a/agentex-ui/app/api/_lib/bff.ts
+++ b/agentex-ui/app/api/_lib/bff.ts
@@ -1,8 +1,4 @@
-/**
- * Server-only platform API upstream, shared by the platform-backed BFF routes
- * (/api/feedback, /api/user-info). SGP_API_URL preferred; falls back to the dashboard
- * app origin's /api.
- */
+/** Server-only platform API base for the BFF routes. Prefers SGP_API_URL, else the app URL. */
 export const SGP_BASE_URL =
   process.env.SGP_API_URL ??
   (process.env.NEXT_PUBLIC_SGP_APP_URL
@@ -10,12 +6,9 @@ export const SGP_BASE_URL =
     : undefined);
 
 /**
- * Apply BFF credentials to an outgoing upstream request's `headers`, in place, so no
- * credential reaches client JS. Shared by every /api/* proxy (agentex, platform):
- *   - `x-selected-account-id` from the client (sourced from the account_id query param);
- *     forwarded as-is — the upstream authorizes the principal's access to the account.
- *   - any client-supplied `authorization` is dropped so a client can't inject its own
- *     bearer token; the request cookies are forwarded for the upstream's cookie auth.
+ * Attach credentials to an upstream request's `headers` in place, so none reach client JS:
+ * forward `x-selected-account-id` (the upstream authorizes the account), drop any
+ * client-sent `authorization`, and forward cookies for the upstream's own auth.
  */
 export async function applyBffCredentials(
   req: Request,
@@ -25,7 +18,6 @@ export async function applyBffCredentials(
   if (accountId) headers.set('x-selected-account-id', accountId);
   else headers.delete('x-selected-account-id');
 
-  // Credentials are server-managed: never trust a client-sent Authorization header.
   headers.delete('authorization');
 
   const cookie = req.headers.get('cookie');

--- a/agentex-ui/app/api/_lib/bff.ts
+++ b/agentex-ui/app/api/_lib/bff.ts
@@ -5,10 +5,26 @@ export const SGP_BASE_URL =
     ? `${process.env.NEXT_PUBLIC_SGP_APP_URL}/api`
     : undefined);
 
+/** Return the Cookie header with the named cookie removed (null if nothing remains). */
+function stripCookie(header: string | null, name: string): string | null {
+  if (!header) return null;
+  const kept = header
+    .split(';')
+    .map(c => c.trim())
+    .filter(c => {
+      const eq = c.indexOf('=');
+      return (eq === -1 ? c : c.slice(0, eq)) !== name;
+    });
+  return kept.length ? kept.join('; ') : null;
+}
+
 /**
  * Attach credentials to an upstream request's `headers` in place, so none reach client JS:
  * forward `x-selected-account-id` (the upstream authorizes the account), drop any
- * client-sent `authorization`, and forward cookies for the upstream's own auth.
+ * client-sent `authorization`, and forward cookies for the upstream's own auth — minus the
+ * account-scoped `_jwt` (access-profile) cookie. Cookie-auth backends prioritize `_jwt` over
+ * `x-selected-account-id`, so leaving it would pin the account to the one the user linked in
+ * with and ignore the selected account; identity still comes from `_identityJwt`.
  */
 export async function applyBffCredentials(
   req: Request,
@@ -20,7 +36,7 @@ export async function applyBffCredentials(
 
   headers.delete('authorization');
 
-  const cookie = req.headers.get('cookie');
+  const cookie = stripCookie(req.headers.get('cookie'), '_jwt');
   if (cookie) headers.set('cookie', cookie);
   else headers.delete('cookie');
 }

--- a/agentex-ui/app/api/_lib/bff.ts
+++ b/agentex-ui/app/api/_lib/bff.ts
@@ -14,7 +14,8 @@ export const SGP_BASE_URL =
  * credential reaches client JS. Shared by every /api/* proxy (agentex, platform):
  *   - `x-selected-account-id` from the client (sourced from the account_id query param);
  *     forwarded as-is — the upstream authorizes the principal's access to the account.
- *   - the request cookies are forwarded for the upstream's own cookie auth.
+ *   - any client-supplied `authorization` is dropped so a client can't inject its own
+ *     bearer token; the request cookies are forwarded for the upstream's cookie auth.
  */
 export async function applyBffCredentials(
   req: Request,
@@ -23,6 +24,9 @@ export async function applyBffCredentials(
   const accountId = req.headers.get('x-selected-account-id');
   if (accountId) headers.set('x-selected-account-id', accountId);
   else headers.delete('x-selected-account-id');
+
+  // Credentials are server-managed: never trust a client-sent Authorization header.
+  headers.delete('authorization');
 
   const cookie = req.headers.get('cookie');
   if (cookie) headers.set('cookie', cookie);

--- a/agentex-ui/app/api/agentex/[...path]/route.ts
+++ b/agentex-ui/app/api/agentex/[...path]/route.ts
@@ -14,8 +14,10 @@ const UPSTREAM = (
   process.env.AGENTEX_API_URL ?? 'http://localhost:5003'
 ).replace(/\/$/, '');
 
-// Hop-by-hop / spoofable request headers to drop before forwarding. `cookie` and
-// `authorization` are managed by applyBffCredentials, not stripped here.
+// Hop-by-hop request headers to drop before forwarding. Credential headers (`cookie`,
+// `authorization`) are intentionally NOT listed here: applyBffCredentials owns them — it
+// deletes any client-supplied values and sets the server-managed ones — so the same
+// stripping applies to every /api/* proxy, not just this route.
 const STRIP_REQ = ['host', 'connection', 'content-length'];
 const STRIP_RES = [
   'content-encoding',

--- a/agentex-ui/app/api/agentex/[...path]/route.ts
+++ b/agentex-ui/app/api/agentex/[...path]/route.ts
@@ -1,23 +1,17 @@
 import { applyBffCredentials } from '@/app/api/_lib/bff';
 
 /**
- * BFF proxy for the Agentex API. The browser ALWAYS calls this same-origin route, so
- * the backend origin + credentials never touch client JS. Credentials (access token
- * or forwarded cookies, plus x-selected-account-id) are applied server-side by
- * applyBffCredentials — see app/api/_lib/bff.ts.
+ * Same-origin BFF proxy for the Agentex API, so the upstream URL and credentials never
+ * reach client JS. applyBffCredentials attaches credentials server-side.
  */
 export const dynamic = 'force-dynamic';
 
-// Server-only upstream — the client only ever calls /api/agentex, so the backend URL
-// stays out of the browser bundle.
 const UPSTREAM = (
   process.env.AGENTEX_API_URL ?? 'http://localhost:5003'
 ).replace(/\/$/, '');
 
-// Hop-by-hop request headers to drop before forwarding. Credential headers (`cookie`,
-// `authorization`) are intentionally NOT listed here: applyBffCredentials owns them — it
-// deletes any client-supplied values and sets the server-managed ones — so the same
-// stripping applies to every /api/* proxy, not just this route.
+// Hop-by-hop headers to drop. Credential headers (cookie/authorization) are handled by
+// applyBffCredentials, not here.
 const STRIP_REQ = ['host', 'connection', 'content-length'];
 const STRIP_RES = [
   'content-encoding',

--- a/agentex-ui/app/api/agentex/[...path]/route.ts
+++ b/agentex-ui/app/api/agentex/[...path]/route.ts
@@ -50,6 +50,10 @@ async function proxy(
   // Pass the upstream body through unbuffered so SSE / streaming responses work.
   const resHeaders = new Headers(upstream.headers);
   for (const h of STRIP_RES) resHeaders.delete(h);
+  // Don't leak an upstream (internal) redirect target to the browser.
+  if (upstream.status >= 300 && upstream.status < 400) {
+    resHeaders.delete('location');
+  }
   return new Response(upstream.body, {
     status: upstream.status,
     headers: resHeaders,

--- a/agentex-ui/app/api/agentex/[...path]/route.ts
+++ b/agentex-ui/app/api/agentex/[...path]/route.ts
@@ -1,0 +1,67 @@
+import { applyBffCredentials } from '@/app/api/_lib/bff';
+
+/**
+ * BFF proxy for the Agentex API. The browser ALWAYS calls this same-origin route, so
+ * the backend origin + credentials never touch client JS. Credentials (access token
+ * or forwarded cookies, plus x-selected-account-id) are applied server-side by
+ * applyBffCredentials — see app/api/_lib/bff.ts.
+ */
+export const dynamic = 'force-dynamic';
+
+// Server-only upstream — the client only ever calls /api/agentex, so the backend URL
+// stays out of the browser bundle.
+const UPSTREAM = (
+  process.env.AGENTEX_API_URL ?? 'http://localhost:5003'
+).replace(/\/$/, '');
+
+// Hop-by-hop / spoofable request headers to drop before forwarding. `cookie` and
+// `authorization` are managed by applyBffCredentials, not stripped here.
+const STRIP_REQ = ['host', 'connection', 'content-length'];
+const STRIP_RES = [
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+  'connection',
+];
+
+async function proxy(
+  req: Request,
+  ctx: { params: Promise<{ path?: string[] }> }
+): Promise<Response> {
+  const { path = [] } = await ctx.params;
+  const search = new URL(req.url).search;
+  const target = `${UPSTREAM}/${path.join('/')}${search}`;
+
+  const headers = new Headers(req.headers);
+  for (const h of STRIP_REQ) headers.delete(h);
+  await applyBffCredentials(req, headers);
+
+  const method = req.method.toUpperCase();
+  const hasBody = method !== 'GET' && method !== 'HEAD';
+  const upstream = await fetch(target, {
+    method,
+    headers,
+    body: hasBody ? req.body : undefined,
+    redirect: 'manual',
+    // @ts-expect-error `duplex` is required to stream a request body (undici)
+    duplex: 'half',
+  });
+
+  // Pass the upstream body through unbuffered so SSE / streaming responses work.
+  const resHeaders = new Headers(upstream.headers);
+  for (const h of STRIP_RES) resHeaders.delete(h);
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: resHeaders,
+  });
+}
+
+export {
+  proxy as DELETE,
+  proxy as GET,
+  proxy as HEAD,
+  proxy as OPTIONS,
+  proxy as PATCH,
+  proxy as POST,
+  proxy as PUT,
+};

--- a/agentex-ui/app/api/feedback/route.ts
+++ b/agentex-ui/app/api/feedback/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+import { applyBffCredentials, SGP_BASE_URL } from '@/app/api/_lib/bff';
+
 type FeedbackRequestBody = {
   traceId: string;
   messageId: string;
@@ -13,33 +15,10 @@ type FeedbackRequestBody = {
   agentAcpType?: string;
 };
 
-const SGP_BASE_URL =
-  process.env.NEXT_PUBLIC_SGP_API_URL ??
-  (process.env.NEXT_PUBLIC_SGP_APP_URL
-    ? `${process.env.NEXT_PUBLIC_SGP_APP_URL}/api`
-    : undefined);
-
-function getSGPHeaders(request: Request): Record<string, string> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-  const forwarded = [
-    'cookie',
-    'authorization',
-    'x-api-key',
-    'x-selected-account-id',
-  ];
-  for (const key of forwarded) {
-    const value = request.headers.get(key);
-    if (value) headers[key] = value;
-  }
-  return headers;
-}
-
 async function sgpPost<T>(
   path: string,
   body: unknown,
-  headers: Record<string, string>
+  headers: Headers
 ): Promise<T> {
   const res = await fetch(`${SGP_BASE_URL}${path}`, {
     method: 'POST',
@@ -57,8 +36,7 @@ export async function POST(request: Request) {
   if (!SGP_BASE_URL) {
     return NextResponse.json(
       {
-        error:
-          'SGP feedback is not configured. Set NEXT_PUBLIC_SGP_API_URL or NEXT_PUBLIC_SGP_APP_URL.',
+        error: 'SGP feedback is not configured. Set SGP_API_URL.',
       },
       { status: 503 }
     );
@@ -100,7 +78,10 @@ export async function POST(request: Request) {
     );
   }
 
-  const sgpHeaders = getSGPHeaders(request);
+  // Same server-side credentials the agentex proxy forwards (access token or cookies,
+  // plus x-selected-account-id) — the client never sends them.
+  const sgpHeaders = new Headers({ 'Content-Type': 'application/json' });
+  await applyBffCredentials(request, sgpHeaders);
   const now = new Date().toISOString();
 
   try {

--- a/agentex-ui/app/api/feedback/route.ts
+++ b/agentex-ui/app/api/feedback/route.ts
@@ -78,8 +78,7 @@ export async function POST(request: Request) {
     );
   }
 
-  // Same server-side credentials the agentex proxy forwards (access token or cookies,
-  // plus x-selected-account-id) — the client never sends them.
+  // Credentials attached server-side (see applyBffCredentials).
   const sgpHeaders = new Headers({ 'Content-Type': 'application/json' });
   await applyBffCredentials(request, sgpHeaders);
   const now = new Date().toISOString();

--- a/agentex-ui/app/api/user-info/route.ts
+++ b/agentex-ui/app/api/user-info/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+import { applyBffCredentials, SGP_BASE_URL } from '@/app/api/_lib/bff';
+
+/**
+ * BFF proxy for the one SGP endpoint agentex-ui needs client-side: the caller's
+ * accounts (access_profiles), used to bootstrap / switch the selected account. Scoped
+ * to just this path — deliberately NOT a catch-all SGP proxy — so the browser can't
+ * reach arbitrary SGP endpoints with the server-attached credentials.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request): Promise<Response> {
+  if (!SGP_BASE_URL) {
+    return NextResponse.json(
+      { error: 'SGP is not configured. Set SGP_API_URL.' },
+      { status: 503 }
+    );
+  }
+
+  const headers = new Headers({ accept: 'application/json' });
+  await applyBffCredentials(request, headers);
+  const upstream = await fetch(`${SGP_BASE_URL}/user-info`, { headers });
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/agentex-ui/app/api/user-info/route.ts
+++ b/agentex-ui/app/api/user-info/route.ts
@@ -3,10 +3,9 @@ import { NextResponse } from 'next/server';
 import { applyBffCredentials, SGP_BASE_URL } from '@/app/api/_lib/bff';
 
 /**
- * BFF proxy for the one SGP endpoint agentex-ui needs client-side: the caller's
- * accounts (access_profiles), used to bootstrap / switch the selected account. Scoped
- * to just this path — deliberately NOT a catch-all SGP proxy — so the browser can't
- * reach arbitrary SGP endpoints with the server-attached credentials.
+ * Scoped BFF proxy for the caller's accounts (access_profiles), used to bootstrap/switch
+ * the selected account. Only this path is exposed — not a catch-all — so the browser can't
+ * reach arbitrary platform endpoints with the server-attached credentials.
  */
 export const dynamic = 'force-dynamic';
 

--- a/agentex-ui/app/page.tsx
+++ b/agentex-ui/app/page.tsx
@@ -7,23 +7,13 @@ export default async function RootPage() {
   await connection();
 
   const sgpAppURL = process.env.NEXT_PUBLIC_SGP_APP_URL ?? '';
-  const agentexAPIBaseURL =
-    process.env.NEXT_PUBLIC_AGENTEX_API_BASE_URL ?? 'http://localhost:5003';
-
-  if (!agentexAPIBaseURL) {
-    return (
-      <div role="alert">
-        <p>Missing some configs</p>
-        <pre>{JSON.stringify({ sgpAppURL, agentexAPIBaseURL }, null, 2)}</pre>
-      </div>
-    );
-  }
+  // The account picker needs the platform API (accounts come from /api/user-info).
+  const accountsEnabled = !!(
+    process.env.SGP_API_URL ?? process.env.NEXT_PUBLIC_SGP_APP_URL
+  );
 
   return (
-    <AgentexProvider
-      sgpAppURL={sgpAppURL}
-      agentexAPIBaseURL={agentexAPIBaseURL}
-    >
+    <AgentexProvider accountsEnabled={accountsEnabled} sgpAppURL={sgpAppURL}>
       <AgentexUIRoot />
     </AgentexProvider>
   );

--- a/agentex-ui/components/account-picker/account-picker.tsx
+++ b/agentex-ui/components/account-picker/account-picker.tsx
@@ -37,10 +37,9 @@ export function AccountPicker({
   const profiles = useMemo(() => data?.access_profiles ?? [], [data]);
   const selectedId = selectedAccountId ?? undefined;
 
-  // Reset (not just invalidate) account-scoped data on a switch. invalidate keeps the
-  // previous data cached during the refetch, so the new account would briefly render the
-  // old account's agents (HomeView) before recalibrating; reset clears it so we show a
-  // loading state instead. user-info is preserved — the account list doesn't change.
+  // Reset (not invalidate) account-scoped data on switch: invalidate keeps the old data
+  // cached during refetch, briefly showing the previous account's agents. user-info is
+  // preserved — the account list doesn't change on switch.
   const resetAccountScoped = useCallback(
     () =>
       queryClient.resetQueries({
@@ -73,8 +72,8 @@ export function AccountPicker({
 
   if (!accountsEnabled) return null;
 
-  // A size-9 icon tile — the collapsed-rail footprint. Shared by the loading placeholder
-  // (muted) and the single-account display (solid, with the name as a tooltip).
+  // Size-9 collapsed-rail tile — shared by the loading placeholder (muted) and the
+  // single-account display (solid).
   const iconTile = (opts?: { muted?: boolean; title?: string | undefined }) => (
     <div
       title={opts?.title}
@@ -89,8 +88,7 @@ export function AccountPicker({
     </div>
   );
 
-  // While accounts load, show a disabled, empty picker (icon only) instead of a skeleton
-  // block — keeps the row stable and reads as a loading account selector.
+  // Loading: a disabled, empty picker (icon only) rather than a skeleton — keeps the row stable.
   if (isLoading) {
     return collapsed ? (
       iconTile({ muted: true })
@@ -123,8 +121,7 @@ export function AccountPicker({
   );
 
   if (collapsed) {
-    // Single account → static icon; multiple → an icon-only trigger whose dropdown pops
-    // out beside the collapsed rail (Radix keeps it in view).
+    // Single → static icon; multiple → icon-only trigger (dropdown pops out beside the rail).
     if (single) return iconTile({ title: current?.account.name });
     return (
       <Select value={selectedId ?? ''} onValueChange={onAccountChange}>
@@ -142,8 +139,7 @@ export function AccountPicker({
     );
   }
 
-  // A single account needs no switcher — show it as static context, matching the New Chat
-  // button's size + spacing (size-5 icon, p-2, medium weight).
+  // Single account: no switcher, just static context (matches the New Chat button).
   if (single) {
     return (
       <div

--- a/agentex-ui/components/account-picker/account-picker.tsx
+++ b/agentex-ui/components/account-picker/account-picker.tsx
@@ -13,7 +13,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Skeleton } from '@/components/ui/skeleton';
 import { useUserInfo, userInfoKey } from '@/hooks/use-user-info';
 import { cn } from '@/lib/utils';
 
@@ -63,16 +62,30 @@ export function AccountPicker({
   }, [profiles, selectedId, setSelectedAccountId, refetchAccountScoped]);
 
   if (!accountsEnabled) return null;
-  // Reserve the picker's height while accounts load so New Chat doesn't jump when it
-  // appears. Once loaded with no accounts, render nothing.
+  // While accounts load, show a disabled, empty picker (building icon only) rather than
+  // a bare skeleton block — keeps the footer row stable and reads as "account selector,
+  // loading". Once loaded with no accounts, render nothing.
   if (isLoading) {
+    if (collapsed) {
+      return (
+        <div
+          className={cn('flex size-9 items-center justify-center', className)}
+        >
+          <Building2 className="text-muted-foreground size-5 shrink-0" />
+        </div>
+      );
+    }
     return (
-      <Skeleton
-        className={cn(
-          collapsed ? 'size-9 rounded-md' : 'h-9 w-full rounded-md',
-          className
-        )}
-      />
+      <Select disabled>
+        <SelectTrigger
+          aria-label="Account"
+          className={cn('w-full gap-2 rounded-md font-medium', className)}
+        >
+          <span className="flex flex-1 items-center gap-2 overflow-hidden text-left">
+            <Building2 className="text-muted-foreground size-5 shrink-0" />
+          </span>
+        </SelectTrigger>
+      </Select>
     );
   }
   if (profiles.length === 0) return null;

--- a/agentex-ui/components/account-picker/account-picker.tsx
+++ b/agentex-ui/components/account-picker/account-picker.tsx
@@ -37,11 +37,13 @@ export function AccountPicker({
   const profiles = useMemo(() => data?.access_profiles ?? [], [data]);
   const selectedId = selectedAccountId ?? undefined;
 
-  // Refetch account-scoped data (agents, tasks, …) on an account change — but NOT
-  // user-info: the account list itself doesn't change when you switch accounts.
-  const refetchAccountScoped = useCallback(
+  // Reset (not just invalidate) account-scoped data on a switch. invalidate keeps the
+  // previous data cached during the refetch, so the new account would briefly render the
+  // old account's agents (HomeView) before recalibrating; reset clears it so we show a
+  // loading state instead. user-info is preserved — the account list doesn't change.
+  const resetAccountScoped = useCallback(
     () =>
-      queryClient.invalidateQueries({
+      queryClient.resetQueries({
         predicate: q => q.queryKey[0] !== userInfoKey[0],
       }),
     [queryClient]
@@ -50,9 +52,9 @@ export function AccountPicker({
     (id: string) => {
       if (id === selectedId) return;
       setSelectedAccountId(id);
-      void refetchAccountScoped();
+      void resetAccountScoped();
     },
-    [selectedId, setSelectedAccountId, refetchAccountScoped]
+    [selectedId, setSelectedAccountId, resetAccountScoped]
   );
 
   // Default to the first account when the URL has no valid account_id (fixes the
@@ -66,8 +68,8 @@ export function AccountPicker({
     const first = profiles[0];
     if (!first) return;
     setSelectedAccountId(first.account.id, true);
-    void refetchAccountScoped();
-  }, [profiles, selectedId, setSelectedAccountId, refetchAccountScoped]);
+    void resetAccountScoped();
+  }, [profiles, selectedId, setSelectedAccountId, resetAccountScoped]);
 
   if (!accountsEnabled) return null;
 

--- a/agentex-ui/components/account-picker/account-picker.tsx
+++ b/agentex-ui/components/account-picker/account-picker.tsx
@@ -46,6 +46,14 @@ export function AccountPicker({
       }),
     [queryClient]
   );
+  const onAccountChange = useCallback(
+    (id: string) => {
+      if (id === selectedId) return;
+      setSelectedAccountId(id);
+      void refetchAccountScoped();
+    },
+    [selectedId, setSelectedAccountId, refetchAccountScoped]
+  );
 
   // Default to the first account when the URL has no valid account_id (fixes the
   // "no account → 401" first load). `replace` so it doesn't add a history entry.
@@ -62,20 +70,29 @@ export function AccountPicker({
   }, [profiles, selectedId, setSelectedAccountId, refetchAccountScoped]);
 
   if (!accountsEnabled) return null;
-  // While accounts load, show a disabled, empty picker (building icon only) rather than
-  // a bare skeleton block — keeps the footer row stable and reads as "account selector,
-  // loading". Once loaded with no accounts, render nothing.
+
+  // A size-9 icon tile — the collapsed-rail footprint. Shared by the loading placeholder
+  // (muted) and the single-account display (solid, with the name as a tooltip).
+  const iconTile = (opts?: { muted?: boolean; title?: string | undefined }) => (
+    <div
+      title={opts?.title}
+      className={cn('flex size-9 items-center justify-center', className)}
+    >
+      <Building2
+        className={cn(
+          'size-5 shrink-0',
+          opts?.muted ? 'text-muted-foreground' : 'text-foreground'
+        )}
+      />
+    </div>
+  );
+
+  // While accounts load, show a disabled, empty picker (icon only) instead of a skeleton
+  // block — keeps the row stable and reads as a loading account selector.
   if (isLoading) {
-    if (collapsed) {
-      return (
-        <div
-          className={cn('flex size-9 items-center justify-center', className)}
-        >
-          <Building2 className="text-muted-foreground size-5 shrink-0" />
-        </div>
-      );
-    }
-    return (
+    return collapsed ? (
+      iconTile({ muted: true })
+    ) : (
       <Select disabled>
         <SelectTrigger
           aria-label="Account"
@@ -88,31 +105,27 @@ export function AccountPicker({
       </Select>
     );
   }
+
   if (profiles.length === 0) return null;
 
-  const select = (id: string) => {
-    if (id === selectedId) return;
-    setSelectedAccountId(id);
-    void refetchAccountScoped();
-  };
-
   const current = profiles.find(p => p.account.id === selectedId);
+  const single = profiles.length === 1;
+  const options = (
+    <SelectContent>
+      {profiles.map(p => (
+        <SelectItem key={p.account.id} value={p.account.id}>
+          {p.account.name}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  );
 
   if (collapsed) {
     // Single account → static icon; multiple → an icon-only trigger whose dropdown pops
-    // out beside the collapsed rail (Radix positions it to stay in view).
-    if (profiles.length === 1) {
-      return (
-        <div
-          title={current?.account.name}
-          className={cn('flex size-9 items-center justify-center', className)}
-        >
-          <Building2 className="text-foreground size-5 shrink-0" />
-        </div>
-      );
-    }
+    // out beside the collapsed rail (Radix keeps it in view).
+    if (single) return iconTile({ title: current?.account.name });
     return (
-      <Select value={selectedId ?? ''} onValueChange={select}>
+      <Select value={selectedId ?? ''} onValueChange={onAccountChange}>
         <SelectTrigger
           aria-label="Account"
           className={cn(
@@ -122,23 +135,17 @@ export function AccountPicker({
         >
           <Building2 className="text-foreground size-5 shrink-0" />
         </SelectTrigger>
-        <SelectContent>
-          {profiles.map(p => (
-            <SelectItem key={p.account.id} value={p.account.id}>
-              {p.account.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
+        {options}
       </Select>
     );
   }
 
-  // A single account needs no switcher — show it as static context.
-  if (profiles.length === 1) {
+  // A single account needs no switcher — show it as static context, matching the New Chat
+  // button's size + spacing (size-5 icon, p-2, medium weight).
+  if (single) {
     return (
       <div
         className={cn(
-          // Match the New Chat button's size + spacing (size-5 icon, p-2, medium weight).
           'text-foreground flex items-center gap-2 p-2 text-sm font-medium select-none',
           className
         )}
@@ -150,7 +157,7 @@ export function AccountPicker({
   }
 
   return (
-    <Select value={selectedId ?? ''} onValueChange={select}>
+    <Select value={selectedId ?? ''} onValueChange={onAccountChange}>
       <SelectTrigger
         className={cn('w-full gap-2 rounded-md font-medium', className)}
         aria-label="Account"
@@ -162,13 +169,7 @@ export function AccountPicker({
           <SelectValue placeholder="Select account" />
         </span>
       </SelectTrigger>
-      <SelectContent>
-        {profiles.map(p => (
-          <SelectItem key={p.account.id} value={p.account.id}>
-            {p.account.name}
-          </SelectItem>
-        ))}
-      </SelectContent>
+      {options}
     </Select>
   );
 }

--- a/agentex-ui/components/account-picker/account-picker.tsx
+++ b/agentex-ui/components/account-picker/account-picker.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { Building2 } from 'lucide-react';
+
+import { useAgentexClient } from '@/components/providers';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useUserInfo, userInfoKey } from '@/hooks/use-user-info';
+import { cn } from '@/lib/utils';
+
+export type AccountPickerProps = {
+  className?: string;
+  collapsed?: boolean;
+};
+
+/**
+ * Current-account selector, driven by the `account_id` query param (the BFF turns it into
+ * the `x-selected-account-id` header). Bootstraps to the first account when the param is
+ * missing/stale — the API can't resolve a principal without it.
+ */
+export function AccountPicker({
+  className,
+  collapsed = false,
+}: AccountPickerProps) {
+  const { accountsEnabled, selectedAccountId, setSelectedAccountId } =
+    useAgentexClient();
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useUserInfo(accountsEnabled);
+  const profiles = useMemo(() => data?.access_profiles ?? [], [data]);
+  const selectedId = selectedAccountId ?? undefined;
+
+  // Refetch account-scoped data (agents, tasks, …) on an account change — but NOT
+  // user-info: the account list itself doesn't change when you switch accounts.
+  const refetchAccountScoped = useCallback(
+    () =>
+      queryClient.invalidateQueries({
+        predicate: q => q.queryKey[0] !== userInfoKey[0],
+      }),
+    [queryClient]
+  );
+
+  // Default to the first account when the URL has no valid account_id (fixes the
+  // "no account → 401" first load). `replace` so it doesn't add a history entry.
+  useEffect(() => {
+    if (profiles.length === 0) return;
+    const valid =
+      selectedId !== undefined &&
+      profiles.some(p => p.account.id === selectedId);
+    if (valid) return;
+    const first = profiles[0];
+    if (!first) return;
+    setSelectedAccountId(first.account.id, true);
+    void refetchAccountScoped();
+  }, [profiles, selectedId, setSelectedAccountId, refetchAccountScoped]);
+
+  if (!accountsEnabled) return null;
+  // Reserve the picker's height while accounts load so New Chat doesn't jump when it
+  // appears. Once loaded with no accounts, render nothing.
+  if (isLoading) {
+    return (
+      <Skeleton
+        className={cn(
+          collapsed ? 'size-9 rounded-md' : 'h-9 w-full rounded-md',
+          className
+        )}
+      />
+    );
+  }
+  if (profiles.length === 0) return null;
+
+  const select = (id: string) => {
+    if (id === selectedId) return;
+    setSelectedAccountId(id);
+    void refetchAccountScoped();
+  };
+
+  const current = profiles.find(p => p.account.id === selectedId);
+
+  if (collapsed) {
+    // Single account → static icon; multiple → an icon-only trigger whose dropdown pops
+    // out beside the collapsed rail (Radix positions it to stay in view).
+    if (profiles.length === 1) {
+      return (
+        <div
+          title={current?.account.name}
+          className={cn('flex size-9 items-center justify-center', className)}
+        >
+          <Building2 className="text-foreground size-5 shrink-0" />
+        </div>
+      );
+    }
+    return (
+      <Select value={selectedId ?? ''} onValueChange={select}>
+        <SelectTrigger
+          aria-label="Account"
+          className={cn(
+            'hover:bg-muted size-9 justify-center rounded-md border-0 bg-transparent p-0 shadow-none focus-visible:ring-0 [&>svg:last-child]:hidden',
+            className
+          )}
+        >
+          <Building2 className="text-foreground size-5 shrink-0" />
+        </SelectTrigger>
+        <SelectContent>
+          {profiles.map(p => (
+            <SelectItem key={p.account.id} value={p.account.id}>
+              {p.account.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  // A single account needs no switcher — show it as static context.
+  if (profiles.length === 1) {
+    return (
+      <div
+        className={cn(
+          // Match the New Chat button's size + spacing (size-5 icon, p-2, medium weight).
+          'text-foreground flex items-center gap-2 p-2 text-sm font-medium select-none',
+          className
+        )}
+      >
+        <Building2 className="size-5 shrink-0" />
+        <span className="truncate">{current?.account.name}</span>
+      </div>
+    );
+  }
+
+  return (
+    <Select value={selectedId ?? ''} onValueChange={select}>
+      <SelectTrigger
+        className={cn('w-full gap-2 rounded-md font-medium', className)}
+        aria-label="Account"
+      >
+        {/* Wrap icon + value in a flex-1 span so the value stays left-aligned
+            (icon | value … chevron) instead of centered by justify-between. */}
+        <span className="flex flex-1 items-center gap-2 overflow-hidden text-left">
+          <Building2 className="text-foreground size-5 shrink-0" />
+          <SelectValue placeholder="Select account" />
+        </span>
+      </SelectTrigger>
+      <SelectContent>
+        {profiles.map(p => (
+          <SelectItem key={p.account.id} value={p.account.id}>
+            {p.account.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/agentex-ui/components/agentex-ui-root.tsx
+++ b/agentex-ui/components/agentex-ui-root.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ToastContainer } from 'react-toastify';
 
@@ -17,7 +17,8 @@ import {
 } from '@/hooks/use-safe-search-params';
 
 export function AgentexUIRoot() {
-  const { agentName, taskID, updateParams } = useSafeSearchParams();
+  const { agentName, taskID, sgpAccountID, updateParams } =
+    useSafeSearchParams();
   const [isTracesSidebarOpen, setIsTracesSidebarOpen] = useState(false);
   const { agentexClient } = useAgentexClient();
   const { data: agents = [], isFetching: isAgentsFetching } =
@@ -32,6 +33,7 @@ export function AgentexUIRoot() {
   const [localAgentName, setLocalAgentName] = useLocalStorageState<
     string | undefined
   >('lastSelectedAgent', undefined);
+  const accountRef = useRef(sgpAccountID);
 
   // Wait until neither query is fetching before validating. We gate on `isFetching` (not
   // `isLoading`, which is false once a query has cached data) so we never validate against
@@ -39,6 +41,15 @@ export function AgentexUIRoot() {
   // doesn't block the localStorage-restore path when there's no agent_name. Deps are
   // intentionally narrowed so we re-validate on fetch settle / agent_name change.
   useEffect(() => {
+    // An account switch resets to the home grid: the selected agent is account-scoped,
+    // so a same-named agent in the new account must not stay selected.
+    if (accountRef.current !== sgpAccountID) {
+      accountRef.current = sgpAccountID;
+      setLocalAgentName(undefined);
+      if (agentName) updateParams({ [SearchParamKey.AGENT_NAME]: null });
+      return;
+    }
+
     if (isAgentsFetching || isAgentByNameFetching) return;
 
     // Accept an agent found in the (paginated) list OR resolved directly by name, so a valid
@@ -61,7 +72,13 @@ export function AgentexUIRoot() {
       updateParams({ [SearchParamKey.AGENT_NAME]: localAgentName });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAgentsFetching, isAgentByNameFetching, isAgentByNameError, agentName]);
+  }, [
+    sgpAccountID,
+    isAgentsFetching,
+    isAgentByNameFetching,
+    isAgentByNameError,
+    agentName,
+  ]);
 
   const handleSelectTask = useCallback(
     (taskId: string | null) => {

--- a/agentex-ui/components/providers/agentex-provider.tsx
+++ b/agentex-ui/components/providers/agentex-provider.tsx
@@ -58,7 +58,15 @@ export function AgentexProvider({
   const setSelectedAccountId = useCallback(
     (id: string, replace = false) => {
       selectedAccountIdRef.current = id;
-      updateParams({ [SearchParamKey.SGP_ACCOUNT_ID]: id }, replace);
+      updateParams(
+        {
+          [SearchParamKey.SGP_ACCOUNT_ID]: id,
+          // An explicit switch (not the initial bootstrap, which passes replace) drops the
+          // open task — it's account-scoped and won't resolve under the new account.
+          ...(replace ? {} : { [SearchParamKey.TASK_ID]: null }),
+        },
+        replace
+      );
     },
     [updateParams]
   );

--- a/agentex-ui/components/providers/agentex-provider.tsx
+++ b/agentex-ui/components/providers/agentex-provider.tsx
@@ -1,40 +1,101 @@
 'use client';
 
-import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from 'react';
 
 import AgentexSDK from 'agentex';
+
+import {
+  SearchParamKey,
+  useSafeSearchParams,
+} from '@/hooks/use-safe-search-params';
 
 interface AgentexContextValue {
   agentexClient: AgentexSDK;
   sgpAppURL: string;
+  // Whether the platform API is configured, so the account picker can fetch/switch accounts
+  accountsEnabled: boolean;
+  // Selected account id (from the `account_id` query param) + a setter that mirrors it
+  // to the URL and updates the header the SDK sends.
+  selectedAccountId: string | null;
+  setSelectedAccountId: (id: string, replace?: boolean) => void;
 }
 
 const AgentexContext = createContext<AgentexContextValue | null>(null);
 
 /**
- * Main provider for Agentex application
- * Provides the Agentex SDK client and app configuration to all child components
+ * Main provider. The SDK ALWAYS targets the same-origin BFF proxy (`/api/agentex`), which
+ * forwards credentials server-side. The selected account travels as the
+ * `x-selected-account-id` header, sourced from the `account_id` query param — no cookie
+ * involved.
  */
 export function AgentexProvider({
   children,
-  agentexAPIBaseURL,
   sgpAppURL,
+  accountsEnabled,
 }: {
   children: ReactNode;
-  agentexAPIBaseURL: string;
   sgpAppURL: string;
+  accountsEnabled: boolean;
 }) {
-  const agentexClient = useMemo(
-    () =>
-      new AgentexSDK({
-        baseURL: agentexAPIBaseURL,
-        fetchOptions: { credentials: 'include' },
-      }),
-    [agentexAPIBaseURL]
+  const { sgpAccountID, updateParams } = useSafeSearchParams();
+
+  // Synchronous source for the SDK's per-request header. Seeded from the URL and kept in
+  // sync with it; setSelectedAccountId also sets it synchronously so a switch's refetch doesn't
+  // race the (async) URL navigation.
+  const selectedAccountIdRef = useRef<string | null>(sgpAccountID);
+  useEffect(() => {
+    selectedAccountIdRef.current = sgpAccountID;
+  }, [sgpAccountID]);
+
+  const setSelectedAccountId = useCallback(
+    (id: string, replace = false) => {
+      selectedAccountIdRef.current = id;
+      updateParams({ [SearchParamKey.SGP_ACCOUNT_ID]: id }, replace);
+    },
+    [updateParams]
   );
 
+  const agentexClient = useMemo(() => {
+    // The SDK builds request URLs with `new URL()`, so the base must be ABSOLUTE. On the
+    // server `window` is absent, but no request fires during the initial server render
+    // (react-query fetches on the client); the client render recomputes an absolute URL.
+    const baseURL =
+      typeof window !== 'undefined'
+        ? `${window.location.origin}/api/agentex`
+        : '/api/agentex';
+
+    return new AgentexSDK({
+      baseURL,
+      fetchOptions: { credentials: 'include' },
+      // Attach the selected account on every request (read from the ref — always current).
+      fetch: (input, init) => {
+        const headers = new Headers(init?.headers);
+        if (selectedAccountIdRef.current) {
+          headers.set('x-selected-account-id', selectedAccountIdRef.current);
+        }
+        return fetch(input, { ...init, headers });
+      },
+    });
+  }, []);
+
   return (
-    <AgentexContext.Provider value={{ agentexClient, sgpAppURL }}>
+    <AgentexContext.Provider
+      value={{
+        agentexClient,
+        sgpAppURL,
+        accountsEnabled,
+        selectedAccountId: sgpAccountID,
+        setSelectedAccountId,
+      }}
+    >
       {children}
     </AgentexContext.Provider>
   );

--- a/agentex-ui/components/providers/agentex-provider.tsx
+++ b/agentex-ui/components/providers/agentex-provider.tsx
@@ -20,10 +20,9 @@ import {
 interface AgentexContextValue {
   agentexClient: AgentexSDK;
   sgpAppURL: string;
-  // Whether the platform API is configured, so the account picker can fetch/switch accounts
+  // Platform API configured → the account picker can fetch/switch accounts.
   accountsEnabled: boolean;
-  // Selected account id (from the `account_id` query param) + a setter that mirrors it
-  // to the URL and updates the header the SDK sends.
+  // Selected account (from the `account_id` param) + a setter that mirrors it to the URL.
   selectedAccountId: string | null;
   setSelectedAccountId: (id: string, replace?: boolean) => void;
 }
@@ -31,10 +30,9 @@ interface AgentexContextValue {
 const AgentexContext = createContext<AgentexContextValue | null>(null);
 
 /**
- * Main provider. The SDK ALWAYS targets the same-origin BFF proxy (`/api/agentex`), which
- * forwards credentials server-side. The selected account travels as the
- * `x-selected-account-id` header, sourced from the `account_id` query param — no cookie
- * involved.
+ * The SDK always targets the same-origin BFF (`/api/agentex`), which attaches credentials
+ * server-side. The selected account rides as `x-selected-account-id`, from the `account_id`
+ * query param.
  */
 export function AgentexProvider({
   children,
@@ -47,9 +45,8 @@ export function AgentexProvider({
 }) {
   const { sgpAccountID, updateParams } = useSafeSearchParams();
 
-  // Synchronous source for the SDK's per-request header. Seeded from the URL and kept in
-  // sync with it; setSelectedAccountId also sets it synchronously so a switch's refetch doesn't
-  // race the (async) URL navigation.
+  // Synchronous source for the SDK header: setSelectedAccountId sets it before the (async)
+  // URL navigation, so a switch's refetch doesn't race it.
   const selectedAccountIdRef = useRef<string | null>(sgpAccountID);
   useEffect(() => {
     selectedAccountIdRef.current = sgpAccountID;
@@ -61,8 +58,8 @@ export function AgentexProvider({
       updateParams(
         {
           [SearchParamKey.SGP_ACCOUNT_ID]: id,
-          // An explicit switch (not the initial bootstrap, which passes replace) drops the
-          // open task — it's account-scoped and won't resolve under the new account.
+          // An explicit switch (not bootstrap, which passes replace) drops the open task:
+          // it's account-scoped and won't resolve under the new account.
           ...(replace ? {} : { [SearchParamKey.TASK_ID]: null }),
         },
         replace
@@ -72,9 +69,8 @@ export function AgentexProvider({
   );
 
   const agentexClient = useMemo(() => {
-    // The SDK builds request URLs with `new URL()`, so the base must be ABSOLUTE. On the
-    // server `window` is absent, but no request fires during the initial server render
-    // (react-query fetches on the client); the client render recomputes an absolute URL.
+    // The SDK builds URLs with `new URL()`, so the base must be absolute. `window` is absent
+    // on the server, but no request fires during SSR; the client render recomputes it.
     const baseURL =
       typeof window !== 'undefined'
         ? `${window.location.origin}/api/agentex`

--- a/agentex-ui/components/task-sidebar/task-sidebar-footer.tsx
+++ b/agentex-ui/components/task-sidebar/task-sidebar-footer.tsx
@@ -1,32 +1,49 @@
-import { useCallback } from 'react';
-
 import { MessageSquare } from 'lucide-react';
 
+import { IconButton } from '@/components/ui/icon-button';
 import { ResizableSidebar } from '@/components/ui/resizable-sidebar';
 import { cn } from '@/lib/utils';
 
+const FEEDBACK_URL = 'https://github.com/scaleapi/scale-agentex/issues/new';
+
+function openFeedback() {
+  window.open(FEEDBACK_URL, '_blank', 'noopener,noreferrer');
+}
+
 export type TaskSidebarFooterProps = {
   className?: string;
+  collapsed?: boolean;
 };
 
-export function TaskSidebarFooter({ className }: TaskSidebarFooterProps) {
-  const handleFeedback = useCallback(() => {
-    window.open(
-      'https://github.com/scaleapi/scale-agentex/issues/new',
-      '_blank',
-      'noopener,noreferrer'
+export function TaskSidebarFooter({
+  className,
+  collapsed = false,
+}: TaskSidebarFooterProps) {
+  if (collapsed) {
+    return (
+      <div className={cn('flex flex-col items-start gap-2 pl-2', className)}>
+        <IconButton
+          icon={MessageSquare}
+          onClick={openFeedback}
+          variant="ghost"
+          className="text-foreground"
+          aria-label="Give Feedback"
+        />
+      </div>
     );
-  }, []);
+  }
 
   return (
-    <div className={cn('mx-2 flex flex-col gap-2', className)}>
+    <div className={cn('mx-2 mb-2 flex flex-col gap-2', className)}>
       <ResizableSidebar.Button
-        onClick={handleFeedback}
-        className="mb-2 p-3"
+        onClick={openFeedback}
+        className="flex items-center gap-2 p-2"
         disableAnimation
       >
-        <MessageSquare className="size-5" />
-        Give Feedback
+        <div className="flex items-center gap-2">
+          <MessageSquare className="size-5" />
+          Give Feedback
+        </div>
       </ResizableSidebar.Button>
     </div>
   );

--- a/agentex-ui/components/task-sidebar/task-sidebar-footer.tsx
+++ b/agentex-ui/components/task-sidebar/task-sidebar-footer.tsx
@@ -1,5 +1,6 @@
 import { MessageSquare } from 'lucide-react';
 
+import { AccountPicker } from '@/components/account-picker/account-picker';
 import { IconButton } from '@/components/ui/icon-button';
 import { ResizableSidebar } from '@/components/ui/resizable-sidebar';
 import { cn } from '@/lib/utils';
@@ -29,6 +30,7 @@ export function TaskSidebarFooter({
           className="text-foreground"
           aria-label="Give Feedback"
         />
+        <AccountPicker collapsed />
       </div>
     );
   }
@@ -45,6 +47,7 @@ export function TaskSidebarFooter({
           Give Feedback
         </div>
       </ResizableSidebar.Button>
+      <AccountPicker />
     </div>
   );
 }

--- a/agentex-ui/components/task-sidebar/task-sidebar-header.tsx
+++ b/agentex-ui/components/task-sidebar/task-sidebar-header.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/navigation';
 
 import { PanelLeftClose, MessageSquarePlus } from 'lucide-react';
 
-import { AccountPicker } from '@/components/account-picker/account-picker';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
@@ -43,7 +42,6 @@ export function TaskSidebarHeader({
           aria-label="Close Task Sidebar"
         />
       </div>
-      <AccountPicker />
       <ResizableSidebar.Button
         onClick={handleNewChat}
         className="text-foreground flex items-center justify-between gap-2 p-2"

--- a/agentex-ui/components/task-sidebar/task-sidebar-header.tsx
+++ b/agentex-ui/components/task-sidebar/task-sidebar-header.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 
 import { PanelLeftClose, MessageSquarePlus } from 'lucide-react';
 
+import { AccountPicker } from '@/components/account-picker/account-picker';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
@@ -42,6 +43,7 @@ export function TaskSidebarHeader({
           aria-label="Close Task Sidebar"
         />
       </div>
+      <AccountPicker />
       <ResizableSidebar.Button
         onClick={handleNewChat}
         className="text-foreground flex items-center justify-between gap-2 p-2"

--- a/agentex-ui/components/task-sidebar/task-sidebar.tsx
+++ b/agentex-ui/components/task-sidebar/task-sidebar.tsx
@@ -2,7 +2,6 @@ import { useCallback, useState } from 'react';
 
 import { MessageSquarePlus, PanelLeftOpen } from 'lucide-react';
 
-import { AccountPicker } from '@/components/account-picker/account-picker';
 import { TaskSidebarBody } from '@/components/task-sidebar/task-sidebar-body';
 import { TaskSidebarFooter } from '@/components/task-sidebar/task-sidebar-footer';
 import { TaskSidebarHeader } from '@/components/task-sidebar/task-sidebar-header';
@@ -44,7 +43,6 @@ export function TaskSidebar() {
               className="text-foreground"
               aria-label="Open Task Sidebar"
             />
-            <AccountPicker collapsed />
             <IconButton
               icon={MessageSquarePlus}
               onClick={handleNewChat}

--- a/agentex-ui/components/task-sidebar/task-sidebar.tsx
+++ b/agentex-ui/components/task-sidebar/task-sidebar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 
 import { MessageSquarePlus, PanelLeftOpen } from 'lucide-react';
 
+import { AccountPicker } from '@/components/account-picker/account-picker';
 import { TaskSidebarBody } from '@/components/task-sidebar/task-sidebar-body';
 import { TaskSidebarFooter } from '@/components/task-sidebar/task-sidebar-footer';
 import { TaskSidebarHeader } from '@/components/task-sidebar/task-sidebar-header';
@@ -34,22 +35,26 @@ export function TaskSidebar() {
       className="flex h-full flex-col gap-2 pt-4"
       isCollapsed={isCollapsed}
       renderCollapsed={() => (
-        <div className="flex flex-col items-center gap-4">
-          <IconButton
-            icon={PanelLeftOpen}
-            onClick={toggleCollapse}
-            variant="ghost"
-            className="text-foreground"
-            aria-label="Open Task Sidebar"
-          />
-          <IconButton
-            icon={MessageSquarePlus}
-            onClick={handleNewChat}
-            variant="ghost"
-            className="text-foreground"
-            aria-label="New Chat"
-          />
-        </div>
+        <>
+          <div className="flex flex-col items-start gap-4 pl-2">
+            <IconButton
+              icon={PanelLeftOpen}
+              onClick={toggleCollapse}
+              variant="ghost"
+              className="text-foreground"
+              aria-label="Open Task Sidebar"
+            />
+            <AccountPicker collapsed />
+            <IconButton
+              icon={MessageSquarePlus}
+              onClick={handleNewChat}
+              variant="ghost"
+              className="text-foreground"
+              aria-label="New Chat"
+            />
+          </div>
+          <TaskSidebarFooter collapsed className="mt-auto pb-2" />
+        </>
       )}
     >
       <TaskSidebarHeader

--- a/agentex-ui/components/ui/select.tsx
+++ b/agentex-ui/components/ui/select.tsx
@@ -38,7 +38,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-full border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-primary-foreground focus-visible:ring-primary-foreground/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-full border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -108,7 +108,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-muted focus:text-primary-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/agentex-ui/example.env.development
+++ b/agentex-ui/example.env.development
@@ -1,1 +1,3 @@
-NEXT_PUBLIC_AGENTEX_API_BASE_URL=http://localhost:5003
+AGENTEX_API_URL=http://localhost:5003          # /api/agentex → agentex API
+# SGP_API_URL=<your_sgp_api_url>               # optional: /api/feedback & /api/user-info → SGP API
+# NEXT_PUBLIC_SGP_APP_URL=<your_sgp_app_url>   # optional: links to SGP traces

--- a/agentex-ui/hooks/use-feedback.ts
+++ b/agentex-ui/hooks/use-feedback.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { toast } from '@/components/ui/toast';
+import { useSafeSearchParams } from '@/hooks/use-safe-search-params';
 
 type SubmitFeedbackParams = {
   traceId: string;
@@ -21,13 +22,18 @@ type FeedbackResponse = {
 };
 
 export function useFeedback() {
+  const { sgpAccountID } = useSafeSearchParams();
   return useMutation({
     mutationFn: async (
       params: SubmitFeedbackParams
     ): Promise<FeedbackResponse> => {
       const response = await fetch('/api/feedback', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          // Selected account (same source as the SDK); the BFF forwards it.
+          ...(sgpAccountID ? { 'x-selected-account-id': sgpAccountID } : {}),
+        },
         body: JSON.stringify(params),
       });
 

--- a/agentex-ui/hooks/use-user-info.ts
+++ b/agentex-ui/hooks/use-user-info.ts
@@ -16,11 +16,7 @@ type UserInfo = { access_profiles: AccessProfile[] };
 
 export const userInfoKey = ['user-info'] as const;
 
-/**
- * Fetches the caller's accounts (access_profiles) via the scoped `/api/user-info` BFF
- * proxy, to bootstrap / switch the selected account. `enabled` gates the fetch (off when
- * the platform API isn't configured).
- */
+/** Caller's accounts (access_profiles) via /api/user-info; `enabled` off when unconfigured. */
 export function useUserInfo(enabled: boolean) {
   return useQuery({
     queryKey: userInfoKey,
@@ -30,8 +26,8 @@ export function useUserInfo(enabled: boolean) {
       if (!res.ok) throw new Error(`user-info: ${res.status}`);
       return res.json();
     },
-    // The account list is stable for the session — fetch once, don't refetch on remount
-    // (e.g. the account_id navigation) or focus.
+    // The account list is stable for the session — don't refetch on the account_id
+    // navigation or window focus.
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   });

--- a/agentex-ui/hooks/use-user-info.ts
+++ b/agentex-ui/hooks/use-user-info.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+
+/** A member account the caller can access (from the platform's /user-info). */
+export type AccessProfile = {
+  id: string;
+  role?: string;
+  account: {
+    id: string;
+    name: string;
+    organization_id?: string | null;
+    status?: string;
+  };
+};
+
+type UserInfo = { access_profiles: AccessProfile[] };
+
+export const userInfoKey = ['user-info'] as const;
+
+/**
+ * Fetches the caller's accounts (access_profiles) via the scoped `/api/user-info` BFF
+ * proxy, to bootstrap / switch the selected account. `enabled` gates the fetch (off when
+ * the platform API isn't configured).
+ */
+export function useUserInfo(enabled: boolean) {
+  return useQuery({
+    queryKey: userInfoKey,
+    enabled,
+    queryFn: async (): Promise<UserInfo> => {
+      const res = await fetch('/api/user-info', { credentials: 'include' });
+      if (!res.ok) throw new Error(`user-info: ${res.status}`);
+      return res.json();
+    },
+    // The account list is stable for the session — fetch once, don't refetch on remount
+    // (e.g. the account_id navigation) or focus.
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+}


### PR DESCRIPTION
## Summary

First of a **2-PR stack** bringing account scoping + OIDC login to agentex-ui. This base PR routes the SDK through a same-origin BFF and adds an account switcher. Chart + deploy side lives in scaleapi/sgp#3961.

- Routes the agentex SDK through a same-origin **BFF** (`/api/agentex`) instead of calling the API directly from the browser — the upstream URL and credentials never reach client JS.
- Shared `applyBffCredentials` forwards `x-selected-account-id`, drops any client-sent `Authorization`, and strips the account-scoped `_jwt` cookie so SGP honors the **selected** account rather than the one you linked in with (identity stays via `_identityJwt`). The proxy also strips `Location` on upstream 3xx so internal redirect targets don't leak.
- Account selection is driven by the `account_id` query param (no cookie), injected on every SDK request via a synchronous ref. Switching accounts resets the open task + selected agent to the account's home grid, and `resetQueries` drops the previous account's cached data so it never briefly renders the old agents.
- `/api/user-info` fetches the caller's accounts; the picker bootstraps to the first when the param is missing/stale, shows a disabled/empty loading state (not a skeleton), renders single-account as static context, and lives in the sidebar footer (collapsed → icon-only).
- Env-gated on the platform API being configured (`SGP_API_URL` / `NEXT_PUBLIC_SGP_APP_URL`); no-op otherwise.

**Env:** `NEXT_PUBLIC_AGENTEX_API_BASE_URL` → server-only `AGENTEX_API_URL`.

In this PR the BFF runs in default (cookie) mode — no auth dependency. The token-hiding Bearer path arrives in the stacked PR.

## Stack

1. **This PR** — account picker + same-origin BFF proxy → `main`
2. #351 — OIDC login with server-side access token → stacked on this branch
3. scaleapi/sgp#3961 — Helm chart + system-manager pack (deploy side)

## Test plan

- [x] `npm run typecheck` / `npm run lint` — clean
- [x] Runtime: switching accounts re-scopes agents/tasks (and SGP calls via the `_jwt` strip); single / multi / no-account render; loading state; no stale-account flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes the Agentex SDK through a same-origin BFF proxy (`/api/agentex`) so the upstream URL and credentials stay server-side, and adds an account picker driven by the `account_id` query param. A new shared `applyBffCredentials` helper manages cookie stripping (`_jwt`) and header hygiene across the BFF routes; a scoped `/api/user-info` endpoint bootstraps and switches accounts without exposing arbitrary platform endpoints.

- **BFF proxy** (`app/api/agentex/[...path]/route.ts`): streams all HTTP methods through to the upstream, strips hop-by-hop and credential headers, and drops `location` on upstream 3xx so internal redirect targets don't escape.
- **Account picker** (`components/account-picker/account-picker.tsx`): bootstraps to the first account when `account_id` is absent, resets account-scoped React Query cache on switch (preserving `user-info`), and renders as an icon-only tile in the collapsed sidebar rail.
- **Provider** (`components/providers/agentex-provider.tsx`): injects `x-selected-account-id` on every SDK request via a synchronous ref to avoid a race between URL navigation and the next fetch.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the bootstrap/localAgentName regression in agentex-ui-root.tsx.

The account-switch detection in `agentex-ui-root.tsx` treats the initial bootstrap (null → first account on a fresh URL load) the same as an explicit switch, causing `setLocalAgentName(undefined)` to permanently erase the user's stored agent preference on every fresh-tab or direct-URL visit. Users with a single account — the most common deployment — would lose their last-used agent selection on every new session. The BFF proxy, credential stripping, and account picker logic are otherwise well-structured.

agentex-ui/components/agentex-ui-root.tsx — the bootstrap path needs to be distinguished from an explicit account switch before the localStorage clear runs.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex-ui/app/api/_lib/bff.ts | New shared BFF helper: strips `_jwt` cookie, deletes `authorization`, forwards `x-selected-account-id`. Logic is correct; `async` signature is forward-compatible with the stacked PR's Bearer path. |
| agentex-ui/app/api/agentex/[...path]/route.ts | Catch-all BFF proxy: strips hop-by-hop headers, calls `applyBffCredentials`, drops `location` on upstream 3xx. Streaming via unbuffered body is correct. Previous `authorization` and `location` issues from prior review round are fixed. |
| agentex-ui/app/api/user-info/route.ts | Scoped BFF endpoint for account list. Missing try/catch around upstream fetch means a network failure returns an unstructured 500, unlike the feedback route which has proper error handling. |
| agentex-ui/components/agentex-ui-root.tsx | Adds account-switch detection via `accountRef`. The bootstrap (null → first account) is indistinguishable from an explicit switch, causing `localAgentName` to be permanently cleared and the restore-from-localStorage path to be skipped on every fresh-URL page load. |
| agentex-ui/components/providers/agentex-provider.tsx | SDK re-routed to same-origin BFF; account ID injected via a ref to avoid race between URL navigation and the next fetch. `useMemo([])` with ref access is the correct pattern here. |
| agentex-ui/components/account-picker/account-picker.tsx | Account picker with bootstrap, collapsed/expanded modes, and single-account static display. `resetAccountScoped` correctly preserves user-info while clearing other account-scoped query cache. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant BFF as Next.js BFF<br/>(same-origin)
    participant Agentex as Agentex API
    participant SGP as SGP Platform API

    Note over Browser,SGP: Account bootstrap (first load, no account_id in URL)
    Browser->>BFF: GET /api/user-info (cookies)
    BFF->>SGP: GET /user-info (cookies minus _jwt)
    SGP-->>BFF: "{ access_profiles: [...] }"
    BFF-->>Browser: "{ access_profiles: [...] }"
    Browser->>Browser: "router.replace(?account_id=first)"

    Note over Browser,Agentex: SDK request with selected account
    Browser->>BFF: GET /api/agentex/v1/agents x-selected-account-id: abc
    BFF->>BFF: applyBffCredentials() drop authorization strip _jwt cookie forward x-selected-account-id
    BFF->>Agentex: GET /v1/agents x-selected-account-id: abc
    Agentex-->>BFF: 200 agents[]
    BFF-->>Browser: 200 agents[] (streamed)

    Note over Browser,SGP: Account switch
    Browser->>Browser: "onAccountChange resetQueries router.push(?account_id=new-id)"
    Browser->>BFF: GET /api/agentex/v1/agents x-selected-account-id: new-id
    BFF->>Agentex: GET /v1/agents x-selected-account-id: new-id
    Agentex-->>BFF: 200 agents[] (new account)
    BFF-->>Browser: 200 agents[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant BFF as Next.js BFF<br/>(same-origin)
    participant Agentex as Agentex API
    participant SGP as SGP Platform API

    Note over Browser,SGP: Account bootstrap (first load, no account_id in URL)
    Browser->>BFF: GET /api/user-info (cookies)
    BFF->>SGP: GET /user-info (cookies minus _jwt)
    SGP-->>BFF: "{ access_profiles: [...] }"
    BFF-->>Browser: "{ access_profiles: [...] }"
    Browser->>Browser: "router.replace(?account_id=first)"

    Note over Browser,Agentex: SDK request with selected account
    Browser->>BFF: GET /api/agentex/v1/agents x-selected-account-id: abc
    BFF->>BFF: applyBffCredentials() drop authorization strip _jwt cookie forward x-selected-account-id
    BFF->>Agentex: GET /v1/agents x-selected-account-id: abc
    Agentex-->>BFF: 200 agents[]
    BFF-->>Browser: 200 agents[] (streamed)

    Note over Browser,SGP: Account switch
    Browser->>Browser: "onAccountChange resetQueries router.push(?account_id=new-id)"
    Browser->>BFF: GET /api/agentex/v1/agents x-selected-account-id: new-id
    BFF->>Agentex: GET /v1/agents x-selected-account-id: new-id
    Agentex-->>BFF: 200 agents[] (new account)
    BFF-->>Browser: 200 agents[]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex-ui%2Fcomponents%2Fagentex-ui-root.tsx%3A41-53%0A**Bootstrap%20mistaken%20for%20account%20switch%2C%20permanently%20clears%20stored%20agent%20name**%0A%0AWhen%20a%20user%20loads%20the%20page%20without%20%60%3Faccount_id%60%20in%20the%20URL%2C%20%60accountRef.current%60%20is%20initialized%20to%20%60null%60.%20The%20%60AccountPicker%60%20effect%20bootstraps%20the%20first%20account%20%28via%20%60router.replace%60%29%2C%20changing%20%60sgpAccountID%60%20from%20%60null%60%20%E2%86%92%20%60'first-account-id'%60.%20On%20the%20next%20render%2C%20this%20effect%20fires%20because%20%60sgpAccountID%60%20is%20in%20its%20deps%2C%20sees%20%60null%20!%3D%3D%20'first-account-id'%60%2C%20and%20treats%20it%20as%20an%20explicit%20account%20switch%20%E2%80%94%20calling%20%60setLocalAgentName%28undefined%29%60%20%28which%20overwrites%20localStorage%29%20and%20returning%20before%20the%20restore-from-localStorage%20logic%20can%20run.%20Every%20fresh%20navigation%20to%20%60%2F%60%20without%20%60%3Faccount_id%60%20permanently%20erases%20the%20user's%20saved%20agent%20preference.%20Single-account%20users%20%28the%20most%20common%20case%29%20are%20affected%20on%20every%20new%20tab%20or%20bookmarked-root%20visit.%0A%0AA%20simple%20guard%20fixes%20it%3A%20skip%20the%20clear%20when%20%60accountRef.current%60%20is%20%60null%60%20%28first%20load%2C%20no%20prior%20account%29%20and%20only%20apply%20it%20when%20there%20is%20a%20known%20previous%20account%20being%20replaced.%0A%0A&pr=350&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex-ui%2Fcomponents%2Fagentex-ui-root.tsx%3A41-53%0A**Bootstrap%20mistaken%20for%20account%20switch%2C%20permanently%20clears%20stored%20agent%20name**%0A%0AWhen%20a%20user%20loads%20the%20page%20without%20%60%3Faccount_id%60%20in%20the%20URL%2C%20%60accountRef.current%60%20is%20initialized%20to%20%60null%60.%20The%20%60AccountPicker%60%20effect%20bootstraps%20the%20first%20account%20%28via%20%60router.replace%60%29%2C%20changing%20%60sgpAccountID%60%20from%20%60null%60%20%E2%86%92%20%60'first-account-id'%60.%20On%20the%20next%20render%2C%20this%20effect%20fires%20because%20%60sgpAccountID%60%20is%20in%20its%20deps%2C%20sees%20%60null%20!%3D%3D%20'first-account-id'%60%2C%20and%20treats%20it%20as%20an%20explicit%20account%20switch%20%E2%80%94%20calling%20%60setLocalAgentName%28undefined%29%60%20%28which%20overwrites%20localStorage%29%20and%20returning%20before%20the%20restore-from-localStorage%20logic%20can%20run.%20Every%20fresh%20navigation%20to%20%60%2F%60%20without%20%60%3Faccount_id%60%20permanently%20erases%20the%20user's%20saved%20agent%20preference.%20Single-account%20users%20%28the%20most%20common%20case%29%20are%20affected%20on%20every%20new%20tab%20or%20bookmarked-root%20visit.%0A%0AA%20simple%20guard%20fixes%20it%3A%20skip%20the%20clear%20when%20%60accountRef.current%60%20is%20%60null%60%20%28first%20load%2C%20no%20prior%20account%29%20and%20only%20apply%20it%20when%20there%20is%20a%20known%20previous%20account%20being%20replaced.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=350&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22feat%2Fagentex-ui-account-picker%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fagentex-ui-account-picker%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aagentex-ui%2Fcomponents%2Fagentex-ui-root.tsx%3A41-53%0A**Bootstrap%20mistaken%20for%20account%20switch%2C%20permanently%20clears%20stored%20agent%20name**%0A%0AWhen%20a%20user%20loads%20the%20page%20without%20%60%3Faccount_id%60%20in%20the%20URL%2C%20%60accountRef.current%60%20is%20initialized%20to%20%60null%60.%20The%20%60AccountPicker%60%20effect%20bootstraps%20the%20first%20account%20%28via%20%60router.replace%60%29%2C%20changing%20%60sgpAccountID%60%20from%20%60null%60%20%E2%86%92%20%60'first-account-id'%60.%20On%20the%20next%20render%2C%20this%20effect%20fires%20because%20%60sgpAccountID%60%20is%20in%20its%20deps%2C%20sees%20%60null%20!%3D%3D%20'first-account-id'%60%2C%20and%20treats%20it%20as%20an%20explicit%20account%20switch%20%E2%80%94%20calling%20%60setLocalAgentName%28undefined%29%60%20%28which%20overwrites%20localStorage%29%20and%20returning%20before%20the%20restore-from-localStorage%20logic%20can%20run.%20Every%20fresh%20navigation%20to%20%60%2F%60%20without%20%60%3Faccount_id%60%20permanently%20erases%20the%20user's%20saved%20agent%20preference.%20Single-account%20users%20%28the%20most%20common%20case%29%20are%20affected%20on%20every%20new%20tab%20or%20bookmarked-root%20visit.%0A%0AA%20simple%20guard%20fixes%20it%3A%20skip%20the%20clear%20when%20%60accountRef.current%60%20is%20%60null%60%20%28first%20load%2C%20no%20prior%20account%29%20and%20only%20apply%20it%20when%20there%20is%20a%20known%20previous%20account%20being%20replaced.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=350&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
agentex-ui/components/agentex-ui-root.tsx:41-53
**Bootstrap mistaken for account switch, permanently clears stored agent name**

When a user loads the page without `?account_id` in the URL, `accountRef.current` is initialized to `null`. The `AccountPicker` effect bootstraps the first account (via `router.replace`), changing `sgpAccountID` from `null` → `'first-account-id'`. On the next render, this effect fires because `sgpAccountID` is in its deps, sees `null !== 'first-account-id'`, and treats it as an explicit account switch — calling `setLocalAgentName(undefined)` (which overwrites localStorage) and returning before the restore-from-localStorage logic can run. Every fresh navigation to `/` without `?account_id` permanently erases the user's saved agent preference. Single-account users (the most common case) are affected on every new tab or bookmarked-root visit.

A simple guard fixes it: skip the clear when `accountRef.current` is `null` (first load, no prior account) and only apply it when there is a known previous account being replaced.

`````

</details>

<sub>Reviews (9): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/agentex-ui..."](https://github.com/scaleapi/scale-agentex/commit/9b500ec6e5d3f65c2c1efc588601646517b5183e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42798449)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->