### PR TITLE
feat(tasks): non-terminal task/interrupt + INTERRUPTED status (AGX1-391)

### DIFF
--- a/agentex/database/migrations/alembic/versions/2026_07_16_1200_add_interrupted_task_status_a1b2c3d4e5f6.py
+++ b/agentex/database/migrations/alembic/versions/2026_07_16_1200_add_interrupted_task_status_a1b2c3d4e5f6.py
@@ -1,0 +1,32 @@
+"""add interrupted task status
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9a4b8c7d6e5f
+Create Date: 2026-07-16 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = '9a4b8c7d6e5f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # New non-terminal task status: the current turn was interrupted by the user
+    # and the task is waiting for the next message (see task/interrupt).
+    op.execute("""
+        ALTER TYPE taskstatus ADD VALUE IF NOT EXISTS 'INTERRUPTED';
+    """)
+
+
+def downgrade() -> None:
+    # Postgres does not support removing a value from an enum type, so there is
+    # nothing to do on downgrade (mirrors the soft_delete_status migration).
+    pass

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -754,6 +754,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /tasks/{task_id}/interrupt:
+    post:
+      tags:
+      - Tasks
+      summary: Interrupt Task
+      description: Stop the in-flight turn without terminating the task. Transitions
+        a running task to the non-terminal INTERRUPTED status; the task stays continuable
+        and the next message or event resumes it.
+      operationId: interrupt_task_tasks__task_id__interrupt_post
+      parameters:
+      - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Task Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+              - $ref: '#/components/schemas/TaskStatusReasonRequest'
+              - type: 'null'
+              title: Request
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /tasks/{task_id}/terminate:
     post:
       tags:
@@ -4247,11 +4284,13 @@ components:
       - task/create
       - message/send
       - task/cancel
+      - task/interrupt
       title: AgentRPCMethod
     AgentRPCParams:
       anyOf:
       - $ref: '#/components/schemas/CreateTaskRequest'
       - $ref: '#/components/schemas/CancelTaskRequest'
+      - $ref: '#/components/schemas/InterruptTaskRequest'
       - $ref: '#/components/schemas/SendMessageRequest'
       - $ref: '#/components/schemas/SendEventRequest'
       title: AgentRPCParams
@@ -5569,6 +5608,24 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    InterruptTaskRequest:
+      properties:
+        task_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Task Id
+          description: The ID of the task to interrupt. Either this or task_name must
+            be provided.
+        task_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Task Name
+          description: The name of the task to interrupt. Either this or task_id must
+            be provided.
+      type: object
+      title: InterruptTaskRequest
     ListCheckpointsRequest:
       properties:
         thread_id:
@@ -6743,6 +6800,7 @@ components:
       - COMPLETED
       - FAILED
       - RUNNING
+      - INTERRUPTED
       - TERMINATED
       - TIMED_OUT
       - DELETED

--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -478,6 +478,30 @@ async def _authorize_rpc_request(
                 raise ValueError(
                     "Either task_id or task_name must be provided for task/cancel"
                 )
+
+        case AgentRPCMethod.TASK_INTERRUPT:
+            # Interrupt is non-terminal (the task stays continuable), so it maps
+            # to ``update`` rather than the owner-only ``cancel`` used above.
+            task_id = request.params.task_id
+            task_name = request.params.task_name
+
+            if task_id is not None:
+                await check_task_or_collapse_to_404(
+                    authorization_service,
+                    task_id,
+                    AuthorizedOperationType.update,
+                )
+            elif task_name is not None:
+                existing_task = await task_service.get_task(name=task_name)
+                await check_task_or_collapse_to_404(
+                    authorization_service,
+                    existing_task.id,
+                    AuthorizedOperationType.update,
+                )
+            else:
+                raise ValueError(
+                    "Either task_id or task_name must be provided for task/interrupt"
+                )
         case _:
             raise NotImplementedError(
                 f"_authorize_rpc_request has no case for {request.method}; "

--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -276,6 +276,30 @@ async def cancel_task(
 
 
 @router.post(
+    "/{task_id}/interrupt",
+    response_model=Task,
+    summary="Interrupt Task",
+    description=(
+        "Stop the in-flight turn without terminating the task. Transitions a "
+        "running task to the non-terminal INTERRUPTED status; the task stays "
+        "continuable and the next message or event resumes it."
+    ),
+)
+async def interrupt_task(
+    # Interrupt is non-terminal (the task remains continuable), so it authorizes
+    # the editor-allowed ``update`` action — matching the RPC task/interrupt
+    # path — rather than the owner-only ``cancel`` used by the sibling cancel route.
+    task_id: DAuthorizedId(AgentexResourceType.task, AuthorizedOperationType.update),
+    task_use_case: DTaskUseCase,
+    request: TaskStatusReasonRequest | None = None,
+) -> Task:
+    updated = await task_use_case.interrupt_task(
+        id=task_id, reason=request.reason if request else None
+    )
+    return Task.model_validate(updated)
+
+
+@router.post(
     "/{task_id}/terminate",
     response_model=Task,
     summary="Terminate Task",

--- a/agentex/src/api/schemas/agents.py
+++ b/agentex/src/api/schemas/agents.py
@@ -30,6 +30,7 @@ class AgentRPCMethod(str, Enum):
     TASK_CREATE = "task/create"
     MESSAGE_SEND = "message/send"
     TASK_CANCEL = "task/cancel"
+    TASK_INTERRUPT = "task/interrupt"
 
 
 class AgentInputType(str, Enum):

--- a/agentex/src/api/schemas/agents_rpc.py
+++ b/agentex/src/api/schemas/agents_rpc.py
@@ -19,6 +19,7 @@ class AgentRPCMethod(str, Enum):
     TASK_CREATE = "task/create"
     MESSAGE_SEND = "message/send"
     TASK_CANCEL = "task/cancel"
+    TASK_INTERRUPT = "task/interrupt"
 
 
 class CreateTaskRequest(BaseModel):
@@ -57,6 +58,23 @@ class CancelTaskRequest(BaseModel):
     task_name: str | None = Field(
         None,
         description="The name of the task to cancel. Either this or task_id must be provided.",
+    )
+
+    @model_validator(mode="after")
+    def validate_task_identifiers(self):
+        if self.task_id is not None and self.task_name is not None:
+            raise ValueError("Cannot provide both task_id and task_name - use only one")
+        return self
+
+
+class InterruptTaskRequest(BaseModel):
+    task_id: str | None = Field(
+        None,
+        description="The ID of the task to interrupt. Either this or task_name must be provided.",
+    )
+    task_name: str | None = Field(
+        None,
+        description="The name of the task to interrupt. Either this or task_id must be provided.",
     )
 
     @model_validator(mode="after")
@@ -111,7 +129,11 @@ class SendEventRequest(BaseModel):
 
 class AgentRPCParams(RootModel):
     root: (
-        CreateTaskRequest | CancelTaskRequest | SendMessageRequest | SendEventRequest
+        CreateTaskRequest
+        | CancelTaskRequest
+        | InterruptTaskRequest
+        | SendMessageRequest
+        | SendEventRequest
     ) = Field(..., description="The parameters for the agent RPC request")
 
 
@@ -136,6 +158,10 @@ class AgentRPCRequest(JSONRPCRequest):
                 elif method == AgentRPCMethod.TASK_CANCEL:
                     data["params"] = AgentRPCParams(
                         root=CancelTaskRequest(**params_data)
+                    )
+                elif method == AgentRPCMethod.TASK_INTERRUPT:
+                    data["params"] = AgentRPCParams(
+                        root=InterruptTaskRequest(**params_data)
                     )
                 elif method == AgentRPCMethod.MESSAGE_SEND:
                     data["params"] = AgentRPCParams(

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -19,6 +19,8 @@ class TaskStatus(str, Enum):
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
     RUNNING = "RUNNING"
+    # Non-terminal: current turn stopped by the user, task still continuable.
+    INTERRUPTED = "INTERRUPTED"
     TERMINATED = "TERMINATED"
     TIMED_OUT = "TIMED_OUT"
     DELETED = "DELETED"

--- a/agentex/src/domain/entities/agents_rpc.py
+++ b/agentex/src/domain/entities/agents_rpc.py
@@ -7,6 +7,7 @@ from src.api.schemas.agents_rpc import (
     AgentRPCRequest,
     CancelTaskRequest,
     CreateTaskRequest,
+    InterruptTaskRequest,
 )
 from src.domain.entities.agents import ACPType, AgentEntity
 from src.domain.entities.events import EventEntity
@@ -26,6 +27,7 @@ class AgentRPCMethod(str, Enum):
 
     TASK_CREATE = "task/create"
     TASK_CANCEL = "task/cancel"
+    TASK_INTERRUPT = "task/interrupt"
     MESSAGE_SEND = "message/send"
     EVENT_SEND = "event/send"
 
@@ -85,16 +87,32 @@ class CancelTaskParams(BaseModel):
     task: TaskEntity = Field(..., description="The task that was cancelled")
 
 
+class InterruptTaskParams(BaseModel):
+    """Parameters for task/interrupt method"""
+
+    agent: AgentEntity = Field(
+        ...,
+        description="The agent that the task was sent to",
+    )
+    task: TaskEntity = Field(..., description="The task that was interrupted")
+
+
 ACP_TYPE_TO_ALLOWED_RPC_METHODS = {
-    ACPType.SYNC: [AgentRPCMethod.MESSAGE_SEND, AgentRPCMethod.TASK_CREATE],
+    ACPType.SYNC: [
+        AgentRPCMethod.MESSAGE_SEND,
+        AgentRPCMethod.TASK_CREATE,
+        AgentRPCMethod.TASK_INTERRUPT,
+    ],
     ACPType.AGENTIC: [
         AgentRPCMethod.TASK_CREATE,
         AgentRPCMethod.TASK_CANCEL,
+        AgentRPCMethod.TASK_INTERRUPT,
         AgentRPCMethod.EVENT_SEND,
     ],
     ACPType.ASYNC: [
         AgentRPCMethod.TASK_CREATE,
         AgentRPCMethod.TASK_CANCEL,
+        AgentRPCMethod.TASK_INTERRUPT,
         AgentRPCMethod.EVENT_SEND,
     ],
 }
@@ -123,6 +141,23 @@ class CancelTaskRequestEntity(BaseModel):
     task_name: str | None = Field(
         None,
         description="The name of the task to cancel. Either this or task_id must be provided.",
+    )
+
+    @model_validator(mode="after")
+    def validate_task_identifiers(self):
+        if self.task_id is not None and self.task_name is not None:
+            raise ValueError("Cannot provide both task_id and task_name - use only one")
+        return self
+
+
+class InterruptTaskRequestEntity(BaseModel):
+    task_id: str | None = Field(
+        None,
+        description="The ID of the task to interrupt. Either this or task_name must be provided.",
+    )
+    task_name: str | None = Field(
+        None,
+        description="The name of the task to interrupt. Either this or task_id must be provided.",
     )
 
     @model_validator(mode="after")
@@ -180,6 +215,7 @@ class AgentRPCRequestEntity(JSONRPCRequest):
     params: (
         CreateTaskRequestEntity
         | CancelTaskRequestEntity
+        | InterruptTaskRequestEntity
         | SendMessageRequestEntity
         | SendEventRequestEntity
     ) = Field(..., description="The parameters for the agent RPC request")
@@ -198,6 +234,13 @@ class AgentRPCRequestEntity(JSONRPCRequest):
             request.params.root, CancelTaskRequest
         ):
             params = CancelTaskRequestEntity(
+                task_id=request.params.root.task_id,
+                task_name=request.params.root.task_name,
+            )
+        elif request.method == AgentRPCMethod.TASK_INTERRUPT and isinstance(
+            request.params.root, InterruptTaskRequest
+        ):
+            params = InterruptTaskRequestEntity(
                 task_id=request.params.root.task_id,
                 task_name=request.params.root.task_name,
             )

--- a/agentex/src/domain/entities/tasks.py
+++ b/agentex/src/domain/entities/tasks.py
@@ -20,6 +20,10 @@ class TaskStatus(str, Enum):
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
     RUNNING = "RUNNING"
+    # Non-terminal resting state: the current turn was stopped by the user and the
+    # task is waiting for the next message. Distinct from RUNNING (a turn is
+    # actively in flight) and from the terminal statuses below.
+    INTERRUPTED = "INTERRUPTED"
     TERMINATED = "TERMINATED"
     TIMED_OUT = "TIMED_OUT"
     DELETED = "DELETED"

--- a/agentex/src/domain/services/agent_acp_service.py
+++ b/agentex/src/domain/services/agent_acp_service.py
@@ -78,6 +78,7 @@ BLOCKED_HEADERS = frozenset(
         "x-agent-api-key",
         "x-acting-user-api-key",
         "x-acting-user-cookie",
+        "x-acting-user-authorization",
         "x-acting-as-agent",
         "x-selected-account-id",
     }

--- a/agentex/src/domain/services/agent_acp_service.py
+++ b/agentex/src/domain/services/agent_acp_service.py
@@ -13,6 +13,7 @@ from src.domain.entities.agents_rpc import (
     AgentRPCMethod,
     CancelTaskParams,
     CreateTaskParams,
+    InterruptTaskParams,
     SendEventParams,
     SendMessageParams,
 )
@@ -77,7 +78,6 @@ BLOCKED_HEADERS = frozenset(
         "x-agent-api-key",
         "x-acting-user-api-key",
         "x-acting-user-cookie",
-        "x-acting-user-authorization",
         "x-acting-as-agent",
         "x-selected-account-id",
     }
@@ -409,6 +409,21 @@ class AgentACPService(TaskMessageMixin):
             method=AgentRPCMethod.TASK_CANCEL,
             params=params,
             request_id=f"{AgentRPCMethod.TASK_CANCEL}-{task.id}",  # Use cancel-specific request ID
+            default_headers=headers,
+        )
+
+    async def interrupt_task(
+        self, agent: AgentEntity, task: TaskEntity, acp_url: str
+    ) -> dict[str, Any]:
+        """Forward a task/interrupt to the agent pod (non-terminal stop of the
+        in-flight turn). Same HTTP JSON-RPC transport as cancel_task."""
+        params = InterruptTaskParams(agent=agent, task=task)
+        headers = await self.get_headers(agent)
+        return await self._call_jsonrpc(
+            url=acp_url,
+            method=AgentRPCMethod.TASK_INTERRUPT,
+            params=params,
+            request_id=f"{AgentRPCMethod.TASK_INTERRUPT}-{task.id}",  # Use interrupt-specific request ID
             default_headers=headers,
         )
 

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -379,42 +379,17 @@ class AgentTaskService:
     async def interrupt_task(
         self, agent: AgentEntity, task: TaskEntity, acp_url: str
     ) -> TaskEntity:
-        """Interrupt a running task without terminating it.
+        """Forward a task/interrupt to the agent (courier only; no status write).
 
-        Mirrors cancel_task but transitions to the NON-terminal INTERRUPTED
-        status so the task stays continuable. The pod-forward is best-effort:
-        interrupt semantics live agent-side (for async agents the pod stops the
-        in-flight turn; for sync agents the real interrupt is the client tearing
-        down the streaming connection and the agent may not implement a handler
-        at all), so a forwarding failure must not prevent the platform from
-        recording the status transition. This never calls _transition_to_terminal.
+        Interrupt is a COOPERATIVE action, unlike cancel. The control plane only
+        forwards the request to the agent pod (same as event/send); the agent is
+        responsible for stopping its in-flight turn and then recording INTERRUPTED
+        via the REST POST /tasks/{id}/interrupt route (like the other task-state
+        routes). The control plane never writes status here — so an agent that does
+        not implement interrupt simply keeps running and its status stays honest.
+        Resume back to RUNNING is owned by the control plane (see _get_or_create_task).
         """
-        try:
-            await self.acp_client.interrupt_task(
-                agent=agent, task=task, acp_url=acp_url
-            )
-        except Exception as e:
-            logger.warning(
-                f"Best-effort interrupt forward to ACP failed for task {task.id}: {e}"
-            )
-
-        # Compare-and-swap RUNNING -> INTERRUPTED (mirrors resume_interrupted_task).
-        # If the CAS misses, the task moved to another status during the ACP call
-        # (the agent completed/failed it, or it was concurrently canceled); leave
-        # that status intact rather than clobbering a terminal status with the
-        # non-terminal INTERRUPTED.
-        updated = await self.transition_task_status(
-            task_id=task.id,
-            expected_status=TaskStatus.RUNNING,
-            new_status=TaskStatus.INTERRUPTED,
-            status_reason="Task interrupted by user",
-        )
-        if updated is not None:
-            return updated
-        logger.info(
-            f"Interrupt for task {task.id} not applied: task is no longer RUNNING; "
-            f"leaving its current status intact."
-        )
+        await self.acp_client.interrupt_task(agent=agent, task=task, acp_url=acp_url)
         return await self.task_repository.get(id=task.id)
 
     async def resume_interrupted_task(self, task_id: str) -> TaskEntity | None:

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -384,10 +384,24 @@ class AgentTaskService:
                 f"Best-effort interrupt forward to ACP failed for task {task.id}: {e}"
             )
 
-        task = await self.task_repository.get(id=task.id)
-        task.status = TaskStatus.INTERRUPTED
-        task.status_reason = "Task interrupted by user"
-        return await self.task_repository.update(task)
+        # Compare-and-swap RUNNING -> INTERRUPTED (mirrors resume_interrupted_task).
+        # If the CAS misses, the task moved to another status during the ACP call
+        # (the agent completed/failed it, or it was concurrently canceled); leave
+        # that status intact rather than clobbering a terminal status with the
+        # non-terminal INTERRUPTED.
+        updated = await self.transition_task_status(
+            task_id=task.id,
+            expected_status=TaskStatus.RUNNING,
+            new_status=TaskStatus.INTERRUPTED,
+            status_reason="Task interrupted by user",
+        )
+        if updated is not None:
+            return updated
+        logger.info(
+            f"Interrupt for task {task.id} not applied: task is no longer RUNNING; "
+            f"leaving its current status intact."
+        )
+        return await self.task_repository.get(id=task.id)
 
     async def resume_interrupted_task(self, task_id: str) -> TaskEntity | None:
         """Atomically resume an INTERRUPTED task back to RUNNING on next-turn start.

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -362,6 +362,47 @@ class AgentTaskService:
         task.status_reason = "Task canceled by user"
         return await self.task_repository.update(task)
 
+    async def interrupt_task(
+        self, agent: AgentEntity, task: TaskEntity, acp_url: str
+    ) -> TaskEntity:
+        """Interrupt a running task without terminating it.
+
+        Mirrors cancel_task but transitions to the NON-terminal INTERRUPTED
+        status so the task stays continuable. The pod-forward is best-effort:
+        interrupt semantics live agent-side (for async agents the pod stops the
+        in-flight turn; for sync agents the real interrupt is the client tearing
+        down the streaming connection and the agent may not implement a handler
+        at all), so a forwarding failure must not prevent the platform from
+        recording the status transition. This never calls _transition_to_terminal.
+        """
+        try:
+            await self.acp_client.interrupt_task(
+                agent=agent, task=task, acp_url=acp_url
+            )
+        except Exception as e:
+            logger.warning(
+                f"Best-effort interrupt forward to ACP failed for task {task.id}: {e}"
+            )
+
+        task = await self.task_repository.get(id=task.id)
+        task.status = TaskStatus.INTERRUPTED
+        task.status_reason = "Task interrupted by user"
+        return await self.task_repository.update(task)
+
+    async def resume_interrupted_task(self, task_id: str) -> TaskEntity | None:
+        """Atomically resume an INTERRUPTED task back to RUNNING on next-turn start.
+
+        Non-terminal transition (INTERRUPTED -> RUNNING). Returns None if the task
+        was not INTERRUPTED (e.g. it was concurrently canceled), so callers can
+        keep the task as-is rather than clobbering a terminal status.
+        """
+        return await self.transition_task_status(
+            task_id=task_id,
+            expected_status=TaskStatus.INTERRUPTED,
+            new_status=TaskStatus.RUNNING,
+            status_reason="Task resumed on next turn",
+        )
+
     async def create_event_and_forward_to_acp(
         self,
         agent: AgentEntity,

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -354,13 +354,27 @@ class AgentTaskService:
     async def cancel_task(
         self, agent: AgentEntity, task: TaskEntity, acp_url: str
     ) -> TaskEntity:
-        """Cancel a running task"""
+        """Cancel a running (or interrupted) task."""
         await self.acp_client.cancel_task(agent=agent, task=task, acp_url=acp_url)
 
-        task = await self.task_repository.get(id=task.id)
-        task.status = TaskStatus.CANCELED
-        task.status_reason = "Task canceled by user"
-        return await self.task_repository.update(task)
+        # Compare-and-swap to CANCELED on the observed non-terminal source status
+        # (mirrors interrupt_task). If the task moved to another status during the
+        # ACP call (the agent completed/failed it, or it was concurrently modified),
+        # leave that status intact rather than clobbering it with CANCELED.
+        current = await self.task_repository.get(id=task.id)
+        if current.status not in (TaskStatus.RUNNING, TaskStatus.INTERRUPTED):
+            logger.info(
+                f"Cancel for task {task.id} not applied: task is no longer running "
+                f"(current status: {current.status}); leaving its status intact."
+            )
+            return current
+        updated = await self.transition_task_status(
+            task_id=task.id,
+            expected_status=current.status,
+            new_status=TaskStatus.CANCELED,
+            status_reason="Task canceled by user",
+        )
+        return updated if updated is not None else await self.task_repository.get(id=task.id)
 
     async def interrupt_task(
         self, agent: AgentEntity, task: TaskEntity, acp_url: str

--- a/agentex/src/domain/use_cases/agents_acp_use_case.py
+++ b/agentex/src/domain/use_cases/agents_acp_use_case.py
@@ -302,6 +302,17 @@ class AgentsACPUseCase(TaskMessageMixin):
             resumed = await self.task_service.resume_interrupted_task(task.id)
             if resumed is not None:
                 task = resumed
+            else:
+                # The INTERRUPTED -> RUNNING CAS missed: the task moved out of
+                # INTERRUPTED concurrently (e.g. a cancel/complete). Refetch and
+                # reject if it is now terminal, rather than starting a turn against
+                # a terminal task. (RUNNING here means another turn already resumed
+                # it, which is fine to proceed with.)
+                task = await self.task_service.get_task(id=task.id)
+                if task.status not in (TaskStatus.RUNNING, TaskStatus.INTERRUPTED):
+                    raise ClientError(
+                        f"Task {task.id} is {task.status.value} and cannot accept new turns."
+                    )
 
         # If task exists and params provided, update them
         if task and task_params is not None:

--- a/agentex/src/domain/use_cases/agents_acp_use_case.py
+++ b/agentex/src/domain/use_cases/agents_acp_use_case.py
@@ -18,6 +18,7 @@ from src.domain.entities.agents_rpc import (
     AgentRPCRequestEntity,
     CancelTaskRequestEntity,
     CreateTaskRequestEntity,
+    InterruptTaskRequestEntity,
     SendEventRequestEntity,
     SendMessageRequestEntity,
 )
@@ -41,7 +42,7 @@ from src.domain.entities.task_messages import (
     ToolRequestContentEntity,
     ToolResponseContentEntity,
 )
-from src.domain.entities.tasks import TaskEntity
+from src.domain.entities.tasks import TaskEntity, TaskStatus
 from src.domain.exceptions import ClientError
 from src.domain.mixins.task_messages.task_message_mixin import TaskMessageMixin
 from src.domain.repositories.agent_repository import DAgentRepository
@@ -292,6 +293,16 @@ class AgentsACPUseCase(TaskMessageMixin):
             # No identifier provided - will create below
             task = None
 
+        # INTERRUPTED is a transient resting state ("paused, waiting for you").
+        # Reaching an existing task here means a new turn is starting (message/send,
+        # event/send, or a get-or-create by name), so resume it back to RUNNING.
+        # This is NOT a terminal transition, so it does not go through
+        # _transition_to_terminal.
+        if task is not None and task.status == TaskStatus.INTERRUPTED:
+            resumed = await self.task_service.resume_interrupted_task(task.id)
+            if resumed is not None:
+                task = resumed
+
         # If task exists and params provided, update them
         if task and task_params is not None:
             if task.params != task_params:
@@ -346,6 +357,7 @@ class AgentsACPUseCase(TaskMessageMixin):
         method: AgentRPCMethod,
         params: CreateTaskRequestEntity
         | CancelTaskRequestEntity
+        | InterruptTaskRequestEntity
         | SendMessageRequestEntity
         | SendEventRequestEntity,
         agent_id: str | None = None,
@@ -372,7 +384,7 @@ class AgentsACPUseCase(TaskMessageMixin):
         Returns:
             - list[TaskMessageEntity] for synchronous MESSAGE_SEND
             - AsyncIterator[TaskMessageUpdateEntity] for streaming MESSAGE_SEND
-            - TaskEntity for TASK_CREATE or TASK_CANCEL
+            - TaskEntity for TASK_CREATE, TASK_CANCEL or TASK_INTERRUPT
             - EventEntity for EVENT_SEND
         """
         # Get the agent
@@ -396,6 +408,8 @@ class AgentsACPUseCase(TaskMessageMixin):
             return await self._handle_task_create(agent, params, acp_url)
         elif method == AgentRPCMethod.TASK_CANCEL:
             return await self._handle_task_cancel(agent, params, acp_url)
+        elif method == AgentRPCMethod.TASK_INTERRUPT:
+            return await self._handle_task_interrupt(agent, params, acp_url)
         elif method == AgentRPCMethod.EVENT_SEND:
             return await self._handle_event_send(
                 agent, params, request_headers, acp_url
@@ -801,6 +815,45 @@ class AgentsACPUseCase(TaskMessageMixin):
         )
 
         return await self.task_service.cancel_task(
+            agent=agent,
+            task=task,
+            acp_url=acp_url,
+        )
+
+    async def _handle_task_interrupt(
+        self, agent: AgentEntity, params: InterruptTaskRequestEntity, acp_url: str
+    ) -> TaskEntity:
+        """
+        Handle task/interrupt method.
+
+        Interrupt is a non-terminal counterpart to task/cancel: it stops the
+        in-flight turn and leaves the task continuable (status INTERRUPTED),
+        rather than transitioning to a terminal status. It never calls
+        _transition_to_terminal.
+
+        For ASYNC/AGENTIC agents the interrupt is forwarded to the pod over the
+        same HTTP JSON-RPC transport as event/send and task/cancel; the agent is
+        the actor that actually stops the model/tool calls. For SYNC agents the
+        real interrupt is the teardown of the streaming connection on the client
+        side, so the forwarded RPC is best-effort (a sync agent may not implement
+        an interrupt handler). In both cases the platform's job is to record the
+        non-terminal status transition; the forward is best-effort and must not
+        wedge the request.
+
+        Args:
+            agent: The agent to interrupt the task for
+            params: Parameters containing task_id or task_name
+            acp_url: Resolved ACP URL to route to
+
+        Returns:
+            The task with its (non-terminal) INTERRUPTED status.
+        """
+
+        task = await self.task_service.get_task(
+            id=params.task_id, name=params.task_name
+        )
+
+        return await self.task_service.interrupt_task(
             agent=agent,
             task=task,
             acp_url=acp_url,

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -153,8 +153,8 @@ class TasksUseCase:
             raise ItemDoesNotExist(f"Task {id or name} not found")
         if task_entity.status not in self._TERMINAL_TRANSITION_SOURCES:
             raise ClientError(
-                f"Task {task_entity.id} is not running (current status: {task_entity.status}). "
-                f"Only running tasks can have their status updated."
+                f"Task {task_entity.id} cannot be transitioned (current status: {task_entity.status}). "
+                f"Only running or interrupted tasks can have their status updated."
             )
 
         # Compare-and-swap on the observed non-terminal source status (RUNNING or

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -132,6 +132,11 @@ class TasksUseCase:
 
         return task_entity
 
+    # Non-terminal statuses a task can be transitioned to a terminal status from.
+    # RUNNING is the normal case; INTERRUPTED is also valid so an interrupted
+    # (paused, still-continuable) task can still be canceled/completed/etc later.
+    _TERMINAL_TRANSITION_SOURCES = (TaskStatus.RUNNING, TaskStatus.INTERRUPTED)
+
     async def _transition_to_terminal(
         self,
         target_status: TaskStatus,
@@ -139,7 +144,47 @@ class TasksUseCase:
         name: str | None = None,
         reason: str | None = None,
     ) -> TaskEntity:
-        """Atomically transition a running task to a terminal status."""
+        """Atomically transition a running or interrupted task to a terminal status."""
+        if not id and not name:
+            raise ClientError("Either id or name must be provided")
+
+        task_entity = await self.task_service.get_task(id=id, name=name)
+        if task_entity.status == TaskStatus.DELETED:
+            raise ItemDoesNotExist(f"Task {id or name} not found")
+        if task_entity.status not in self._TERMINAL_TRANSITION_SOURCES:
+            raise ClientError(
+                f"Task {task_entity.id} is not running (current status: {task_entity.status}). "
+                f"Only running tasks can have their status updated."
+            )
+
+        # Compare-and-swap on the observed non-terminal source status (RUNNING or
+        # INTERRUPTED) so a concurrent modification is still detected as a lost race.
+        expected_status = task_entity.status
+        status_reason = reason or f"Task {target_status.value.lower()}"
+        updated = await self.task_service.transition_task_status(
+            task_id=task_entity.id,
+            expected_status=expected_status,
+            new_status=target_status,
+            status_reason=status_reason,
+        )
+        if updated is None:
+            raise ClientError(
+                f"Task {task_entity.id} status was concurrently modified. "
+                f"Please retry the request."
+            )
+        return updated
+
+    async def interrupt_task(
+        self, id: str | None = None, name: str | None = None, reason: str | None = None
+    ) -> TaskEntity:
+        """Interrupt a running task without terminating it.
+
+        This is the non-terminal counterpart to the terminal-transition methods
+        (cancel/complete/fail/...): it transitions RUNNING -> INTERRUPTED via a
+        compare-and-swap and deliberately does NOT go through
+        _transition_to_terminal. The task stays continuable; the next message or
+        event resumes it back to RUNNING.
+        """
         if not id and not name:
             raise ClientError("Either id or name must be provided")
 
@@ -149,14 +194,14 @@ class TasksUseCase:
         if task_entity.status != TaskStatus.RUNNING:
             raise ClientError(
                 f"Task {task_entity.id} is not running (current status: {task_entity.status}). "
-                f"Only running tasks can have their status updated."
+                f"Only running tasks can be interrupted."
             )
 
-        status_reason = reason or f"Task {target_status.value.lower()}"
+        status_reason = reason or "Task interrupted"
         updated = await self.task_service.transition_task_status(
             task_id=task_entity.id,
             expected_status=TaskStatus.RUNNING,
-            new_status=target_status,
+            new_status=TaskStatus.INTERRUPTED,
             status_reason=status_reason,
         )
         if updated is None:

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -156,6 +156,7 @@ class TestTasksAPIIntegration:
                     "COMPLETED",
                     "FAILED",
                     "RUNNING",
+                    "INTERRUPTED",
                     "TERMINATED",
                     "TIMED_OUT",
                 ]
@@ -1607,6 +1608,72 @@ class TestTasksAPIIntegration:
         task_data = response.json()
         assert task_data["status"] == "CANCELED"
         assert task_data["status_reason"] == "User requested cancellation"
+
+    async def test_interrupt_task_endpoint(self, isolated_client, test_task):
+        """POST /tasks/{task_id}/interrupt transitions RUNNING to the non-terminal
+        INTERRUPTED status (task stays continuable)."""
+        # When
+        response = await isolated_client.post(
+            f"/tasks/{test_task.id}/interrupt",
+            json={"reason": "User hit stop"},
+        )
+
+        # Then
+        assert response.status_code == 200
+        task_data = response.json()
+        assert task_data["status"] == "INTERRUPTED"
+        assert task_data["status_reason"] == "User hit stop"
+
+    async def test_interrupt_task_default_reason(self, isolated_client, test_task):
+        """POST /tasks/{task_id}/interrupt without a reason uses the default."""
+        response = await isolated_client.post(
+            f"/tasks/{test_task.id}/interrupt",
+        )
+
+        assert response.status_code == 200
+        task_data = response.json()
+        assert task_data["status"] == "INTERRUPTED"
+        assert task_data["status_reason"] == "Task interrupted"
+
+    async def test_interrupted_task_stays_transition_eligible(
+        self, isolated_client, test_task
+    ):
+        """An interrupted task is non-terminal: it can still be canceled
+        afterwards (terminal-from-INTERRUPTED)."""
+        # Given - interrupt the running task
+        response = await isolated_client.post(
+            f"/tasks/{test_task.id}/interrupt",
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "INTERRUPTED"
+
+        # When - cancel the interrupted task
+        response = await isolated_client.post(
+            f"/tasks/{test_task.id}/cancel",
+            json={"reason": "canceled after interrupt"},
+        )
+
+        # Then - the terminal transition succeeds from INTERRUPTED
+        assert response.status_code == 200
+        task_data = response.json()
+        assert task_data["status"] == "CANCELED"
+        assert task_data["status_reason"] == "canceled after interrupt"
+
+    async def test_cannot_interrupt_completed_task(self, isolated_client, test_task):
+        """A terminal (completed) task cannot be interrupted."""
+        # Given - complete the task first
+        response = await isolated_client.post(
+            f"/tasks/{test_task.id}/complete",
+        )
+        assert response.status_code == 200
+
+        # When - try to interrupt the completed task
+        response = await isolated_client.post(
+            f"/tasks/{test_task.id}/interrupt",
+        )
+
+        # Then - rejected
+        assert response.status_code == 400
 
     async def test_terminate_task_endpoint(self, isolated_client, test_task):
         """Test POST /tasks/{task_id}/terminate transitions RUNNING to TERMINATED"""

--- a/agentex/tests/unit/api/test_tasks_authz.py
+++ b/agentex/tests/unit/api/test_tasks_authz.py
@@ -192,6 +192,50 @@ class TestPerRpcOperationRouting:
             (AgentexResourceType.task, "task-cancel", AuthorizedOperationType.cancel)
         ]
 
+    async def test_task_interrupt_with_task_id_uses_update(self):
+        # Interrupt is non-terminal, so it maps to ``update`` (editor-allowed),
+        # NOT the owner-only ``cancel`` that task/cancel uses.
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        request = MagicMock()
+        request.method = AgentRPCMethod.TASK_INTERRUPT
+        request.params = MagicMock(task_id="task-int", task_name=None)
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        assert calls == [
+            (AgentexResourceType.task, "task-int", AuthorizedOperationType.update)
+        ]
+
+    async def test_task_interrupt_with_task_name_uses_update(self):
+        from src.api.routes.agents import _authorize_rpc_request
+        from src.api.schemas.agents import AgentRPCMethod
+
+        authorization = MagicMock()
+        calls = self._capture_check(authorization)
+        task_service = MagicMock()
+        task_service.get_task = AsyncMock(
+            return_value=MagicMock(id="task-int-resolved")
+        )
+        request = MagicMock()
+        request.method = AgentRPCMethod.TASK_INTERRUPT
+        request.params = MagicMock(task_id=None, task_name="interrupt-task")
+
+        await _authorize_rpc_request(request, authorization, task_service)
+
+        task_service.get_task.assert_awaited_once_with(name="interrupt-task")
+        assert calls == [
+            (
+                AgentexResourceType.task,
+                "task-int-resolved",
+                AuthorizedOperationType.update,
+            )
+        ]
+
     async def test_unwired_method_fails_closed_with_not_implemented(self):
         # Fail-closed default: any AgentRPCMethod not explicitly wired in
         # _authorize_rpc_request must raise rather than silently pass through
@@ -235,6 +279,49 @@ class TestRestCancelRouteRequiresOwner:
         assert (
             authorization.check.await_args.kwargs["operation"]
             == AuthorizedOperationType.cancel
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestRestInterruptRouteRequiresUpdate:
+    """The REST ``POST /tasks/{id}/interrupt`` route authorizes the editor-allowed
+    ``update`` action (interrupt is non-terminal), distinct from the owner-only
+    ``cancel`` used by the sibling cancel route."""
+
+    async def test_rest_interrupt_route_checks_update_operation(self):
+        import inspect
+
+        from src.api.routes.tasks import interrupt_task
+
+        annotation = inspect.signature(interrupt_task).parameters["task_id"].annotation
+        dep = _dep_callable(annotation)
+
+        authorization = MagicMock()
+        authorization.check = AsyncMock(return_value=True)
+        repos = (MagicMock(), MagicMock(), MagicMock())
+
+        result = await dep(authorization, *repos, "task-i")
+
+        assert result == "task-i"
+        assert (
+            authorization.check.await_args.kwargs["operation"]
+            == AuthorizedOperationType.update
+        )
+
+
+def test_sync_acp_type_permits_task_interrupt():
+    """task/interrupt must be allowed for SYNC, ASYNC and AGENTIC agents. The
+    SYNC allow-list historically only permitted MESSAGE_SEND and TASK_CREATE."""
+    from src.domain.entities.agents import ACPType
+    from src.domain.entities.agents_rpc import (
+        ACP_TYPE_TO_ALLOWED_RPC_METHODS,
+        AgentRPCMethod,
+    )
+
+    for acp_type in (ACPType.SYNC, ACPType.ASYNC, ACPType.AGENTIC):
+        assert (
+            AgentRPCMethod.TASK_INTERRUPT in ACP_TYPE_TO_ALLOWED_RPC_METHODS[acp_type]
         )
 
 

--- a/agentex/tests/unit/use_cases/test_acp_type_backwards_compatibility_use_case.py
+++ b/agentex/tests/unit/use_cases/test_acp_type_backwards_compatibility_use_case.py
@@ -36,14 +36,15 @@ class TestACPTypeBackwardsCompatibility:
         agentic_methods = set(ACP_TYPE_TO_ALLOWED_RPC_METHODS[ACPType.AGENTIC])
         async_methods = set(ACP_TYPE_TO_ALLOWED_RPC_METHODS[ACPType.ASYNC])
 
-        assert agentic_methods == async_methods, (
-            "AGENTIC and ASYNC should have identical allowed RPC methods"
-        )
+        assert (
+            agentic_methods == async_methods
+        ), "AGENTIC and ASYNC should have identical allowed RPC methods"
 
         # Verify they include the expected methods
         expected_methods = {
             AgentRPCMethod.TASK_CREATE,
             AgentRPCMethod.TASK_CANCEL,
+            AgentRPCMethod.TASK_INTERRUPT,
             AgentRPCMethod.EVENT_SEND,
         }
         assert agentic_methods == expected_methods
@@ -361,6 +362,6 @@ class TestACPTypeBackwardsCompatibility:
         # Both AGENTIC and ASYNC should pass the same conditional checks
         agentic_is_not_sync = agentic_agent.acp_type != ACPType.SYNC
         async_is_not_sync = async_agent.acp_type != ACPType.SYNC
-        assert agentic_is_not_sync == async_is_not_sync, (
-            "AGENTIC and ASYNC should have identical behavior in != SYNC checks"
-        )
+        assert (
+            agentic_is_not_sync == async_is_not_sync
+        ), "AGENTIC and ASYNC should have identical behavior in != SYNC checks"

--- a/agentex/tests/unit/use_cases/test_tasks_use_case.py
+++ b/agentex/tests/unit/use_cases/test_tasks_use_case.py
@@ -267,7 +267,7 @@ class TestTasksUseCaseStatusTransitions:
         )
         await tasks_use_case.complete_task(id=task.id)
 
-        with pytest.raises(ClientError, match="not running"):
+        with pytest.raises(ClientError, match="Only running"):
             await tasks_use_case.interrupt_task(id=task.id)
 
     async def test_cannot_interrupt_already_interrupted_task(
@@ -280,7 +280,7 @@ class TestTasksUseCaseStatusTransitions:
         )
         await tasks_use_case.interrupt_task(id=task.id)
 
-        with pytest.raises(ClientError, match="not running"):
+        with pytest.raises(ClientError, match="Only running"):
             await tasks_use_case.interrupt_task(id=task.id)
 
     async def test_interrupt_requires_id_or_name(self, tasks_use_case):
@@ -357,7 +357,7 @@ class TestTasksUseCaseStatusTransitions:
         await tasks_use_case.complete_task(id=task.id)
 
         # When / Then
-        with pytest.raises(ClientError, match="not running"):
+        with pytest.raises(ClientError, match="Only running"):
             await tasks_use_case.terminate_task(id=task.id)
 
     async def test_cannot_transition_failed_task(
@@ -372,7 +372,7 @@ class TestTasksUseCaseStatusTransitions:
         await tasks_use_case.fail_task(id=task.id)
 
         # When / Then
-        with pytest.raises(ClientError, match="not running"):
+        with pytest.raises(ClientError, match="Only running"):
             await tasks_use_case.complete_task(id=task.id)
 
     async def test_cannot_transition_canceled_task(
@@ -387,7 +387,7 @@ class TestTasksUseCaseStatusTransitions:
         await tasks_use_case.cancel_task(id=task.id)
 
         # When / Then
-        with pytest.raises(ClientError, match="not running"):
+        with pytest.raises(ClientError, match="Only running"):
             await tasks_use_case.complete_task(id=task.id)
 
     async def test_cannot_transition_terminated_task(
@@ -402,7 +402,7 @@ class TestTasksUseCaseStatusTransitions:
         await tasks_use_case.terminate_task(id=task.id)
 
         # When / Then
-        with pytest.raises(ClientError, match="not running"):
+        with pytest.raises(ClientError, match="Only running"):
             await tasks_use_case.complete_task(id=task.id)
 
     async def test_cannot_transition_timed_out_task(
@@ -417,7 +417,7 @@ class TestTasksUseCaseStatusTransitions:
         await tasks_use_case.timeout_task(id=task.id)
 
         # When / Then
-        with pytest.raises(ClientError, match="not running"):
+        with pytest.raises(ClientError, match="Only running"):
             await tasks_use_case.complete_task(id=task.id)
 
     async def test_cannot_transition_deleted_task(

--- a/agentex/tests/unit/use_cases/test_tasks_use_case.py
+++ b/agentex/tests/unit/use_cases/test_tasks_use_case.py
@@ -155,6 +155,139 @@ class TestTasksUseCaseStatusTransitions:
         assert updated.status == TaskStatus.TIMED_OUT
         assert updated.status_reason == "Task timed_out"
 
+    # --- Non-terminal interrupt (RUNNING <-> INTERRUPTED) ---
+
+    async def test_interrupt_running_task_is_non_terminal(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """Interrupt transitions RUNNING -> INTERRUPTED, a non-terminal status."""
+        # Given
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="interrupt-test"
+        )
+        assert task.status == TaskStatus.RUNNING
+
+        # When
+        updated = await tasks_use_case.interrupt_task(
+            id=task.id, reason="User hit stop"
+        )
+
+        # Then
+        assert updated.status == TaskStatus.INTERRUPTED
+        assert updated.status_reason == "User hit stop"
+
+    async def test_interrupt_default_reason(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """Interrupt without an explicit reason uses the default."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="interrupt-default-reason-test"
+        )
+
+        updated = await tasks_use_case.interrupt_task(id=task.id)
+
+        assert updated.status == TaskStatus.INTERRUPTED
+        assert updated.status_reason == "Task interrupted"
+
+    async def test_interrupted_task_can_resume_to_running(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """INTERRUPTED -> RUNNING on next-turn start (resume_interrupted_task)."""
+        # Given an interrupted task
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="interrupt-resume-test"
+        )
+        await tasks_use_case.interrupt_task(id=task.id)
+
+        # When the next turn starts
+        resumed = await task_service.resume_interrupted_task(task.id)
+
+        # Then it is RUNNING again
+        assert resumed is not None
+        assert resumed.status == TaskStatus.RUNNING
+
+    async def test_resume_non_interrupted_task_is_noop(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """Resuming a task that is not INTERRUPTED must not clobber its status."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="interrupt-resume-noop-test"
+        )
+        # RUNNING (not INTERRUPTED): the compare-and-swap misses, returns None.
+        resumed = await task_service.resume_interrupted_task(task.id)
+        assert resumed is None
+
+    async def test_interrupted_task_can_transition_to_terminal(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """An INTERRUPTED task is still transition-eligible: it can be canceled
+        (terminal-from-INTERRUPTED) later."""
+        # Given an interrupted task
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="interrupt-then-cancel-test"
+        )
+        interrupted = await tasks_use_case.interrupt_task(id=task.id)
+        assert interrupted.status == TaskStatus.INTERRUPTED
+
+        # When the interrupted task is canceled
+        canceled = await tasks_use_case.cancel_task(
+            id=task.id, reason="User canceled after interrupt"
+        )
+
+        # Then the terminal transition succeeds from INTERRUPTED
+        assert canceled.status == TaskStatus.CANCELED
+        assert canceled.status_reason == "User canceled after interrupt"
+
+    async def test_interrupted_task_can_be_completed(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """terminal-from-INTERRUPTED also works for complete()."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="interrupt-then-complete-test"
+        )
+        await tasks_use_case.interrupt_task(id=task.id)
+
+        completed = await tasks_use_case.complete_task(id=task.id, reason="done")
+
+        assert completed.status == TaskStatus.COMPLETED
+
+    async def test_cannot_interrupt_non_running_task(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """A task that is not RUNNING cannot be interrupted."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="interrupt-non-running-test"
+        )
+        await tasks_use_case.complete_task(id=task.id)
+
+        with pytest.raises(ClientError, match="not running"):
+            await tasks_use_case.interrupt_task(id=task.id)
+
+    async def test_cannot_interrupt_already_interrupted_task(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """Interrupt is only valid from RUNNING; a second interrupt is rejected."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="interrupt-twice-test"
+        )
+        await tasks_use_case.interrupt_task(id=task.id)
+
+        with pytest.raises(ClientError, match="not running"):
+            await tasks_use_case.interrupt_task(id=task.id)
+
+    async def test_interrupt_requires_id_or_name(self, tasks_use_case):
+        """Interrupt with neither id nor name raises."""
+        with pytest.raises(ClientError, match="Either id or name"):
+            await tasks_use_case.interrupt_task()
+
     # --- Default reason for each transition ---
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Platform half of AGX1-391 (stop an agent run mid-stream). Adds a non-terminal `INTERRUPTED` task status and a `task/interrupt` operation so a running turn can be stopped without terminating the task or locking the chat.

## Ownership model (important)

Interrupt is **cooperative**, not control-plane-authoritative like `cancel`:

- **`task/interrupt` RPC = courier only.** It is forwarded to the agent (exactly like `event/send`) and writes no status. Only the agent can actually stop an in-flight turn.
- **The agent records `INTERRUPTED`.** After stopping its turn, the agent calls the REST **`POST /tasks/{task_id}/interrupt`** route (like the other task-state routes: complete/fail/cancel/timeout) to set its status. An agent that does not implement interrupt simply stays `RUNNING`, so status stays honest.
- **The control plane owns `RUNNING`.** It sets `RUNNING` on task creation and auto-resumes `INTERRUPTED -> RUNNING` on the next turn (`_get_or_create_task`).

Contrast with `cancel`, which is authoritative: the control plane sets `CANCELED` itself (and the RPC `cancel_task` also CAS-writes `CANCELED`), because cancel does not depend on the agent cooperating.

## What's included

- `task/interrupt` RPC method (forward-only) + REST `POST /tasks/{task_id}/interrupt` (authorized `update`, the agent's write path). Allowed for `SYNC` / `ASYNC` / `AGENTIC`.
- New non-terminal `INTERRUPTED` status + alembic migration; terminal transitions accept `INTERRUPTED` as a valid source (so an interrupted task can still be canceled/completed).
- Auto-resume `INTERRUPTED -> RUNNING` on the next turn; if that CAS loses to a concurrent terminal transition, the turn is rejected instead of running against a terminal task.
- Regenerated `openapi.yaml` (drives SDK regeneration).
- Unit + integration tests mirroring the `task/cancel` suite.

## Review follow-ups (in this PR)

- `task/interrupt` RPC reworked to forward-only per design discussion (agent owns `INTERRUPTED`); control plane keeps ownership of `RUNNING`/auto-resume.
- Auto-resume rejects with `ClientError` if the resume CAS lost to a concurrent cancel/complete (@smoreinis).
- `cancel_task` (RPC path) hardened with a compare-and-swap so it cannot clobber a task the agent terminated during the ACP call (independent correctness fix; @greptile).
- Restored `x-acting-user-authorization` to `BLOCKED_HEADERS` (had been dropped inadvertently).
- Corrected the `_transition_to_terminal` error text now that `INTERRUPTED` is a valid source.

## Not in this PR (tracked separately)

- Agent-side behavior: golden agent `on_interrupt` (stops the turn and calls the REST interrupt route to record `INTERRUPTED`) and the agentex SDK interrupt hook (`interrupt_turn` signal / `on_interrupt` base workflow method).
- SDK regeneration (scale-agentex-python / agentex-typescript) once this `openapi.yaml` lands in Stainless — this includes adding the `task/interrupt` path to the Stainless config so `tasks.interrupt` is generated (per @smoreinis).
- Golden-agent Stop + queue-at-boundary UI (scaleapi egp-annotation). The generic agentex-ui Stop button was intentionally dropped: a generic Stop is misleading for agents that do not implement self-interruption.

## Testing

Unit + integration tests pass (authz mapping, non-terminal interrupt via REST, `INTERRUPTED -> RUNNING` resume, terminal-from-`INTERRUPTED`, SYNC now permits the method, fail-closed unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a non-terminal `task/interrupt` operation and an `INTERRUPTED` task status as a structural sibling of `task/cancel`. It allows a running turn to be stopped without terminating the task, enabling the user to resume via the next message or event.

- Adds `INTERRUPTED` enum value with a guarded Alembic migration, state machine transitions (`RUNNING → INTERRUPTED`, `INTERRUPTED → RUNNING`, and terminal transitions from `INTERRUPTED`), and compare-and-swap logic throughout to prevent concurrent-status clobbering.
- Exposes a REST `POST /tasks/{task_id}/interrupt` endpoint (authorized as `update`) and a `task/interrupt` RPC method (allowed for SYNC, ASYNC, and AGENTIC agents), with matching unit and integration tests.
- Aligns `cancel_task` in `AgentTaskService` to the same CAS pattern for consistency, and restores `x-acting-user-authorization` to `BLOCKED_HEADERS`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the CAS-based state transitions are correct, the authorization mapping is consistent, and the migration is guarded with IF NOT EXISTS.

The INTERRUPTED state machine is cleanly implemented with compare-and-swap throughout — no path can overwrite a terminal status. Authorization for interrupt correctly maps to the less-privileged update operation. The one notable issue is a docstring on _handle_task_interrupt that claims the returned task carries INTERRUPTED status when the cooperative design intentionally leaves the task RUNNING until the agent acknowledges; this does not affect runtime correctness.

agentex/src/domain/use_cases/agents_acp_use_case.py — the _handle_task_interrupt return-value docstring should be corrected to reflect that the returned task retains RUNNING status until the agent-side callback writes INTERRUPTED.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/database/migrations/alembic/versions/2026_07_16_1200_add_interrupted_task_status_a1b2c3d4e5f6.py | Adds INTERRUPTED enum value with IF NOT EXISTS guard; downgrade is a documented no-op consistent with prior enum migrations. |
| agentex/src/domain/services/task_service.py | Adds cooperative interrupt_task (courier-only, no DB write) and resume_interrupted_task (CAS INTERRUPTED→RUNNING); cancel_task aligned to same CAS guard pattern. |
| agentex/src/domain/use_cases/tasks_use_case.py | New interrupt_task method with CAS RUNNING→INTERRUPTED; _transition_to_terminal expanded to accept INTERRUPTED as a valid source status. |
| agentex/src/domain/use_cases/agents_acp_use_case.py | _handle_task_interrupt wired correctly; INTERRUPTED→RUNNING resume in _get_or_create_task is sound; docstring on return type of _handle_task_interrupt is inaccurate (returns RUNNING, not INTERRUPTED). |
| agentex/src/api/routes/tasks.py | New interrupt_task REST endpoint authorized as update (not cancel); delegates to use-case CAS correctly. |
| agentex/src/domain/entities/agents_rpc.py | InterruptTaskParams, InterruptTaskRequestEntity, and ACP_TYPE_TO_ALLOWED_RPC_METHODS all updated consistently; SYNC now permits task/interrupt. |
| agentex/tests/unit/use_cases/test_tasks_use_case.py | Comprehensive tests for interrupt/resume/terminal-from-INTERRUPTED paths; error message match strings updated to reflect new wording. |
| agentex/tests/integration/api/tasks/test_tasks_api.py | Integration tests cover interrupt, default reason, terminal-from-INTERRUPTED, and rejection of interrupt on completed task. |
| agentex/tests/unit/api/test_tasks_authz.py | Authorization tests confirm interrupt maps to update (not cancel) for both task_id and task_name resolution paths, and SYNC/ASYNC/AGENTIC allowlists. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Client / UI
    participant TasksRoute as REST /tasks/{id}/interrupt
    participant AgentsRoute as RPC task/interrupt
    participant UseCase as TasksUseCase
    participant ACPUseCase as AgentsACPUseCase
    participant TaskSvc as AgentTaskService
    participant DB as Task Repository
    participant Agent as Agent Pod

    note over UI,Agent: Path A — REST endpoint (direct status write)
    UI->>TasksRoute: "POST /tasks/{id}/interrupt"
    TasksRoute->>UseCase: interrupt_task(id, reason)
    UseCase->>DB: CAS RUNNING → INTERRUPTED
    DB-->>UseCase: TaskEntity (INTERRUPTED)
    TasksRoute-->>UI: "200 OK — Task{status: INTERRUPTED}"

    note over UI,Agent: Path B — RPC endpoint (agent signal, no status write)
    UI->>AgentsRoute: "POST /agents/{id}/rpc method=task/interrupt"
    AgentsRoute->>ACPUseCase: _handle_task_interrupt
    ACPUseCase->>TaskSvc: interrupt_task(agent, task, url)
    TaskSvc->>Agent: JSON-RPC task/interrupt (best-effort)
    TaskSvc->>DB: get task (no write)
    ACPUseCase-->>UI: "200 OK — Task{status: RUNNING}"

    note over UI,DB: Resume on next turn
    UI->>AgentsRoute: message/send or task/create
    AgentsRoute->>ACPUseCase: _get_or_create_task
    ACPUseCase->>TaskSvc: resume_interrupted_task (CAS INTERRUPTED→RUNNING)
    TaskSvc-->>ACPUseCase: TaskEntity (RUNNING)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Client / UI
    participant TasksRoute as REST /tasks/{id}/interrupt
    participant AgentsRoute as RPC task/interrupt
    participant UseCase as TasksUseCase
    participant ACPUseCase as AgentsACPUseCase
    participant TaskSvc as AgentTaskService
    participant DB as Task Repository
    participant Agent as Agent Pod

    note over UI,Agent: Path A — REST endpoint (direct status write)
    UI->>TasksRoute: "POST /tasks/{id}/interrupt"
    TasksRoute->>UseCase: interrupt_task(id, reason)
    UseCase->>DB: CAS RUNNING → INTERRUPTED
    DB-->>UseCase: TaskEntity (INTERRUPTED)
    TasksRoute-->>UI: "200 OK — Task{status: INTERRUPTED}"

    note over UI,Agent: Path B — RPC endpoint (agent signal, no status write)
    UI->>AgentsRoute: "POST /agents/{id}/rpc method=task/interrupt"
    AgentsRoute->>ACPUseCase: _handle_task_interrupt
    ACPUseCase->>TaskSvc: interrupt_task(agent, task, url)
    TaskSvc->>Agent: JSON-RPC task/interrupt (best-effort)
    TaskSvc->>DB: get task (no write)
    ACPUseCase-->>UI: "200 OK — Task{status: RUNNING}"

    note over UI,DB: Resume on next turn
    UI->>AgentsRoute: message/send or task/create
    AgentsRoute->>ACPUseCase: _get_or_create_task
    ACPUseCase->>TaskSvc: resume_interrupted_task (CAS INTERRUPTED→RUNNING)
    TaskSvc-->>ACPUseCase: TaskEntity (RUNNING)
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["refactor(tasks): make task/interrupt RPC..."](https://github.com/scaleapi/scale-agentex/commit/605066e626fabd5dc95cf4047480e76b788005c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44814841)</sub>

<!-- /greptile_comment -->