### PR TITLE
feat(agentex): forward OIDC bearer credential for user delegation

### DIFF
--- a/agentex/src/domain/delegation_headers.py
+++ b/agentex/src/domain/delegation_headers.py
@@ -96,15 +96,19 @@ def build_delegation_headers(
     cookie_header = normalized.get(HEADER_COOKIE)
     authorization = normalized.get(HEADER_AUTHORIZATION)
 
+    # Resolve the session cookie up front: a Cookie header carrying only
+    # non-allowlisted morsels (analytics, CSRF) yields nothing, and must not
+    # pre-empt a bearer that rides alongside it (browser OIDC callers send both).
+    session_cookie = (
+        _minimal_session_cookie(cookie_header, session_cookie_names_to_forward())
+        if cookie_header
+        else None
+    )
+
     result: dict[str, str] = {}
     if api_key:
         result[HEADER_ACTING_USER_API_KEY] = api_key
-    elif cookie_header:
-        session_cookie = _minimal_session_cookie(
-            cookie_header, session_cookie_names_to_forward()
-        )
-        if not session_cookie:
-            return {}
+    elif session_cookie:
         result[HEADER_ACTING_USER_COOKIE] = session_cookie
     elif authorization and authorization.lower().startswith(_BEARER_PREFIX):
         result[HEADER_ACTING_USER_AUTHORIZATION] = authorization

--- a/agentex/src/domain/delegation_headers.py
+++ b/agentex/src/domain/delegation_headers.py
@@ -4,9 +4,19 @@ Outbound runtime-delegation headers for ACP calls to agent pods (v1).
 After auth, agentex may attach x-acting-user-* headers so agent pods can call
 downstream APIs as the user. Values are minimal (never the full browser Cookie).
 
+Three credential forms are forwarded, in precedence order:
+  1. x-api-key            -> x-acting-user-api-key
+  2. session cookie       -> x-acting-user-cookie
+  3. Authorization bearer -> x-acting-user-authorization
+
 Session cookies: only configured names are forwarded on x-acting-user-cookie.
 Default name is _identityJwt. Override with AGENTEX_DELEGATION_SESSION_COOKIE_NAMES
 (comma-separated). Set to empty string to disable cookie delegation.
+
+The bearer branch is the lowest-precedence fallback: it only fires when neither an
+api key nor a session cookie is present. Callers authenticated by an OIDC/OneAuth
+access token (bearer, no api key or session cookie) land here, so the agent pod can
+present the same bearer to downstream APIs that accept it.
 """
 
 import os
@@ -14,9 +24,13 @@ from typing import Any
 
 HEADER_ACTING_USER_API_KEY = "x-acting-user-api-key"
 HEADER_ACTING_USER_COOKIE = "x-acting-user-cookie"
+HEADER_ACTING_USER_AUTHORIZATION = "x-acting-user-authorization"
+HEADER_AUTHORIZATION = "authorization"
 HEADER_COOKIE = "cookie"
 HEADER_SELECTED_ACCOUNT_ID = "x-selected-account-id"
 HEADER_USER_API_KEY = "x-api-key"
+
+_BEARER_PREFIX = "bearer "
 
 ENV_SESSION_COOKIE_NAMES = "AGENTEX_DELEGATION_SESSION_COOKIE_NAMES"
 DEFAULT_SESSION_COOKIE_NAMES = ("_identityJwt",)
@@ -80,6 +94,7 @@ def build_delegation_headers(
     normalized = _normalize_headers(inbound_headers)
     api_key = normalized.get(HEADER_USER_API_KEY)
     cookie_header = normalized.get(HEADER_COOKIE)
+    authorization = normalized.get(HEADER_AUTHORIZATION)
 
     result: dict[str, str] = {}
     if api_key:
@@ -91,6 +106,8 @@ def build_delegation_headers(
         if not session_cookie:
             return {}
         result[HEADER_ACTING_USER_COOKIE] = session_cookie
+    elif authorization and authorization.lower().startswith(_BEARER_PREFIX):
+        result[HEADER_ACTING_USER_AUTHORIZATION] = authorization
     else:
         return {}
 

--- a/agentex/src/domain/services/agent_acp_service.py
+++ b/agentex/src/domain/services/agent_acp_service.py
@@ -77,6 +77,7 @@ BLOCKED_HEADERS = frozenset(
         "x-agent-api-key",
         "x-acting-user-api-key",
         "x-acting-user-cookie",
+        "x-acting-user-authorization",
         "x-acting-as-agent",
         "x-selected-account-id",
     }

--- a/agentex/tests/unit/domain/test_delegation_headers.py
+++ b/agentex/tests/unit/domain/test_delegation_headers.py
@@ -4,6 +4,7 @@ import pytest
 from src.domain.delegation_headers import (
     ENV_SESSION_COOKIE_NAMES,
     HEADER_ACTING_USER_API_KEY,
+    HEADER_ACTING_USER_AUTHORIZATION,
     HEADER_ACTING_USER_COOKIE,
     build_delegation_headers,
     session_cookie_names_to_forward,
@@ -119,6 +120,51 @@ class TestBuildDelegationHeaders:
         )
         assert HEADER_ACTING_USER_API_KEY in headers
         assert HEADER_ACTING_USER_COOKIE not in headers
+
+    def test_bearer_delegation(self):
+        headers = build_delegation_headers(
+            _user_principal(),
+            {
+                "Authorization": "Bearer eyJ.oneauth.token",
+                "x-selected-account-id": "acct-3",
+            },
+        )
+        assert headers == {
+            HEADER_ACTING_USER_AUTHORIZATION: "Bearer eyJ.oneauth.token",
+            "x-selected-account-id": "acct-3",
+        }
+
+    def test_bearer_delegation_is_lowest_precedence(self):
+        """A bearer alongside an api key or cookie never wins — those flows are
+        unchanged, so only callers with a bearer and neither of the other two
+        (OneAuth) reach the new branch."""
+        api_key_wins = build_delegation_headers(
+            _user_principal(),
+            {"x-api-key": "user-key", "Authorization": "Bearer tok"},
+        )
+        assert api_key_wins == {HEADER_ACTING_USER_API_KEY: "user-key"}
+
+        cookie_wins = build_delegation_headers(
+            _user_principal(),
+            {"cookie": "_identityJwt=jwt", "Authorization": "Bearer tok"},
+        )
+        assert cookie_wins == {HEADER_ACTING_USER_COOKIE: "_identityJwt=jwt"}
+
+    def test_non_bearer_authorization_ignored(self):
+        assert (
+            build_delegation_headers(
+                _user_principal(),
+                {"Authorization": "Basic dXNlcjpwYXNz"},
+            )
+            == {}
+        )
+
+    def test_bearer_scheme_is_case_insensitive(self):
+        headers = build_delegation_headers(
+            _user_principal(),
+            {"authorization": "bearer lower.case.scheme"},
+        )
+        assert headers == {HEADER_ACTING_USER_AUTHORIZATION: "bearer lower.case.scheme"}
 
     def test_skips_when_no_principal(self):
         assert build_delegation_headers(None, {"x-api-key": "k"}) == {}

--- a/agentex/tests/unit/domain/test_delegation_headers.py
+++ b/agentex/tests/unit/domain/test_delegation_headers.py
@@ -150,6 +150,15 @@ class TestBuildDelegationHeaders:
         )
         assert cookie_wins == {HEADER_ACTING_USER_COOKIE: "_identityJwt=jwt"}
 
+    def test_bearer_used_when_cookie_has_no_session_morsel(self):
+        """A browser OIDC caller sends analytics/CSRF cookies alongside the
+        bearer. The non-allowlisted Cookie header must not pre-empt the bearer."""
+        headers = build_delegation_headers(
+            _user_principal(),
+            {"cookie": "csrf=secret", "Authorization": "Bearer tok"},
+        )
+        assert headers == {HEADER_ACTING_USER_AUTHORIZATION: "Bearer tok"}
+
     def test_non_bearer_authorization_ignored(self):
         assert (
             build_delegation_headers(

--- a/agentex/tests/unit/services/test_agent_acp_service.py
+++ b/agentex/tests/unit/services/test_agent_acp_service.py
@@ -1068,6 +1068,7 @@ class TestFilterRequestHeaders:
                 "x-api-key": "user-key",
                 "x-acting-user-api-key": "spoof",
                 "x-acting-user-cookie": "spoof-cookie",
+                "x-acting-user-authorization": "Bearer spoof",
                 "x-acting-as-agent": "spoof-agent",
                 "x-selected-account-id": "spoof-acct",
                 "x-trace-id": "trace-1",


### PR DESCRIPTION
## Problem

`build_delegation_headers` builds the `x-acting-user-*` headers that let an agent pod call downstream APIs *as the invoking user*. It only handled two credential forms:

- `x-api-key` → `x-acting-user-api-key`
- session cookie → `x-acting-user-cookie`

When a deployment authenticates browser users with an **OpenID-Connect / OIDC access token** (a bearer, with no api key and no session cookie), neither branch matched, so `build_delegation_headers` returned `{}`. The agent pod then received no acting-user credential, and the first user-scoped downstream call failed with `No user credentials on this request`.

This only affects deployments using bearer-based interactive auth; api-key and cookie deployments are unaffected.

## Change

Add a **lowest-precedence** bearer branch to `build_delegation_headers`: when neither an api key nor a session cookie is present, forward the inbound `Authorization: Bearer …` as a new `x-acting-user-authorization` header. The agent pod can then present the same bearer to downstream APIs that accept it.

- Precedence is `x-api-key` → session cookie → bearer, so existing api-key/cookie flows match earlier and never reach the new branch (provably unchanged — no env flag needed).
- Only a `Bearer`-scheme `Authorization` value is forwarded (case-insensitive); other schemes are ignored.
- `x-acting-user-authorization` is added to the ACP client-passthrough blocklist (`filter_request_headers`) so a client cannot spoof the delegation header; only the server-generated value is forwarded.

## Tests

`tests/unit/domain/test_delegation_headers.py` — bearer forwarded when it's the only credential, bearer loses to api-key and to cookie, non-bearer `Authorization` ignored, case-insensitive scheme.
`tests/unit/services/test_agent_acp_service.py` — `x-acting-user-authorization` is stripped from client passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `build_delegation_headers` with a lowest-precedence bearer branch so OIDC/OneAuth browser users get a valid `x-acting-user-authorization` delegation header instead of `{}`. It also fixes a pre-existing latent bug where a `Cookie` header containing only non-allowlisted morsels (analytics, CSRF) would fire the old `elif cookie_header:` branch, early-return `{}`, and silently block a co-present bearer token from ever being forwarded.

- **New bearer branch** (`delegation_headers.py`): resolves session cookie up-front before the `if/elif` chain so `elif session_cookie:` only fires when an allowlisted session morsel is actually present; the bearer branch then catches OIDC callers who send analytics cookies alongside their token.
- **Spoofing prevention** (`agent_acp_service.py`): `x-acting-user-authorization` added to `BLOCKED_HEADERS` so clients cannot inject a fake delegation credential.
- **Tests** cover bearer forwarding, all three precedence orderings, non-allowlisted cookie + bearer coexistence, non-bearer scheme rejection, and case-insensitive scheme matching.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is additive and lowest-precedence — existing api-key and cookie paths are provably unaffected — and the new header is blocked from client spoofing.

The refactoring of cookie resolution to run before the if/elif chain cleanly fixes both the new feature and the pre-existing latent bug (non-allowlisted cookies blocking bearer). All three credential paths are independently tested, precedence ordering is verified, and the spoofing guard is covered. No correctness or security concerns remain.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agentex/src/domain/delegation_headers.py | Adds bearer token as a lowest-precedence delegation credential; also fixes the prior bug where a Cookie header with only non-allowlisted cookies would early-return and prevent bearer from being reached. |
| agentex/src/domain/services/agent_acp_service.py | Adds x-acting-user-authorization to BLOCKED_HEADERS, preventing clients from spoofing the new delegation header. |
| agentex/tests/unit/domain/test_delegation_headers.py | Adds five new tests covering bearer delegation, precedence ordering, non-allowlisted cookie + bearer coexistence, non-bearer scheme rejection, and case-insensitive scheme matching. |
| agentex/tests/unit/services/test_agent_acp_service.py | Extends the filter_request_headers test to verify x-acting-user-authorization is stripped from client passthrough. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[inbound request] --> B{principal is None or agent_identity set?}
    B -->|yes| Z[return empty dict]
    B -->|no| C[normalize headers]
    C --> D[resolve session_cookie up-front from Cookie header]
    D --> E{x-api-key present?}
    E -->|yes| F[x-acting-user-api-key = api_key]
    E -->|no| G{allowlisted session_cookie found?}
    G -->|yes| H[x-acting-user-cookie = session_cookie]
    G -->|no| I{Authorization starts with Bearer?}
    I -->|yes| J[x-acting-user-authorization = authorization]
    I -->|no| Z
    F --> K{x-selected-account-id present?}
    H --> K
    J --> K
    K -->|yes| L[add x-selected-account-id to result]
    K -->|no| M[return result]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[inbound request] --> B{principal is None or agent_identity set?}
    B -->|yes| Z[return empty dict]
    B -->|no| C[normalize headers]
    C --> D[resolve session_cookie up-front from Cookie header]
    D --> E{x-api-key present?}
    E -->|yes| F[x-acting-user-api-key = api_key]
    E -->|no| G{allowlisted session_cookie found?}
    G -->|yes| H[x-acting-user-cookie = session_cookie]
    G -->|no| I{Authorization starts with Bearer?}
    I -->|yes| J[x-acting-user-authorization = authorization]
    I -->|no| Z
    F --> K{x-selected-account-id present?}
    H --> K
    J --> K
    K -->|yes| L[add x-selected-account-id to result]
    K -->|no| M[return result]
    L --> M
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `agentex/src/domain/delegation_headers.py`, line 102-112 ([link](https://github.com/scaleapi/scale-agentex/blob/7b05ebb4451547eb2c612505bcf7412e056a2ee9/agentex/src/domain/delegation_headers.py#L102-L112)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cookie branch pre-empts bearer for non-session cookies**

   When a request carries a `Cookie` header containing only non-allowlisted cookies (analytics, CSRF, etc.) *and* an `Authorization: Bearer` token, the `elif cookie_header:` branch fires, `_minimal_session_cookie` returns `None`, and the function returns `{}` — the bearer branch is never reached. Browser-based OIDC users with any analytics or tracking cookies in their `Cookie` header will still receive no delegation credential, which is the exact failure mode this PR is meant to fix. Only API/CLI clients that send zero cookies benefit from the new branch.

   The existing test `test_cookie_delegation_skips_when_no_matching_cookie` confirms the current return-early behavior but there is no test for `{"cookie": "csrf=secret", "Authorization": "Bearer tok"}` → should produce `{HEADER_ACTING_USER_AUTHORIZATION: "Bearer tok"}` under the intended semantics. The fix would be to fall through to the bearer check when `_minimal_session_cookie` returns `None` rather than returning early.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: agentex/src/domain/delegation_headers.py
   Line: 102-112

   Comment:
   **Cookie branch pre-empts bearer for non-session cookies**

   When a request carries a `Cookie` header containing only non-allowlisted cookies (analytics, CSRF, etc.) *and* an `Authorization: Bearer` token, the `elif cookie_header:` branch fires, `_minimal_session_cookie` returns `None`, and the function returns `{}` — the bearer branch is never reached. Browser-based OIDC users with any analytics or tracking cookies in their `Cookie` header will still receive no delegation credential, which is the exact failure mode this PR is meant to fix. Only API/CLI clients that send zero cookies benefit from the new branch.

   The existing test `test_cookie_delegation_skips_when_no_matching_cookie` confirms the current return-early behavior but there is no test for `{"cookie": "csrf=secret", "Authorization": "Bearer tok"}` → should produce `{HEADER_ACTING_USER_AUTHORIZATION: "Bearer tok"}` under the intended semantics. The fix would be to fall through to the bearer check when `_minimal_session_cookie` returns `None` rather than returning early.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fsrc%2Fdomain%2Fdelegation_headers.py%0ALine%3A%20102-112%0A%0AComment%3A%0A**Cookie%20branch%20pre-empts%20bearer%20for%20non-session%20cookies**%0A%0AWhen%20a%20request%20carries%20a%20%60Cookie%60%20header%20containing%20only%20non-allowlisted%20cookies%20%28analytics%2C%20CSRF%2C%20etc.%29%20*and*%20an%20%60Authorization%3A%20Bearer%60%20token%2C%20the%20%60elif%20cookie_header%3A%60%20branch%20fires%2C%20%60_minimal_session_cookie%60%20returns%20%60None%60%2C%20and%20the%20function%20returns%20%60%7B%7D%60%20%E2%80%94%20the%20bearer%20branch%20is%20never%20reached.%20Browser-based%20OIDC%20users%20with%20any%20analytics%20or%20tracking%20cookies%20in%20their%20%60Cookie%60%20header%20will%20still%20receive%20no%20delegation%20credential%2C%20which%20is%20the%20exact%20failure%20mode%20this%20PR%20is%20meant%20to%20fix.%20Only%20API%2FCLI%20clients%20that%20send%20zero%20cookies%20benefit%20from%20the%20new%20branch.%0A%0AThe%20existing%20test%20%60test_cookie_delegation_skips_when_no_matching_cookie%60%20confirms%20the%20current%20return-early%20behavior%20but%20there%20is%20no%20test%20for%20%60%7B%22cookie%22%3A%20%22csrf%3Dsecret%22%2C%20%22Authorization%22%3A%20%22Bearer%20tok%22%7D%60%20%E2%86%92%20should%20produce%20%60%7BHEADER_ACTING_USER_AUTHORIZATION%3A%20%22Bearer%20tok%22%7D%60%20under%20the%20intended%20semantics.%20The%20fix%20would%20be%20to%20fall%20through%20to%20the%20bearer%20check%20when%20%60_minimal_session_cookie%60%20returns%20%60None%60%20rather%20than%20returning%20early.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fscale-agentex&pr=363&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(agentex): fall through to bearer whe..."](https://github.com/scaleapi/scale-agentex/commit/f9bac85ba2526cf977665b963c443b1a4db67ded) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44193155)</sub>

<!-- /greptile_comment -->