### PR TITLE
feat(schedules): add exact skip and unskip actions

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -3595,6 +3595,86 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /agents/{agent_id}/schedules/{schedule_id}/skip:
+    post:
+      tags:
+      - Schedules
+      summary: Skip Run Schedule Action
+      description: Skip a recurring fire of the schedule.
+      operationId: skip_run_schedule_action_agents__agent_id__schedules__schedule_id__skip_post
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Agent Id
+      - name: schedule_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Schedule Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/SkipRunScheduleRequest'
+              - type: 'null'
+              title: Request
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentRunScheduleResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /agents/{agent_id}/schedules/{schedule_id}/unskip:
+    post:
+      tags:
+      - Schedules
+      summary: Unskip Run Schedule Action
+      description: Remove a skip for a recurring fire of the schedule.
+      operationId: unskip_run_schedule_action_agents__agent_id__schedules__schedule_id__unskip_post
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Agent Id
+      - name: schedule_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Schedule Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UnskipRunScheduleRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentRunScheduleResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /agents/{agent_id}/schedules/name/{name}/pause:
     post:
       tags:
@@ -4360,6 +4440,13 @@ components:
           type: array
           title: Next Action Times
           description: Upcoming scheduled fire times.
+        skipped_action_times:
+          items:
+            type: string
+            format: date-time
+          type: array
+          title: Skipped Action Times
+          description: Skipped one-off scheduled fire times.
         last_action_time:
           anyOf:
           - type: string
@@ -6087,6 +6174,18 @@ components:
       required:
       - content
       title: SendMessageRequest
+    SkipRunScheduleRequest:
+      properties:
+        scheduled_time:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Scheduled Time
+          description: Specific scheduled fire time to skip. If omitted, the next
+            fire is skipped.
+      type: object
+      title: SkipRunScheduleRequest
     Span:
       properties:
         id:
@@ -6969,6 +7068,17 @@ components:
       - name
       title: ToolResponseDelta
       description: Delta for tool response updates
+    UnskipRunScheduleRequest:
+      properties:
+        scheduled_time:
+          type: string
+          format: date-time
+          title: Scheduled Time
+          description: Specific scheduled fire time to unskip.
+      type: object
+      required:
+      - scheduled_time
+      title: UnskipRunScheduleRequest
     UpdateAgentRunScheduleRequest:
       properties:
         name:

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -3616,13 +3616,11 @@ paths:
           type: string
           title: Schedule Id
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              anyOf:
-              - $ref: '#/components/schemas/SkipRunScheduleRequest'
-              - type: 'null'
-              title: Request
+              $ref: '#/components/schemas/SkipRunScheduleRequest'
       responses:
         '200':
           description: Successful Response
@@ -6177,14 +6175,13 @@ components:
     SkipRunScheduleRequest:
       properties:
         scheduled_time:
-          anyOf:
-          - type: string
-            format: date-time
-          - type: 'null'
+          type: string
+          format: date-time
           title: Scheduled Time
-          description: Specific scheduled fire time to skip. If omitted, the next
-            fire is skipped.
+          description: Specific scheduled fire time to skip.
       type: object
+      required:
+      - scheduled_time
       title: SkipRunScheduleRequest
     Span:
       properties:

--- a/agentex/src/adapters/temporal/adapter_temporal.py
+++ b/agentex/src/adapters/temporal/adapter_temporal.py
@@ -627,8 +627,8 @@ class TemporalAdapter(TemporalGateway):
                 detail=str(e),
             ) from e
 
-    async def skip_next_schedule_action(
-        self, schedule_id: str, scheduled_time: datetime | None = None
+    async def skip_schedule_action(
+        self, schedule_id: str, scheduled_time: datetime
     ) -> None:
         """
         Add a one-off exclusion for a scheduled action time.
@@ -639,15 +639,8 @@ class TemporalAdapter(TemporalGateway):
         try:
             handle = self.client.get_schedule_handle(schedule_id)
             description = await handle.describe()
-            action_time = scheduled_time or (
-                description.info.next_action_times[0]
-                if description.info.next_action_times
-                else None
-            )
-            if action_time is None:
-                return
             skip = self._one_off_skip_spec(
-                action_time, description.schedule.spec.time_zone_name
+                scheduled_time, description.schedule.spec.time_zone_name
             )
 
             def _apply(input: ScheduleUpdateInput) -> ScheduleUpdate:
@@ -656,7 +649,7 @@ class TemporalAdapter(TemporalGateway):
                 return ScheduleUpdate(schedule=schedule)
 
             await handle.update(_apply)
-            logger.info(f"Skipped next action for schedule {schedule_id}")
+            logger.info(f"Skipped action for schedule {schedule_id}")
         except Exception as e:
             if "not found" in str(e).lower():
                 logger.error(f"Schedule {schedule_id} not found: {e}")
@@ -664,9 +657,9 @@ class TemporalAdapter(TemporalGateway):
                     message=f"Schedule '{schedule_id}' not found",
                     detail=str(e),
                 ) from e
-            logger.error(f"Failed to skip next action for schedule {schedule_id}: {e}")
+            logger.error(f"Failed to skip action for schedule {schedule_id}: {e}")
             raise TemporalScheduleError(
-                message=f"Failed to skip next action for schedule '{schedule_id}'",
+                message=f"Failed to skip action for schedule '{schedule_id}'",
                 detail=str(e),
             ) from e
 

--- a/agentex/src/adapters/temporal/adapter_temporal.py
+++ b/agentex/src/adapters/temporal/adapter_temporal.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, tzinfo
 from typing import Annotated, Any
 from zoneinfo import ZoneInfo
 
@@ -642,10 +642,23 @@ class TemporalAdapter(TemporalGateway):
             skip = self._one_off_skip_spec(
                 scheduled_time, description.schedule.spec.time_zone_name
             )
+            now = datetime.now(UTC)
 
             def _apply(input: ScheduleUpdateInput) -> ScheduleUpdate:
                 schedule = input.description.schedule
-                schedule.spec.skip = [*(schedule.spec.skip or []), skip]
+                retained_skips = self._without_past_one_off_skips(
+                    schedule.spec.skip,
+                    schedule.spec.time_zone_name,
+                    now=now,
+                )
+                # Replace an existing exact match so retries do not duplicate skips.
+                schedule.spec.skip = [
+                    existing
+                    for existing in retained_skips
+                    if not self._same_one_off_skip(existing, skip)
+                ]
+                if scheduled_time.astimezone(UTC) >= now:
+                    schedule.spec.skip.append(skip)
                 return ScheduleUpdate(schedule=schedule)
 
             await handle.update(_apply)
@@ -678,12 +691,18 @@ class TemporalAdapter(TemporalGateway):
             target = self._one_off_skip_spec(
                 scheduled_time, description.schedule.spec.time_zone_name
             )
+            now = datetime.now(UTC)
 
             def _apply(input: ScheduleUpdateInput) -> ScheduleUpdate:
                 schedule = input.description.schedule
+                retained_skips = self._without_past_one_off_skips(
+                    schedule.spec.skip,
+                    schedule.spec.time_zone_name,
+                    now=now,
+                )
                 schedule.spec.skip = [
                     skip
-                    for skip in (schedule.spec.skip or [])
+                    for skip in retained_skips
                     if not self._same_one_off_skip(skip, target)
                 ]
                 return ScheduleUpdate(schedule=schedule)
@@ -740,39 +759,67 @@ class TemporalAdapter(TemporalGateway):
         )
 
     @staticmethod
-    def extract_one_off_skip_times(description: ScheduleDescription) -> list[datetime]:
+    def _one_off_skip_time(
+        skip: ScheduleCalendarSpec, timezone: tzinfo
+    ) -> datetime | None:
+        values: dict[str, int] = {}
+        for field, date_part in (
+            ("second", "second"),
+            ("minute", "minute"),
+            ("hour", "hour"),
+            ("day_of_month", "day"),
+            ("month", "month"),
+            ("year", "year"),
+        ):
+            ranges = getattr(skip, field)
+            if len(ranges) != 1 or ranges[0].start != ranges[0].end:
+                return None
+            values[date_part] = ranges[0].start
+
+        return datetime(
+            values["year"],
+            values["month"],
+            values["day"],
+            values["hour"],
+            values["minute"],
+            values["second"],
+            tzinfo=timezone,
+        ).astimezone(UTC)
+
+    @classmethod
+    def _without_past_one_off_skips(
+        cls,
+        skips: list[ScheduleCalendarSpec] | None,
+        time_zone_name: str | None,
+        *,
+        now: datetime,
+    ) -> list[ScheduleCalendarSpec]:
+        timezone = ZoneInfo(time_zone_name) if time_zone_name else UTC
+        now = now.astimezone(UTC)
+        retained_skips: list[ScheduleCalendarSpec] = []
+
+        for skip in skips or []:
+            skipped_time = cls._one_off_skip_time(skip, timezone)
+            if skipped_time is None or skipped_time >= now:
+                retained_skips.append(skip)
+
+        return retained_skips
+
+    @classmethod
+    def extract_one_off_skip_times(
+        cls, description: ScheduleDescription, *, after: datetime | None = None
+    ) -> list[datetime]:
         time_zone_name = description.schedule.spec.time_zone_name
         timezone = ZoneInfo(time_zone_name) if time_zone_name else UTC
         skipped_times: list[datetime] = []
+        after_utc = after.astimezone(UTC) if after else None
 
         for skip in description.schedule.spec.skip or []:
-            values: dict[str, int] = {}
-            for field, date_part in (
-                ("second", "second"),
-                ("minute", "minute"),
-                ("hour", "hour"),
-                ("day_of_month", "day"),
-                ("month", "month"),
-                ("year", "year"),
+            skipped_time = cls._one_off_skip_time(skip, timezone)
+            if skipped_time is not None and (
+                after_utc is None or skipped_time >= after_utc
             ):
-                ranges = getattr(skip, field)
-                if len(ranges) != 1 or ranges[0].start != ranges[0].end:
-                    values = {}
-                    break
-                values[date_part] = ranges[0].start
-
-            if values:
-                skipped_times.append(
-                    datetime(
-                        values["year"],
-                        values["month"],
-                        values["day"],
-                        values["hour"],
-                        values["minute"],
-                        values["second"],
-                        tzinfo=timezone,
-                    ).astimezone(UTC)
-                )
+                skipped_times.append(skipped_time)
 
         return skipped_times
 

--- a/agentex/src/adapters/temporal/adapter_temporal.py
+++ b/agentex/src/adapters/temporal/adapter_temporal.py
@@ -639,10 +639,23 @@ class TemporalAdapter(TemporalGateway):
         try:
             handle = self.client.get_schedule_handle(schedule_id)
             description = await handle.describe()
+            now = datetime.now(UTC)
+            self._validate_future_scheduled_time(
+                scheduled_time, now=now, operation="skip"
+            )
+            if not self._contains_instant(
+                scheduled_time, description.info.next_action_times or []
+            ):
+                raise TemporalInvalidArgumentError(
+                    message="Cannot skip a time that is not an upcoming schedule action",
+                    detail=(
+                        f"Scheduled time '{scheduled_time.isoformat()}' is not in "
+                        f"the upcoming action times for schedule '{schedule_id}'."
+                    ),
+                )
             skip = self._one_off_skip_spec(
                 scheduled_time, description.schedule.spec.time_zone_name
             )
-            now = datetime.now(UTC)
 
             def _apply(input: ScheduleUpdateInput) -> ScheduleUpdate:
                 schedule = input.description.schedule
@@ -663,6 +676,8 @@ class TemporalAdapter(TemporalGateway):
 
             await handle.update(_apply)
             logger.info(f"Skipped action for schedule {schedule_id}")
+        except TemporalInvalidArgumentError:
+            raise
         except Exception as e:
             if "not found" in str(e).lower():
                 logger.error(f"Schedule {schedule_id} not found: {e}")
@@ -688,10 +703,22 @@ class TemporalAdapter(TemporalGateway):
         try:
             handle = self.client.get_schedule_handle(schedule_id)
             description = await handle.describe()
+            now = datetime.now(UTC)
+            self._validate_future_scheduled_time(
+                scheduled_time, now=now, operation="unskip"
+            )
+            skipped_times = self.extract_one_off_skip_times(description)
+            if not self._contains_instant(scheduled_time, skipped_times):
+                raise TemporalInvalidArgumentError(
+                    message="Cannot unskip a time that is not currently skipped",
+                    detail=(
+                        f"Scheduled time '{scheduled_time.isoformat()}' is not in "
+                        f"the skipped action times for schedule '{schedule_id}'."
+                    ),
+                )
             target = self._one_off_skip_spec(
                 scheduled_time, description.schedule.spec.time_zone_name
             )
-            now = datetime.now(UTC)
 
             def _apply(input: ScheduleUpdateInput) -> ScheduleUpdate:
                 schedule = input.description.schedule
@@ -709,6 +736,8 @@ class TemporalAdapter(TemporalGateway):
 
             await handle.update(_apply)
             logger.info(f"Unskipped action for schedule {schedule_id}")
+        except TemporalInvalidArgumentError:
+            raise
         except Exception as e:
             if "not found" in str(e).lower():
                 logger.error(f"Schedule {schedule_id} not found: {e}")
@@ -757,6 +786,24 @@ class TemporalAdapter(TemporalGateway):
             and getattr(left, field)[0].end == getattr(right, field)[0].end
             for field in fields
         )
+
+    @staticmethod
+    def _contains_instant(target: datetime, times: list[datetime]) -> bool:
+        target_utc = target.astimezone(UTC)
+        return any(time.astimezone(UTC) == target_utc for time in times)
+
+    @staticmethod
+    def _validate_future_scheduled_time(
+        scheduled_time: datetime, *, now: datetime, operation: str
+    ) -> None:
+        if scheduled_time.astimezone(UTC) < now.astimezone(UTC):
+            raise TemporalInvalidArgumentError(
+                message=f"Cannot {operation} a past scheduled time",
+                detail=(
+                    f"Scheduled time '{scheduled_time.isoformat()}' is before "
+                    f"the current time '{now.isoformat()}'."
+                ),
+            )
 
     @staticmethod
     def _one_off_skip_time(

--- a/agentex/src/adapters/temporal/adapter_temporal.py
+++ b/agentex/src/adapters/temporal/adapter_temporal.py
@@ -1,5 +1,6 @@
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
+from zoneinfo import ZoneInfo
 
 from fastapi import Depends
 from temporalio.client import (
@@ -7,11 +8,13 @@ from temporalio.client import (
     Schedule,
     ScheduleActionStartWorkflow,
     ScheduleAlreadyRunningError,
+    ScheduleCalendarSpec,
     ScheduleDescription,
     ScheduleHandle,
     ScheduleIntervalSpec,
     ScheduleOverlapPolicy,
     SchedulePolicy,
+    ScheduleRange,
     ScheduleSpec,
     ScheduleState,
     ScheduleUpdate,
@@ -623,6 +626,162 @@ class TemporalAdapter(TemporalGateway):
                 message=f"Failed to trigger schedule '{schedule_id}'",
                 detail=str(e),
             ) from e
+
+    async def skip_next_schedule_action(
+        self, schedule_id: str, scheduled_time: datetime | None = None
+    ) -> None:
+        """
+        Add a one-off exclusion for a scheduled action time.
+        """
+        if not self.client:
+            raise TemporalConnectionError("Temporal client is not connected")
+
+        try:
+            handle = self.client.get_schedule_handle(schedule_id)
+            description = await handle.describe()
+            action_time = scheduled_time or (
+                description.info.next_action_times[0]
+                if description.info.next_action_times
+                else None
+            )
+            if action_time is None:
+                return
+            skip = self._one_off_skip_spec(
+                action_time, description.schedule.spec.time_zone_name
+            )
+
+            def _apply(input: ScheduleUpdateInput) -> ScheduleUpdate:
+                schedule = input.description.schedule
+                schedule.spec.skip = [*(schedule.spec.skip or []), skip]
+                return ScheduleUpdate(schedule=schedule)
+
+            await handle.update(_apply)
+            logger.info(f"Skipped next action for schedule {schedule_id}")
+        except Exception as e:
+            if "not found" in str(e).lower():
+                logger.error(f"Schedule {schedule_id} not found: {e}")
+                raise TemporalScheduleNotFoundError(
+                    message=f"Schedule '{schedule_id}' not found",
+                    detail=str(e),
+                ) from e
+            logger.error(f"Failed to skip next action for schedule {schedule_id}: {e}")
+            raise TemporalScheduleError(
+                message=f"Failed to skip next action for schedule '{schedule_id}'",
+                detail=str(e),
+            ) from e
+
+    async def unskip_schedule_action(
+        self, schedule_id: str, scheduled_time: datetime
+    ) -> None:
+        """
+        Remove a one-off exclusion for a scheduled action time.
+        """
+        if not self.client:
+            raise TemporalConnectionError("Temporal client is not connected")
+
+        try:
+            handle = self.client.get_schedule_handle(schedule_id)
+            description = await handle.describe()
+            target = self._one_off_skip_spec(
+                scheduled_time, description.schedule.spec.time_zone_name
+            )
+
+            def _apply(input: ScheduleUpdateInput) -> ScheduleUpdate:
+                schedule = input.description.schedule
+                schedule.spec.skip = [
+                    skip
+                    for skip in (schedule.spec.skip or [])
+                    if not self._same_one_off_skip(skip, target)
+                ]
+                return ScheduleUpdate(schedule=schedule)
+
+            await handle.update(_apply)
+            logger.info(f"Unskipped action for schedule {schedule_id}")
+        except Exception as e:
+            if "not found" in str(e).lower():
+                logger.error(f"Schedule {schedule_id} not found: {e}")
+                raise TemporalScheduleNotFoundError(
+                    message=f"Schedule '{schedule_id}' not found",
+                    detail=str(e),
+                ) from e
+            logger.error(f"Failed to unskip action for schedule {schedule_id}: {e}")
+            raise TemporalScheduleError(
+                message=f"Failed to unskip action for schedule '{schedule_id}'",
+                detail=str(e),
+            ) from e
+
+    @staticmethod
+    def _one_off_skip_spec(
+        scheduled_time: datetime, time_zone_name: str | None
+    ) -> ScheduleCalendarSpec:
+        if time_zone_name:
+            scheduled_time = scheduled_time.astimezone(ZoneInfo(time_zone_name))
+
+        def _range(value: int) -> list[ScheduleRange]:
+            return [ScheduleRange(start=value, end=value)]
+
+        return ScheduleCalendarSpec(
+            second=_range(scheduled_time.second),
+            minute=_range(scheduled_time.minute),
+            hour=_range(scheduled_time.hour),
+            day_of_month=_range(scheduled_time.day),
+            month=_range(scheduled_time.month),
+            year=_range(scheduled_time.year),
+            # Specify all days of week so the exact date fields above decide
+            # the match regardless of Temporal/Python weekday numbering.
+            day_of_week=[ScheduleRange(start=0, end=6)],
+            comment=f"Skipped via API at {datetime.now(UTC).isoformat()}",
+        )
+
+    @staticmethod
+    def _same_one_off_skip(
+        left: ScheduleCalendarSpec, right: ScheduleCalendarSpec
+    ) -> bool:
+        fields = ("second", "minute", "hour", "day_of_month", "month", "year")
+        return all(
+            len(getattr(left, field)) == 1
+            and len(getattr(right, field)) == 1
+            and getattr(left, field)[0].start == getattr(right, field)[0].start
+            and getattr(left, field)[0].end == getattr(right, field)[0].end
+            for field in fields
+        )
+
+    @staticmethod
+    def extract_one_off_skip_times(description: ScheduleDescription) -> list[datetime]:
+        time_zone_name = description.schedule.spec.time_zone_name
+        timezone = ZoneInfo(time_zone_name) if time_zone_name else UTC
+        skipped_times: list[datetime] = []
+
+        for skip in description.schedule.spec.skip or []:
+            values: dict[str, int] = {}
+            for field, date_part in (
+                ("second", "second"),
+                ("minute", "minute"),
+                ("hour", "hour"),
+                ("day_of_month", "day"),
+                ("month", "month"),
+                ("year", "year"),
+            ):
+                ranges = getattr(skip, field)
+                if len(ranges) != 1 or ranges[0].start != ranges[0].end:
+                    values = {}
+                    break
+                values[date_part] = ranges[0].start
+
+            if values:
+                skipped_times.append(
+                    datetime(
+                        values["year"],
+                        values["month"],
+                        values["day"],
+                        values["hour"],
+                        values["minute"],
+                        values["second"],
+                        tzinfo=timezone,
+                    ).astimezone(UTC)
+                )
+
+        return skipped_times
 
     async def update_schedule(
         self,

--- a/agentex/src/adapters/temporal/port.py
+++ b/agentex/src/adapters/temporal/port.py
@@ -361,16 +361,15 @@ class TemporalGateway(ABC):
         pass
 
     @abstractmethod
-    async def skip_next_schedule_action(
-        self, schedule_id: str, scheduled_time: datetime | None = None
+    async def skip_schedule_action(
+        self, schedule_id: str, scheduled_time: datetime
     ) -> None:
         """
         Skip a scheduled action for a schedule.
 
         Args:
             schedule_id: The schedule ID
-            scheduled_time: Specific scheduled fire time to skip. If omitted,
-                the next scheduled action is skipped.
+            scheduled_time: Specific scheduled fire time to skip.
 
         Raises:
             TemporalScheduleNotFoundError: If schedule doesn't exist

--- a/agentex/src/adapters/temporal/port.py
+++ b/agentex/src/adapters/temporal/port.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from temporalio.client import (
@@ -357,6 +357,41 @@ class TemporalGateway(ABC):
         Raises:
             TemporalScheduleNotFoundError: If schedule doesn't exist
             TemporalScheduleError: If trigger fails
+        """
+        pass
+
+    @abstractmethod
+    async def skip_next_schedule_action(
+        self, schedule_id: str, scheduled_time: datetime | None = None
+    ) -> None:
+        """
+        Skip a scheduled action for a schedule.
+
+        Args:
+            schedule_id: The schedule ID
+            scheduled_time: Specific scheduled fire time to skip. If omitted,
+                the next scheduled action is skipped.
+
+        Raises:
+            TemporalScheduleNotFoundError: If schedule doesn't exist
+            TemporalScheduleError: If skip fails
+        """
+        pass
+
+    @abstractmethod
+    async def unskip_schedule_action(
+        self, schedule_id: str, scheduled_time: datetime
+    ) -> None:
+        """
+        Remove a one-off skip for a scheduled action.
+
+        Args:
+            schedule_id: The schedule ID
+            scheduled_time: Specific scheduled fire time to unskip.
+
+        Raises:
+            TemporalScheduleNotFoundError: If schedule doesn't exist
+            TemporalScheduleError: If unskip fails
         """
         pass
 

--- a/agentex/src/api/routes/agent_run_schedules.py
+++ b/agentex/src/api/routes/agent_run_schedules.py
@@ -8,6 +8,8 @@ from src.api.schemas.agent_run_schedules import (
     CreateAgentRunScheduleRequest,
     PauseRunScheduleRequest,
     ResumeRunScheduleRequest,
+    SkipRunScheduleRequest,
+    UnskipRunScheduleRequest,
     UpdateAgentRunScheduleRequest,
 )
 from src.api.schemas.authorization_types import (
@@ -269,6 +271,56 @@ async def trigger_run_schedule(
         AuthorizedOperationType.update,
     )
     return await run_schedules_use_case.trigger_schedule(agent_id, schedule_id)
+
+
+@router.post(
+    "/{schedule_id}/skip",
+    response_model=AgentRunScheduleResponse,
+    summary="Skip Run Schedule Action",
+    description="Skip a recurring fire of the schedule.",
+)
+async def skip_run_schedule_action(
+    agent_id: str,
+    schedule_id: str,
+    run_schedules_use_case: DAgentRunSchedulesUseCase,
+    authorization: DAuthorizationService,
+    request: SkipRunScheduleRequest | None = None,
+) -> AgentRunScheduleResponse:
+    await _check_schedule_or_collapse_to_404(
+        authorization,
+        build_run_schedule_authz_selector(agent_id, schedule_id),
+        AuthorizedOperationType.update,
+    )
+    return await run_schedules_use_case.skip_next_schedule_action(
+        agent_id,
+        schedule_id,
+        scheduled_time=request.scheduled_time if request else None,
+    )
+
+
+@router.post(
+    "/{schedule_id}/unskip",
+    response_model=AgentRunScheduleResponse,
+    summary="Unskip Run Schedule Action",
+    description="Remove a skip for a recurring fire of the schedule.",
+)
+async def unskip_run_schedule_action(
+    agent_id: str,
+    schedule_id: str,
+    run_schedules_use_case: DAgentRunSchedulesUseCase,
+    authorization: DAuthorizationService,
+    request: UnskipRunScheduleRequest,
+) -> AgentRunScheduleResponse:
+    await _check_schedule_or_collapse_to_404(
+        authorization,
+        build_run_schedule_authz_selector(agent_id, schedule_id),
+        AuthorizedOperationType.update,
+    )
+    return await run_schedules_use_case.unskip_schedule_action(
+        agent_id,
+        schedule_id,
+        scheduled_time=request.scheduled_time,
+    )
 
 
 @router.post(

--- a/agentex/src/api/routes/agent_run_schedules.py
+++ b/agentex/src/api/routes/agent_run_schedules.py
@@ -284,17 +284,17 @@ async def skip_run_schedule_action(
     schedule_id: str,
     run_schedules_use_case: DAgentRunSchedulesUseCase,
     authorization: DAuthorizationService,
-    request: SkipRunScheduleRequest | None = None,
+    request: SkipRunScheduleRequest,
 ) -> AgentRunScheduleResponse:
     await _check_schedule_or_collapse_to_404(
         authorization,
         build_run_schedule_authz_selector(agent_id, schedule_id),
         AuthorizedOperationType.update,
     )
-    return await run_schedules_use_case.skip_next_schedule_action(
+    return await run_schedules_use_case.skip_schedule_action(
         agent_id,
         schedule_id,
-        scheduled_time=request.scheduled_time if request else None,
+        scheduled_time=request.scheduled_time,
     )
 
 

--- a/agentex/src/api/schemas/agent_run_schedules.py
+++ b/agentex/src/api/schemas/agent_run_schedules.py
@@ -241,16 +241,30 @@ class ResumeRunScheduleRequest(BaseModel):
     note: str | None = Field(None, description="Optional note explaining the resume.")
 
 
+def _require_timezone(value: datetime, field_name: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must include timezone information.")
+    return value
+
+
 class SkipRunScheduleRequest(BaseModel):
-    scheduled_time: datetime | None = Field(
-        None,
-        description=(
-            "Specific scheduled fire time to skip. If omitted, the next fire is skipped."
-        ),
+    scheduled_time: datetime = Field(
+        ...,
+        description="Specific scheduled fire time to skip.",
     )
+
+    @model_validator(mode="after")
+    def require_scheduled_time_timezone(self):
+        self.scheduled_time = _require_timezone(self.scheduled_time, "scheduled_time")
+        return self
 
 
 class UnskipRunScheduleRequest(BaseModel):
     scheduled_time: datetime = Field(
         ..., description="Specific scheduled fire time to unskip."
     )
+
+    @model_validator(mode="after")
+    def require_scheduled_time_timezone(self):
+        self.scheduled_time = _require_timezone(self.scheduled_time, "scheduled_time")
+        return self

--- a/agentex/src/api/schemas/agent_run_schedules.py
+++ b/agentex/src/api/schemas/agent_run_schedules.py
@@ -151,6 +151,9 @@ class AgentRunScheduleResponse(BaseModel):
     next_action_times: list[datetime] = Field(
         default_factory=list, description="Upcoming scheduled fire times."
     )
+    skipped_action_times: list[datetime] = Field(
+        default_factory=list, description="Skipped one-off scheduled fire times."
+    )
     last_action_time: datetime | None = Field(
         None, description="When the schedule last fired."
     )
@@ -236,3 +239,18 @@ class PauseRunScheduleRequest(BaseModel):
 
 class ResumeRunScheduleRequest(BaseModel):
     note: str | None = Field(None, description="Optional note explaining the resume.")
+
+
+class SkipRunScheduleRequest(BaseModel):
+    scheduled_time: datetime | None = Field(
+        None,
+        description=(
+            "Specific scheduled fire time to skip. If omitted, the next fire is skipped."
+        ),
+    )
+
+
+class UnskipRunScheduleRequest(BaseModel):
+    scheduled_time: datetime = Field(
+        ..., description="Specific scheduled fire time to unskip."
+    )

--- a/agentex/src/domain/services/agent_run_schedule_service.py
+++ b/agentex/src/domain/services/agent_run_schedule_service.py
@@ -367,15 +367,15 @@ class AgentRunScheduleService:
         agent = await self.agent_repository.get(id=agent_id)
         return await self._to_response(row, agent=agent, temporal_id=temporal_id)
 
-    async def skip_next_schedule_action(
-        self, agent_id: str, schedule_id: str, scheduled_time: datetime | None = None
+    async def skip_schedule_action(
+        self, agent_id: str, schedule_id: str, scheduled_time: datetime
     ) -> AgentRunScheduleResponse:
-        """Skip a recurring fire, defaulting to the next fire."""
+        """Skip a specific recurring fire."""
         row = await self.schedule_repository.get_by_agent_id_and_id_or_raise(
             agent_id, schedule_id
         )
         temporal_id = build_run_schedule_temporal_id(row.id)
-        await self.temporal_adapter.skip_next_schedule_action(
+        await self.temporal_adapter.skip_schedule_action(
             temporal_id, scheduled_time=scheduled_time
         )
         agent = await self.agent_repository.get(id=agent_id)

--- a/agentex/src/domain/services/agent_run_schedule_service.py
+++ b/agentex/src/domain/services/agent_run_schedule_service.py
@@ -6,7 +6,7 @@ from fastapi import Depends
 from temporalio.client import ScheduleDescription
 
 from src.adapters.crud_store.exceptions import DuplicateItemError, ItemDoesNotExist
-from src.adapters.temporal.adapter_temporal import DTemporalAdapter
+from src.adapters.temporal.adapter_temporal import DTemporalAdapter, TemporalAdapter
 from src.adapters.temporal.exceptions import TemporalScheduleNotFoundError
 from src.api.schemas.agent_run_schedules import (
     AgentRunScheduleListResponse,
@@ -367,6 +367,34 @@ class AgentRunScheduleService:
         agent = await self.agent_repository.get(id=agent_id)
         return await self._to_response(row, agent=agent, temporal_id=temporal_id)
 
+    async def skip_next_schedule_action(
+        self, agent_id: str, schedule_id: str, scheduled_time: datetime | None = None
+    ) -> AgentRunScheduleResponse:
+        """Skip a recurring fire, defaulting to the next fire."""
+        row = await self.schedule_repository.get_by_agent_id_and_id_or_raise(
+            agent_id, schedule_id
+        )
+        temporal_id = build_run_schedule_temporal_id(row.id)
+        await self.temporal_adapter.skip_next_schedule_action(
+            temporal_id, scheduled_time=scheduled_time
+        )
+        agent = await self.agent_repository.get(id=agent_id)
+        return await self._to_response(row, agent=agent, temporal_id=temporal_id)
+
+    async def unskip_schedule_action(
+        self, agent_id: str, schedule_id: str, scheduled_time: datetime
+    ) -> AgentRunScheduleResponse:
+        """Remove a skipped recurring fire."""
+        row = await self.schedule_repository.get_by_agent_id_and_id_or_raise(
+            agent_id, schedule_id
+        )
+        temporal_id = build_run_schedule_temporal_id(row.id)
+        await self.temporal_adapter.unskip_schedule_action(
+            temporal_id, scheduled_time=scheduled_time
+        )
+        agent = await self.agent_repository.get(id=agent_id)
+        return await self._to_response(row, agent=agent, temporal_id=temporal_id)
+
     # -- internals ---------------------------------------------------------
 
     async def _set_paused(
@@ -416,6 +444,7 @@ class AgentRunScheduleService:
 
         state = RunScheduleState.PAUSED if entity.paused else RunScheduleState.ACTIVE
         next_action_times: list[datetime] = []
+        skipped_action_times: list[datetime] = []
         last_action_time: datetime | None = None
         num_actions_taken = 0
 
@@ -430,6 +459,7 @@ class AgentRunScheduleService:
                 live = self._extract_live_fields(description)
                 state = live["state"]
                 next_action_times = live["next_action_times"]
+                skipped_action_times = live["skipped_action_times"]
                 last_action_time = live["last_action_time"]
                 num_actions_taken = live["num_actions_taken"]
             except Exception as exc:
@@ -463,6 +493,7 @@ class AgentRunScheduleService:
             updated_at=entity.updated_at,
             state=state,
             next_action_times=next_action_times,
+            skipped_action_times=skipped_action_times,
             last_action_time=last_action_time,
             num_actions_taken=num_actions_taken,
         )
@@ -477,6 +508,7 @@ class AgentRunScheduleService:
         next_action_times = (
             list(info.next_action_times) if info.next_action_times else []
         )
+        skipped_action_times = TemporalAdapter.extract_one_off_skip_times(description)
         last_action_time: datetime | None = None
         if getattr(info, "recent_actions", None):
             last_action = info.recent_actions[-1]
@@ -489,6 +521,7 @@ class AgentRunScheduleService:
         return {
             "state": state,
             "next_action_times": next_action_times,
+            "skipped_action_times": skipped_action_times,
             "last_action_time": last_action_time,
             "num_actions_taken": num_actions_taken,
         }

--- a/agentex/src/domain/services/agent_run_schedule_service.py
+++ b/agentex/src/domain/services/agent_run_schedule_service.py
@@ -508,7 +508,9 @@ class AgentRunScheduleService:
         next_action_times = (
             list(info.next_action_times) if info.next_action_times else []
         )
-        skipped_action_times = TemporalAdapter.extract_one_off_skip_times(description)
+        skipped_action_times = TemporalAdapter.extract_one_off_skip_times(
+            description, after=datetime.now(UTC)
+        )
         last_action_time: datetime | None = None
         if getattr(info, "recent_actions", None):
             last_action = info.recent_actions[-1]

--- a/agentex/src/domain/use_cases/agent_run_schedules_use_case.py
+++ b/agentex/src/domain/use_cases/agent_run_schedules_use_case.py
@@ -83,10 +83,10 @@ class AgentRunSchedulesUseCase:
     ) -> AgentRunScheduleResponse:
         return await self.run_schedule_service.trigger_schedule(agent_id, schedule_id)
 
-    async def skip_next_schedule_action(
-        self, agent_id: str, schedule_id: str, scheduled_time: datetime | None = None
+    async def skip_schedule_action(
+        self, agent_id: str, schedule_id: str, scheduled_time: datetime
     ) -> AgentRunScheduleResponse:
-        return await self.run_schedule_service.skip_next_schedule_action(
+        return await self.run_schedule_service.skip_schedule_action(
             agent_id, schedule_id, scheduled_time=scheduled_time
         )
 

--- a/agentex/src/domain/use_cases/agent_run_schedules_use_case.py
+++ b/agentex/src/domain/use_cases/agent_run_schedules_use_case.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Annotated, Any
 
 from fastapi import Depends
@@ -81,6 +82,20 @@ class AgentRunSchedulesUseCase:
         self, agent_id: str, schedule_id: str
     ) -> AgentRunScheduleResponse:
         return await self.run_schedule_service.trigger_schedule(agent_id, schedule_id)
+
+    async def skip_next_schedule_action(
+        self, agent_id: str, schedule_id: str, scheduled_time: datetime | None = None
+    ) -> AgentRunScheduleResponse:
+        return await self.run_schedule_service.skip_next_schedule_action(
+            agent_id, schedule_id, scheduled_time=scheduled_time
+        )
+
+    async def unskip_schedule_action(
+        self, agent_id: str, schedule_id: str, scheduled_time: datetime
+    ) -> AgentRunScheduleResponse:
+        return await self.run_schedule_service.unskip_schedule_action(
+            agent_id, schedule_id, scheduled_time=scheduled_time
+        )
 
     async def delete_schedule(self, agent_id: str, schedule_id: str) -> str:
         return await self.run_schedule_service.delete_schedule(agent_id, schedule_id)

--- a/agentex/tests/unit/adapters/test_temporal_schedule_skips.py
+++ b/agentex/tests/unit/adapters/test_temporal_schedule_skips.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from src.adapters.temporal.adapter_temporal import TemporalAdapter
+from src.adapters.temporal.exceptions import TemporalInvalidArgumentError
 from temporalio.client import ScheduleCalendarSpec, ScheduleRange
 
 
@@ -74,3 +75,21 @@ def test_without_past_one_off_skips_preserves_broad_skip_specs():
         None,
         now=datetime(2026, 7, 10, 15, 0, tzinfo=UTC),
     ) == [future_skip, weekend_skip]
+
+
+@pytest.mark.unit
+def test_contains_instant_matches_equivalent_timezone_instants():
+    target = datetime(2026, 7, 9, 15, 0, tzinfo=UTC)
+    same_instant = datetime(2026, 7, 9, 11, 0, tzinfo=ZoneInfo("America/New_York"))
+
+    assert TemporalAdapter._contains_instant(target, [same_instant])
+
+
+@pytest.mark.unit
+def test_validate_future_scheduled_time_rejects_past_time():
+    with pytest.raises(TemporalInvalidArgumentError):
+        TemporalAdapter._validate_future_scheduled_time(
+            datetime(2026, 7, 9, 15, 0, tzinfo=UTC),
+            now=datetime(2026, 7, 10, 15, 0, tzinfo=UTC),
+            operation="skip",
+        )

--- a/agentex/tests/unit/adapters/test_temporal_schedule_skips.py
+++ b/agentex/tests/unit/adapters/test_temporal_schedule_skips.py
@@ -1,0 +1,47 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import pytest
+from src.adapters.temporal.adapter_temporal import TemporalAdapter
+
+
+def _description(*, skips, time_zone_name=None):
+    return SimpleNamespace(
+        schedule=SimpleNamespace(
+            spec=SimpleNamespace(skip=skips, time_zone_name=time_zone_name)
+        )
+    )
+
+
+@pytest.mark.unit
+def test_one_off_skip_round_trips_utc_time():
+    scheduled_time = datetime(2026, 7, 9, 15, 0, tzinfo=UTC)
+
+    skip = TemporalAdapter._one_off_skip_spec(scheduled_time, None)
+
+    assert TemporalAdapter.extract_one_off_skip_times(_description(skips=[skip])) == [
+        scheduled_time
+    ]
+
+
+@pytest.mark.unit
+def test_one_off_skip_round_trips_named_timezone_to_utc():
+    scheduled_time = datetime(2026, 7, 9, 15, 0, tzinfo=UTC)
+
+    skip = TemporalAdapter._one_off_skip_spec(scheduled_time, "America/New_York")
+
+    assert TemporalAdapter.extract_one_off_skip_times(
+        _description(skips=[skip], time_zone_name="America/New_York")
+    ) == [scheduled_time]
+
+
+@pytest.mark.unit
+def test_same_one_off_skip_matches_equivalent_instants_in_schedule_timezone():
+    scheduled_time = datetime(2026, 7, 9, 15, 0, tzinfo=UTC)
+    same_local_time = datetime(2026, 7, 9, 11, 0, tzinfo=ZoneInfo("America/New_York"))
+
+    left = TemporalAdapter._one_off_skip_spec(scheduled_time, "America/New_York")
+    right = TemporalAdapter._one_off_skip_spec(same_local_time, "America/New_York")
+
+    assert TemporalAdapter._same_one_off_skip(left, right)

--- a/agentex/tests/unit/adapters/test_temporal_schedule_skips.py
+++ b/agentex/tests/unit/adapters/test_temporal_schedule_skips.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from src.adapters.temporal.adapter_temporal import TemporalAdapter
+from temporalio.client import ScheduleCalendarSpec, ScheduleRange
 
 
 def _description(*, skips, time_zone_name=None):
@@ -45,3 +46,31 @@ def test_same_one_off_skip_matches_equivalent_instants_in_schedule_timezone():
     right = TemporalAdapter._one_off_skip_spec(same_local_time, "America/New_York")
 
     assert TemporalAdapter._same_one_off_skip(left, right)
+
+
+@pytest.mark.unit
+def test_extract_one_off_skip_times_can_filter_to_future_times():
+    old_time = datetime(2026, 7, 9, 15, 0, tzinfo=UTC)
+    future_time = datetime(2026, 7, 11, 15, 0, tzinfo=UTC)
+    old_skip = TemporalAdapter._one_off_skip_spec(old_time, None)
+    future_skip = TemporalAdapter._one_off_skip_spec(future_time, None)
+
+    assert TemporalAdapter.extract_one_off_skip_times(
+        _description(skips=[old_skip, future_skip]),
+        after=datetime(2026, 7, 10, 15, 0, tzinfo=UTC),
+    ) == [future_time]
+
+
+@pytest.mark.unit
+def test_without_past_one_off_skips_preserves_broad_skip_specs():
+    old_time = datetime(2026, 7, 9, 15, 0, tzinfo=UTC)
+    future_time = datetime(2026, 7, 11, 15, 0, tzinfo=UTC)
+    old_skip = TemporalAdapter._one_off_skip_spec(old_time, None)
+    future_skip = TemporalAdapter._one_off_skip_spec(future_time, None)
+    weekend_skip = ScheduleCalendarSpec(day_of_week=[ScheduleRange(start=0, end=1)])
+
+    assert TemporalAdapter._without_past_one_off_skips(
+        [old_skip, future_skip, weekend_skip],
+        None,
+        now=datetime(2026, 7, 10, 15, 0, tzinfo=UTC),
+    ) == [future_skip, weekend_skip]

--- a/agentex/tests/unit/api/test_agent_run_schedules_authz.py
+++ b/agentex/tests/unit/api/test_agent_run_schedules_authz.py
@@ -19,12 +19,15 @@ from src.api.routes.agent_run_schedules import (
     list_run_schedules,
     pause_run_schedule,
     resume_run_schedule,
+    skip_run_schedule_action,
     trigger_run_schedule,
+    unskip_run_schedule_action,
     update_run_schedule,
 )
 from src.api.schemas.agent_run_schedules import (
     CreateAgentRunScheduleRequest,
     ScheduleInitialInput,
+    UnskipRunScheduleRequest,
     UpdateAgentRunScheduleRequest,
 )
 from src.api.schemas.authorization_types import (
@@ -195,6 +198,7 @@ class TestSingleResourceRouteAuthz:
             (pause_run_schedule, "pause_schedule"),
             (resume_run_schedule, "resume_schedule"),
             (trigger_run_schedule, "trigger_schedule"),
+            (skip_run_schedule_action, "skip_next_schedule_action"),
         ],
     )
     async def test_mutation_routes_use_update_op(self, route, method_name):
@@ -214,6 +218,25 @@ class TestSingleResourceRouteAuthz:
         assert called["resource"] == AgentexResource.schedule(_authz_selector())
         assert called["operation"] == AuthorizedOperationType.update
         getattr(use_case, method_name).assert_awaited_once()
+
+    async def test_unskip_route_uses_update_op(self):
+        authorization = MagicMock()
+        authorization.check = AsyncMock(return_value=True)
+        use_case = MagicMock()
+        use_case.unskip_schedule_action = AsyncMock(return_value=MagicMock())
+
+        await unskip_run_schedule_action(
+            agent_id="agent-1",
+            schedule_id="schedule-1",
+            run_schedules_use_case=use_case,
+            authorization=authorization,
+            request=UnskipRunScheduleRequest(scheduled_time="2026-07-09T15:00:00Z"),
+        )
+
+        called = authorization.check.await_args.kwargs
+        assert called["resource"] == AgentexResource.schedule(_authz_selector())
+        assert called["operation"] == AuthorizedOperationType.update
+        use_case.unskip_schedule_action.assert_awaited_once()
 
     async def test_update_route_uses_update_op(self):
         authorization = MagicMock()

--- a/agentex/tests/unit/api/test_agent_run_schedules_authz.py
+++ b/agentex/tests/unit/api/test_agent_run_schedules_authz.py
@@ -27,6 +27,7 @@ from src.api.routes.agent_run_schedules import (
 from src.api.schemas.agent_run_schedules import (
     CreateAgentRunScheduleRequest,
     ScheduleInitialInput,
+    SkipRunScheduleRequest,
     UnskipRunScheduleRequest,
     UpdateAgentRunScheduleRequest,
 )
@@ -198,7 +199,6 @@ class TestSingleResourceRouteAuthz:
             (pause_run_schedule, "pause_schedule"),
             (resume_run_schedule, "resume_schedule"),
             (trigger_run_schedule, "trigger_schedule"),
-            (skip_run_schedule_action, "skip_next_schedule_action"),
         ],
     )
     async def test_mutation_routes_use_update_op(self, route, method_name):
@@ -218,6 +218,25 @@ class TestSingleResourceRouteAuthz:
         assert called["resource"] == AgentexResource.schedule(_authz_selector())
         assert called["operation"] == AuthorizedOperationType.update
         getattr(use_case, method_name).assert_awaited_once()
+
+    async def test_skip_route_uses_update_op(self):
+        authorization = MagicMock()
+        authorization.check = AsyncMock(return_value=True)
+        use_case = MagicMock()
+        use_case.skip_schedule_action = AsyncMock(return_value=MagicMock())
+
+        await skip_run_schedule_action(
+            agent_id="agent-1",
+            schedule_id="schedule-1",
+            run_schedules_use_case=use_case,
+            authorization=authorization,
+            request=SkipRunScheduleRequest(scheduled_time="2026-07-09T15:00:00Z"),
+        )
+
+        called = authorization.check.await_args.kwargs
+        assert called["resource"] == AgentexResource.schedule(_authz_selector())
+        assert called["operation"] == AuthorizedOperationType.update
+        use_case.skip_schedule_action.assert_awaited_once()
 
     async def test_unskip_route_uses_update_op(self):
         authorization = MagicMock()

--- a/agentex/tests/unit/services/test_agent_run_schedule_service.py
+++ b/agentex/tests/unit/services/test_agent_run_schedule_service.py
@@ -11,6 +11,8 @@ from src.api.schemas.agent_run_schedules import (
     CreateAgentRunScheduleRequest,
     RunScheduleState,
     ScheduleInitialInput,
+    SkipRunScheduleRequest,
+    UnskipRunScheduleRequest,
     UpdateAgentRunScheduleRequest,
 )
 from src.api.schemas.authorization_types import AgentexResource
@@ -481,16 +483,17 @@ class TestAgentRunScheduleServiceTrigger:
         assert start_kwargs["args"] == [row.id, "manual"]
         assert start_kwargs["task_queue"] == "agentex-server"
 
-    async def test_skip_next_updates_temporal_schedule(self, service, agent):
+    async def test_skip_updates_temporal_schedule(self, service, agent):
         row = _persisted(agent.id, _request())
         service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
         service.agent_repository.get.return_value = agent
+        scheduled_time = datetime(2026, 7, 9, 15, 0, tzinfo=UTC)
 
-        await service.skip_next_schedule_action(agent.id, row.id)
+        await service.skip_schedule_action(agent.id, row.id, scheduled_time)
 
         temporal_id = build_run_schedule_temporal_id(row.id)
-        service.temporal_adapter.skip_next_schedule_action.assert_awaited_once_with(
-            temporal_id, scheduled_time=None
+        service.temporal_adapter.skip_schedule_action.assert_awaited_once_with(
+            temporal_id, scheduled_time=scheduled_time
         )
 
     async def test_unskip_updates_temporal_schedule(self, service, agent):
@@ -525,6 +528,17 @@ class TestCadenceValidation:
             UpdateAgentRunScheduleRequest(
                 cron_expression="0 9 * * MON", interval_seconds=86400
             )
+
+    def test_skip_requires_scheduled_time(self):
+        with pytest.raises(ValidationError):
+            SkipRunScheduleRequest()
+
+    @pytest.mark.parametrize(
+        "request_type", [SkipRunScheduleRequest, UnskipRunScheduleRequest]
+    )
+    def test_skip_and_unskip_reject_naive_scheduled_time(self, request_type):
+        with pytest.raises(ValidationError):
+            request_type(scheduled_time=datetime(2026, 7, 9, 15, 0))
 
     def test_update_allows_neither_cadence(self):
         # Partial update changing only an unrelated field is valid.

--- a/agentex/tests/unit/services/test_agent_run_schedule_service.py
+++ b/agentex/tests/unit/services/test_agent_run_schedule_service.py
@@ -1,4 +1,5 @@
 import re
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, PropertyMock
 from uuid import uuid4
 
@@ -479,6 +480,31 @@ class TestAgentRunScheduleServiceTrigger:
         )
         assert start_kwargs["args"] == [row.id, "manual"]
         assert start_kwargs["task_queue"] == "agentex-server"
+
+    async def test_skip_next_updates_temporal_schedule(self, service, agent):
+        row = _persisted(agent.id, _request())
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
+        service.agent_repository.get.return_value = agent
+
+        await service.skip_next_schedule_action(agent.id, row.id)
+
+        temporal_id = build_run_schedule_temporal_id(row.id)
+        service.temporal_adapter.skip_next_schedule_action.assert_awaited_once_with(
+            temporal_id, scheduled_time=None
+        )
+
+    async def test_unskip_updates_temporal_schedule(self, service, agent):
+        row = _persisted(agent.id, _request())
+        service.schedule_repository.get_by_agent_id_and_id_or_raise.return_value = row
+        service.agent_repository.get.return_value = agent
+        scheduled_time = datetime(2026, 7, 9, 15, 0, tzinfo=UTC)
+
+        await service.unskip_schedule_action(agent.id, row.id, scheduled_time)
+
+        temporal_id = build_run_schedule_temporal_id(row.id)
+        service.temporal_adapter.unskip_schedule_action.assert_awaited_once_with(
+            temporal_id, scheduled_time=scheduled_time
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Add backend APIs to skip and unskip a specific run schedule occurrence.
- Store one-off skips in Temporal schedule exclusions and expose future skipped action times in schedule responses.
- Require clients to pass an explicit timezone-aware `scheduled_time` for both skip and unskip.
- Validate skip targets against Temporal's upcoming action times, and validate unskip targets against currently skipped future times.
- Prune expired exact one-off skips when skip/unskip mutates Temporal state, while preserving broader recurring skip specs.
- Keep this PR backend-only: no UI changes and no task-count logic.

## Test plan
- `uv run python scripts/generate_openapi_spec.py`
- `uv run ruff format src/adapters/temporal/adapter_temporal.py src/adapters/temporal/port.py src/api/routes/agent_run_schedules.py src/api/schemas/agent_run_schedules.py src/domain/services/agent_run_schedule_service.py src/domain/use_cases/agent_run_schedules_use_case.py tests/unit/api/test_agent_run_schedules_authz.py tests/unit/services/test_agent_run_schedule_service.py tests/unit/adapters/test_temporal_schedule_skips.py`
- `uv run ruff check src/adapters/temporal/adapter_temporal.py src/adapters/temporal/port.py src/api/routes/agent_run_schedules.py src/api/schemas/agent_run_schedules.py src/domain/services/agent_run_schedule_service.py src/domain/use_cases/agent_run_schedules_use_case.py tests/unit/api/test_agent_run_schedules_authz.py tests/unit/services/test_agent_run_schedule_service.py tests/unit/adapters/test_temporal_schedule_skips.py`
- `uv run python -m py_compile src/adapters/temporal/adapter_temporal.py src/adapters/temporal/port.py src/api/routes/agent_run_schedules.py src/api/schemas/agent_run_schedules.py src/domain/services/agent_run_schedule_service.py src/domain/use_cases/agent_run_schedules_use_case.py tests/unit/api/test_agent_run_schedules_authz.py tests/unit/services/test_agent_run_schedule_service.py tests/unit/adapters/test_temporal_schedule_skips.py`
- `uv run pytest tests/unit/api/test_agent_run_schedules_authz.py tests/unit/services/test_agent_run_schedule_service.py tests/unit/adapters/test_temporal_schedule_skips.py` (blocked locally: missing `testcontainers` during test collection)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds backend-only skip and unskip endpoints for Temporal schedule occurrences, storing one-off exclusions as `ScheduleCalendarSpec` entries in the schedule's `spec.skip` list and surfacing them through a new `skipped_action_times` field on the response schema.

- **New adapter logic**: `skip_schedule_action` and `unskip_schedule_action` validate the target time against Temporal's upcoming or currently-skipped action times, then apply the mutation atomically via `handle.update(_apply)`; a family of static helpers (`_one_off_skip_spec`, `_same_one_off_skip`, `_without_past_one_off_skips`, `extract_one_off_skip_times`) encodes and decodes exact-instant `CalendarSpec` entries and prunes expired ones on every write.
- **API layer**: Two new POST endpoints (`/{schedule_id}/skip` and `/{schedule_id}/unskip`) require a timezone-aware `scheduled_time` validated at schema parse time, and both use `AuthorizedOperationType.update` consistent with other mutating endpoints.
- **Tests**: Unit tests cover static-helper round-trips (UTC and named-timezone), broad-spec preservation, cross-timezone instant matching, and authz/service-layer delegation; all use fixed datetimes making them deterministic.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge as a backend-only change with no data-loss risk; the skip/unskip correctness depends on Temporal's optimistic-concurrency update semantics, and a narrow race window between the pre-validation describe and the commit remains in the adapter.

The adapter's skip_schedule_action validates scheduled_time against next_action_times from an initial handle.describe(), then applies the mutation in a separate handle.update(_apply) callback. If the schedule fires in the window between those two calls, the pre-validation passes on a stale snapshot and the skip is added for a time that already executed. The guard inside _apply uses a now captured before the update call, so it won't catch the race. All other logic — deduplication, expired-skip pruning, timezone round-trip, authz — is solid and well-tested.

agentex/src/adapters/temporal/adapter_temporal.py — the pre-validate / commit window in skip_schedule_action and the stale now guard inside the _apply closure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/adapters/temporal/adapter_temporal.py | Adds skip_schedule_action, unskip_schedule_action, and a family of static helpers; the pre-validate / commit design has a previously-flagged TOCTOU risk that remains unaddressed, though the explicit scheduled_time requirement reduces the blast radius. |
| agentex/src/adapters/temporal/port.py | Adds skip_schedule_action and unskip_schedule_action abstract methods to TemporalGateway; extract_one_off_skip_times is not added to the port, still violating port isolation as noted in a prior review. |
| agentex/src/domain/services/agent_run_schedule_service.py | Adds skip_schedule_action / unskip_schedule_action service methods and populates skipped_action_times in _extract_live_fields; still calls TemporalAdapter.extract_one_off_skip_times as a concrete static (previously flagged). |
| agentex/src/api/routes/agent_run_schedules.py | Adds POST /{schedule_id}/skip and /{schedule_id}/unskip endpoints; both correctly use AuthorizedOperationType.update, consistent with other mutating schedule endpoints. |
| agentex/src/api/schemas/agent_run_schedules.py | Adds SkipRunScheduleRequest / UnskipRunScheduleRequest with required timezone-aware scheduled_time validated via model_validator, and adds skipped_action_times to AgentRunScheduleResponse. |
| agentex/tests/unit/adapters/test_temporal_schedule_skips.py | Good unit-test coverage of the static helpers: round-trip, timezone handling, broad-spec preservation, cross-timezone instant matching, and past-time rejection; all tests use fixed datetimes so they remain deterministic. |
| agentex/tests/unit/api/test_agent_run_schedules_authz.py | Adds authz tests confirming skip and unskip routes enforce AuthorizedOperationType.update; consistent pattern with existing pause/resume/trigger tests. |
| agentex/tests/unit/services/test_agent_run_schedule_service.py | Adds service-layer tests for skip/unskip delegation and schema validation; missing a symmetric test for UnskipRunScheduleRequest() without scheduled_time, though the parametrized timezone test covers both types. |
| agentex/openapi.yaml | Adds skip and unskip path items plus SkipRunScheduleRequest, UnskipRunScheduleRequest schemas and skipped_action_times field; generated from source, consistent with code changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Route as API Route
    participant UseCase as AgentRunSchedulesUseCase
    participant Service as AgentRunScheduleService
    participant Adapter as TemporalAdapter
    participant Temporal as Temporal Server

    Client->>Route: "POST /{schedule_id}/skip {scheduled_time}"
    Route->>Route: _check_schedule_or_collapse_to_404 (AuthorizedOperationType.update)
    Route->>UseCase: skip_schedule_action(agent_id, schedule_id, scheduled_time)
    UseCase->>Service: skip_schedule_action(agent_id, schedule_id, scheduled_time)
    Service->>Service: get_by_agent_id_and_id_or_raise(agent_id, schedule_id)
    Service->>Adapter: skip_schedule_action(temporal_id, scheduled_time)
    Adapter->>Temporal: handle.describe()
    Temporal-->>Adapter: ScheduleDescription (next_action_times, spec.skip)
    Adapter->>Adapter: _validate_future_scheduled_time()
    Adapter->>Adapter: _contains_instant(scheduled_time, next_action_times)
    Adapter->>Adapter: _one_off_skip_spec(scheduled_time, time_zone_name)
    Adapter->>Temporal: handle.update(_apply)
    Note over Adapter,Temporal: _apply: prune past one-off skips, dedup, append new CalendarSpec
    Temporal-->>Adapter: OK
    Adapter-->>Service: None
    Service->>Adapter: describe_schedule(temporal_id)
    Temporal-->>Adapter: ScheduleDescription
    Adapter-->>Service: ScheduleDescription
    Service->>Service: _extract_live_fields() → skipped_action_times
    Service-->>Route: AgentRunScheduleResponse
    Route-->>Client: 200 AgentRunScheduleResponse (with skipped_action_times)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Route as API Route
    participant UseCase as AgentRunSchedulesUseCase
    participant Service as AgentRunScheduleService
    participant Adapter as TemporalAdapter
    participant Temporal as Temporal Server

    Client->>Route: "POST /{schedule_id}/skip {scheduled_time}"
    Route->>Route: _check_schedule_or_collapse_to_404 (AuthorizedOperationType.update)
    Route->>UseCase: skip_schedule_action(agent_id, schedule_id, scheduled_time)
    UseCase->>Service: skip_schedule_action(agent_id, schedule_id, scheduled_time)
    Service->>Service: get_by_agent_id_and_id_or_raise(agent_id, schedule_id)
    Service->>Adapter: skip_schedule_action(temporal_id, scheduled_time)
    Adapter->>Temporal: handle.describe()
    Temporal-->>Adapter: ScheduleDescription (next_action_times, spec.skip)
    Adapter->>Adapter: _validate_future_scheduled_time()
    Adapter->>Adapter: _contains_instant(scheduled_time, next_action_times)
    Adapter->>Adapter: _one_off_skip_spec(scheduled_time, time_zone_name)
    Adapter->>Temporal: handle.update(_apply)
    Note over Adapter,Temporal: _apply: prune past one-off skips, dedup, append new CalendarSpec
    Temporal-->>Adapter: OK
    Adapter-->>Service: None
    Service->>Adapter: describe_schedule(temporal_id)
    Temporal-->>Adapter: ScheduleDescription
    Adapter-->>Service: ScheduleDescription
    Service->>Service: _extract_live_fields() → skipped_action_times
    Service-->>Route: AgentRunScheduleResponse
    Route-->>Client: 200 AgentRunScheduleResponse (with skipped_action_times)
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into jerome/schedule..."](https://github.com/scaleapi/scale-agentex/commit/e14bc404ecce276468450cdd92b5c499a69f333d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43312605)</sub>

<!-- /greptile_comment -->