### PR TITLE
fix(agentex-ui): merge URL updates against the live URL to fix account-switch races

### DIFF
--- a/agentex-ui/components/providers/agentex-provider.tsx
+++ b/agentex-ui/components/providers/agentex-provider.tsx
@@ -73,9 +73,14 @@ export function AgentexProvider({
       updateParams(
         {
           [SearchParamKey.SGP_ACCOUNT_ID]: id,
-          // An explicit switch (not bootstrap, which passes replace) drops the open task:
-          // it's account-scoped and won't resolve under the new account.
-          ...(replace ? {} : { [SearchParamKey.TASK_ID]: null }),
+          // Explicit switch (bootstrap passes replace): drop the account-scoped task + agent
+          // in one navigation so they don't linger under the new account.
+          ...(replace
+            ? {}
+            : {
+                [SearchParamKey.TASK_ID]: null,
+                [SearchParamKey.AGENT_NAME]: null,
+              }),
         },
         replace
       );

--- a/agentex-ui/hooks/use-safe-search-params.test.tsx
+++ b/agentex-ui/hooks/use-safe-search-params.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SearchParamKey, useSafeSearchParams } from './use-safe-search-params';
+
+// Router spies + a mutable snapshot the mocked `useSearchParams` returns. Created via
+// vi.hoisted so the hoisted vi.mock factory can reference them.
+const mocks = vi.hoisted(() => ({
+  push: vi.fn<(url: string) => void>(),
+  replace: vi.fn<(url: string) => void>(),
+  snapshot: new URLSearchParams(''),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.push, replace: mocks.replace }),
+  usePathname: () => '/',
+  useSearchParams: () => mocks.snapshot,
+}));
+
+function setLiveUrl(search: string) {
+  window.history.replaceState(null, '', `${window.location.origin}/${search}`);
+}
+
+function pushedQuery() {
+  expect(mocks.push).toHaveBeenCalledTimes(1);
+  const url = mocks.push.mock.calls[0]![0];
+  return new URLSearchParams(url.split('?')[1] ?? '');
+}
+
+afterEach(() => {
+  mocks.push.mockClear();
+  mocks.replace.mockClear();
+});
+
+describe('useSafeSearchParams.updateParams', () => {
+  it('merges against the live URL, not a stale snapshot (no write-clobber)', () => {
+    // The live URL already reflects a committed account switch: new account, task_id dropped.
+    setLiveUrl('?account_id=new&agent_name=dua-agent');
+    // But the React snapshot still shows the pre-switch state (the lag that caused the bug).
+    mocks.snapshot = new URLSearchParams(
+      'account_id=old&task_id=T&agent_name=dua-agent'
+    );
+
+    const { result } = renderHook(() => useSafeSearchParams());
+    // A second writer (the agent-validation effect) clears only agent_name.
+    result.current.updateParams({ [SearchParamKey.AGENT_NAME]: null });
+
+    // It must build from the live URL: keep account_id=new, leave task_id dropped — not
+    // resurrect account_id=old / task_id=T from the stale snapshot.
+    const qs = pushedQuery();
+    expect(qs.get('account_id')).toBe('new');
+    expect(qs.get('task_id')).toBeNull();
+    expect(qs.get('agent_name')).toBeNull();
+  });
+
+  it('sets, deletes, and preserves unlisted params in one update', () => {
+    setLiveUrl('?account_id=acc&agent_name=keep');
+    mocks.snapshot = new URLSearchParams('account_id=acc&agent_name=keep');
+
+    const { result } = renderHook(() => useSafeSearchParams());
+    result.current.updateParams({
+      [SearchParamKey.TASK_ID]: 'new-task',
+      [SearchParamKey.AGENT_NAME]: null,
+    });
+
+    const qs = pushedQuery();
+    expect(qs.get('task_id')).toBe('new-task'); // set
+    expect(qs.get('agent_name')).toBeNull(); // deleted
+    expect(qs.get('account_id')).toBe('acc'); // preserved (unlisted)
+  });
+
+  it('uses router.replace when replace=true', () => {
+    setLiveUrl('?account_id=acc');
+    mocks.snapshot = new URLSearchParams('account_id=acc');
+
+    const { result } = renderHook(() => useSafeSearchParams());
+    result.current.updateParams({ [SearchParamKey.TASK_ID]: 'x' }, true);
+
+    expect(mocks.push).not.toHaveBeenCalled();
+    expect(mocks.replace).toHaveBeenCalledTimes(1);
+    expect(mocks.replace.mock.calls[0]![0]).toContain('task_id=x');
+  });
+});

--- a/agentex-ui/hooks/use-safe-search-params.ts
+++ b/agentex-ui/hooks/use-safe-search-params.ts
@@ -31,23 +31,30 @@ export function useSafeSearchParams(): SafeSearchParams {
 
   const updateParams = useCallback(
     (updates: SearchParamUpdates, replace: boolean = false): void => {
-      const params = new URLSearchParams(searchParams.toString());
+      // Merge against the live URL, not the `searchParams` snapshot: the snapshot lags a
+      // render behind router navigations, so concurrent updates would clobber each other.
+      const live =
+        typeof window !== 'undefined'
+          ? window.location.search
+          : searchParams.toString();
+      const params = new URLSearchParams(live);
 
       Object.entries(updates).forEach(([key, value]) => {
         const paramKey = key as SearchParamKey;
-        if (value !== undefined) {
-          if (value === null) {
-            params.delete(paramKey);
-          } else {
-            params.set(paramKey, value);
-          }
+        if (value === undefined) return;
+        if (value === null) {
+          params.delete(paramKey);
+        } else {
+          params.set(paramKey, value);
         }
       });
 
+      const query = params.toString();
+      const url = query ? `${pathname}?${query}` : pathname;
       if (replace) {
-        router.replace(`${pathname}?${params.toString()}`);
+        router.replace(url);
       } else {
-        router.push(`${pathname}?${params.toString()}`);
+        router.push(url);
       }
     },
     [pathname, searchParams, router]


### PR DESCRIPTION
## Problem

Switching accounts intermittently corrupted the URL state: `task_id` would survive the switch (leaving a stuck "phantom task" under the new account), `agent_name` would clear, and sometimes `account_id` even reverted to the old value **while the sidebar already showed the new account's tasks**.

## Root cause

`updateParams` rebuilt the entire query string from the `useSearchParams()` **snapshot**, which lags a render behind `router.push`. An account switch fires **two** navigations from two components:

- the provider's `setSelectedAccountId` clears `task_id`
- the agent-validation effect in `agentex-ui-root` clears `agent_name`

Whichever call read the stale snapshot and landed **last** clobbered the other's change. The data layer switches synchronously (`selectedAccountIdRef`), so tasks refetched for the new account even when the URL reverted — the smoking-gun symptom. It was intermittent because it depended on whether `useSearchParams` had propagated between the two writes.

## Fix

- **`use-safe-search-params.ts`** — `updateParams` now merges each update against the **live URL** (`window.location.search`), which is always current, so concurrent writes compose instead of overwrite. This is the systemic fix and addresses all three symptoms.
- **`agentex-provider.tsx`** — an explicit account switch now clears `task_id` **and** `agent_name` in one atomic navigation (no dependence on a downstream effect, no flash of stale params).
- **`use-safe-search-params.test.tsx`** — regression test proving a write built from a stale snapshot no longer resurrects `task_id`/`account_id`.

## Test plan

- `npm run typecheck` ✓
- `npx vitest run` — 50/50 ✓
- `npm run lint` ✓

Independent of #351 (OIDC); can merge in any order.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an intermittent URL-state corruption that occurred during account switches. The root cause was `updateParams` building its query string from the `useSearchParams()` snapshot, which lags behind `router.push()` calls — so two rapid navigations from different components would race and the last writer would clobber the first's changes.

- **`use-safe-search-params.ts`**: `updateParams` now reads `window.location.search` (always current, updated synchronously by the History API) instead of the React snapshot, so concurrent writes compose rather than overwrite. Also fixes a minor trailing-`?` edge case for empty param sets.
- **`agentex-provider.tsx`**: The explicit account-switch now clears both `task_id` and `agent_name` atomically in one navigation, eliminating the need for a downstream effect to clean up `agent_name`.
- **`use-safe-search-params.test.tsx`**: Regression tests proving the stale-snapshot clobber is gone, covering set/delete/preserve semantics and `replace` vs `push` routing.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped to URL merge behavior and is directly validated by new regression tests.

The change replaces a React snapshot read with a synchronous window.location.search read inside updateParams, which is always safe in browser environments and has a correct SSR fallback. The provider change and the new tests are consistent with the fix, and no existing behavior outside the race window is altered.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex-ui/hooks/use-safe-search-params.ts | Core fix: reads from `window.location.search` instead of the stale `useSearchParams()` snapshot so concurrent writes compose correctly. Also adds a clean fallback for SSR and fixes the trailing-`?` edge case for empty param sets. |
| agentex-ui/components/providers/agentex-provider.tsx | Adds `agent_name: null` alongside `task_id: null` in the explicit-switch branch, so both account-scoped params are cleared atomically in one navigation rather than relying on a downstream effect. |
| agentex-ui/hooks/use-safe-search-params.test.tsx | New regression test suite with three cases: stale-snapshot clobber prevention, combined set/delete/preserve in one update, and `replace` vs `push` routing. Correctly uses `vi.hoisted` to share mock state with the factory closure. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant P as AgentexProvider
    participant E as agentex-ui-root effect
    participant H as useSafeSearchParams
    participant W as window.location
    participant R as Next.js Router

    Note over P,R: Before fix - stale snapshot clobber
    P->>H: "updateParams({account_id:new, task_id:null})"
    H->>W: reads stale snapshot (account_id:old, task_id:T)
    H->>R: "push(?account_id=new&task_id=null)"
    R->>W: window.location.search updated
    Note over E: snapshot not yet updated
    E->>H: "updateParams({agent_name:null})"
    H->>W: reads stale snapshot (account_id:old, task_id:T)
    H->>R: "push(?account_id=old&task_id=T) clobbers first write"

    Note over P,R: After fix - live URL merge
    P->>H: "updateParams({account_id:new, task_id:null, agent_name:null})"
    H->>W: reads window.location.search (live)
    H->>R: "push(?account_id=new) atomic, one navigation"
    R->>W: window.location.search updated
    Note over E: effect fires but agent_name already cleared
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant P as AgentexProvider
    participant E as agentex-ui-root effect
    participant H as useSafeSearchParams
    participant W as window.location
    participant R as Next.js Router

    Note over P,R: Before fix - stale snapshot clobber
    P->>H: "updateParams({account_id:new, task_id:null})"
    H->>W: reads stale snapshot (account_id:old, task_id:T)
    H->>R: "push(?account_id=new&task_id=null)"
    R->>W: window.location.search updated
    Note over E: snapshot not yet updated
    E->>H: "updateParams({agent_name:null})"
    H->>W: reads stale snapshot (account_id:old, task_id:T)
    H->>R: "push(?account_id=old&task_id=T) clobbers first write"

    Note over P,R: After fix - live URL merge
    P->>H: "updateParams({account_id:new, task_id:null, agent_name:null})"
    H->>W: reads window.location.search (live)
    H->>R: "push(?account_id=new) atomic, one navigation"
    R->>W: window.location.search updated
    Note over E: effect fires but agent_name already cleared
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agentex-ui): merge URL updates again..."](https://github.com/scaleapi/scale-agentex/commit/dc3529b393acb3620a28512980cb26e3973685d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43214802)</sub>

<!-- /greptile_comment -->