### PR TITLE
feat(agentex-ui): accept RSA (RS256) private_key_jwt keys

### DIFF
--- a/agentex-ui/auth.ts
+++ b/agentex-ui/auth.ts
@@ -1,3 +1,4 @@
+import { importJWK, SignJWT, type JWK } from 'jose';
 import NextAuth, { type NextAuthConfig } from 'next-auth';
 import { getToken } from 'next-auth/jwt';
 
@@ -114,54 +115,57 @@ export async function oidcEndSessionEndpoint(): Promise<string | undefined> {
   return typeof endpoint === 'string' && endpoint ? endpoint : undefined;
 }
 
-// ─── private_key_jwt helpers (WebCrypto only — OSS-clean, no deps) ───
-function base64url(bytes: Uint8Array): string {
-  let bin = '';
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
+// ─── private_key_jwt helpers (JOSE) ───
 
-async function importEs256Key(jwk: JsonWebKey): Promise<CryptoKey> {
-  return crypto.subtle.importKey(
-    'jwk',
-    jwk,
-    { name: 'ECDSA', namedCurve: 'P-256' },
-    false,
-    ['sign']
+/**
+ * Derive the JWS alg for a private JWK: respect an explicit `alg`, else EC by curve
+ * (ES256/384/512) and RSA → RS256. Throws on key types we don't sign with.
+ */
+function signingAlgForJwk(jwk: JWK): string {
+  if (jwk.alg) return jwk.alg;
+  if (jwk.kty === 'EC') {
+    const alg = { 'P-256': 'ES256', 'P-384': 'ES384', 'P-521': 'ES512' }[
+      jwk.crv ?? ''
+    ];
+    if (!alg)
+      throw new Error(
+        `Unsupported EC curve for private_key_jwt: ${jwk.crv ?? 'unknown'}`
+      );
+    return alg;
+  }
+  if (jwk.kty === 'RSA') return 'RS256';
+  throw new Error(
+    `Unsupported key type for private_key_jwt: ${jwk.kty ?? 'unknown'} (expected EC or RSA)`
   );
 }
 
-/** Sign an RFC 7523 client_assertion for the private_key_jwt refresh call. */
+/** Import a private JWK as a signing key. Supports EC (ES256/384/512) and RSA (RS256/384/512/PS*). */
+async function importClientPrivateKey(jwk: JWK): Promise<CryptoKey> {
+  return (await importJWK(jwk, signingAlgForJwk(jwk))) as CryptoKey;
+}
+
+/** Sign an RFC 7523 client_assertion for the private_key_jwt refresh call (alg derived from key). */
 async function signClientAssertion(
   clientId: string,
   tokenEndpoint: string,
   jwkJson: string
 ): Promise<string> {
-  const jwk = JSON.parse(jwkJson) as JsonWebKey & { kid?: string };
-  const key = await importEs256Key(jwk);
-  const now = Math.floor(Date.now() / 1000);
-  const header = {
-    alg: 'ES256',
-    typ: 'JWT',
-    ...(jwk.kid ? { kid: jwk.kid } : {}),
-  };
-  const payload = {
-    iss: clientId,
-    sub: clientId,
-    aud: tokenEndpoint,
-    jti: crypto.randomUUID(),
-    iat: now,
-    exp: now + 60,
-  };
-  const enc = (o: unknown) =>
-    base64url(new TextEncoder().encode(JSON.stringify(o)));
-  const input = `${enc(header)}.${enc(payload)}`;
-  const sig = await crypto.subtle.sign(
-    { name: 'ECDSA', hash: 'SHA-256' },
-    key,
-    new TextEncoder().encode(input)
-  );
-  return `${input}.${base64url(new Uint8Array(sig))}`;
+  const jwk = JSON.parse(jwkJson) as JWK;
+  const alg = signingAlgForJwk(jwk);
+  const key = await importJWK(jwk, alg);
+  return new SignJWT({})
+    .setProtectedHeader({
+      alg,
+      typ: 'JWT',
+      ...(jwk.kid ? { kid: jwk.kid } : {}),
+    })
+    .setIssuer(clientId)
+    .setSubject(clientId)
+    .setAudience(tokenEndpoint)
+    .setJti(crypto.randomUUID())
+    .setIssuedAt()
+    .setExpirationTime('60s')
+    .sign(key);
 }
 
 function buildProvider(id: string) {
@@ -176,7 +180,7 @@ function buildProvider(id: string) {
     checks: ['pkce', 'state'] as ('pkce' | 'state')[],
   };
   if (privateKeyJwk && privateKeyJwk.trim().length > 0) {
-    const jwk = JSON.parse(privateKeyJwk) as JsonWebKey & { kid?: string };
+    const jwk = JSON.parse(privateKeyJwk) as JWK;
     return {
       ...base,
       client: { token_endpoint_auth_method: 'private_key_jwt' },
@@ -184,7 +188,7 @@ function buildProvider(id: string) {
       // refresh signer). `key` is a Promise<CryptoKey> resolved before @auth/core reads it.
       token: {
         clientPrivateKey: {
-          key: importEs256Key(jwk) as unknown as CryptoKey,
+          key: importClientPrivateKey(jwk) as unknown as CryptoKey,
           ...(jwk.kid ? { kid: jwk.kid } : {}),
         },
       },

--- a/agentex-ui/package-lock.json
+++ b/agentex-ui/package-lock.json
@@ -27,6 +27,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "framer-motion": "^12.23.24",
+        "jose": "^6.0.0",
         "lucide-react": "^0.525.0",
         "next": "15.5.18",
         "next-auth": "^5.0.0-beta.29",

--- a/agentex-ui/package.json
+++ b/agentex-ui/package.json
@@ -38,6 +38,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.23.24",
+    "jose": "^6.0.0",
     "lucide-react": "^0.525.0",
     "next": "15.5.18",
     "next-auth": "^5.0.0-beta.29",


### PR DESCRIPTION
## Summary

Brings agentex-ui's bespoke `private_key_jwt` signer back on par with `@scale/oneauth-nextjs` and, in the process, replaces the hand-rolled WebCrypto assertion code with **`jose`**. The signer was **ES256/P-256 only**; an app configured with an RSA `OIDC_PRIVATE_KEY_JWK` couldn't sign the client assertion. It now signs with **EC (ES256/384/512)** or **RSA (RS256/384/512, incl. PS\*)**, alg derived from the key.

Purely additive — the ES256 path is behaviorally unchanged.

## What changed

Single file, `agentex-ui/auth.ts` (+ `jose` promoted to a direct dependency):

- **Sign with `jose`** — `importJWK` + `SignJWT` replace `base64url`, `importEs256Key`, `jwsSigningFor`, and the manual JWT assembly (~55 lines → ~10). `jose` validates the JWK against its `alg` and handles every key type natively, so there are no silent-wrong-alg edge cases to guard by hand.
- **`signingAlgForJwk`** derives the alg — explicit JWK `alg`, else EC by curve (ES256/384/512) / RSA → RS256 — for both the login-key import and the refresh assertion. RS384/RS512/PS256 are supported by declaring `alg` on the JWK.
- **`jose`** was already in the tree transitively (it's what `@auth/core` uses); this makes it a direct dep.

Everything else was already at parity (agentex-ui set the original bar): `getSessionToken` BFF, token-stripped session, fail-loud misconfig guards, top-level-await key resolution, OIDC-discovery-driven endpoints.

## Verification

`tsc --noEmit`, `next lint` (0 warnings), Prettier, and `next build` — all clean.

## Test plan

- [ ] Existing EC/P-256 `OIDC_PRIVATE_KEY_JWK` clients still log in and refresh (ES256, unchanged).
- [ ] An **RSA** `OIDC_PRIVATE_KEY_JWK` (registered with `private_key_jwt` + matching public JWK) → login + refresh succeed (RS256 assertion accepted).
- [ ] A JWK with `alg: RS384`/`PS256` → assertion carries that alg.
- [ ] A malformed / unsupported-kty `OIDC_PRIVATE_KEY_JWK` → clear error (jose rejects), not a silent wrong-alg.
- [ ] `client_secret_post` path unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds RSA (`RS256` and family) support to `agentex-ui`'s `private_key_jwt` signer by replacing ~55 lines of hand-rolled WebCrypto JWT assembly with `jose`'s `importJWK` + `SignJWT`. The ES256/P-256 path is preserved exactly; `signingAlgForJwk` adds EC-curve and RSA-key-type detection for the algorithm negotiation.

- **`signingAlgForJwk`** respects an explicit `alg` field in the JWK, falls back to curve-based EC alg (ES256/384/512), or defaults to `RS256` for bare RSA keys (PSS variants require `alg` to be declared on the JWK, which is documented in the PR).
- **`importClientPrivateKey`** and the `SignJWT` flow replace `importEs256Key`, `jwsSigningFor`, and the manual `base64url` header/payload/signature construction — delegate alg validation and signing to `jose` entirely.
- `jose` is promoted from a transitive dependency (via `@auth/core`) to a direct one at `^6.0.0`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive, the EC/ES256 path is behaviorally unchanged, and the new RSA path delegates all alg validation to jose rather than adding bespoke string-matching that could be wrong.

The replaced code was simple enough that the rewrite is easy to audit line-by-line. signingAlgForJwk correctly checks jwk.alg first, EC curve second, and RSA last. The SignJWT builder covers iss/sub/aud/jti/iat/exp identically to the old manual assembly. No logic regressions visible.

No files require special attention — both changed files are straightforward.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex-ui/auth.ts | Replaces hand-rolled WebCrypto signer with jose's importJWK + SignJWT; adds signingAlgForJwk for EC/RSA alg detection; otherwise unchanged auth flow. |
| agentex-ui/package.json | Adds jose ^6.0.0 as a direct dependency; it was already present transitively via @auth/core. |

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(agentex-ui): accept EC/RSA private\_..."](https://github.com/scaleapi/scale-agentex/commit/523e62ef40c6a2e282cc7a7042332847d387edff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44929291)</sub>

<!-- /greptile_comment -->