### PR TITLE
fix(schedules): include timezone data in backend image

### DIFF
--- a/agentex/pyproject.toml
+++ b/agentex/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "opentelemetry-sdk>=1.28.0",
     "opentelemetry-exporter-otlp>=1.28.0",
     "pyyaml>=6.0,<7",
+    "tzdata>=2025.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -82,6 +82,7 @@ dependencies = [
     { name = "redis", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "sqlalchemy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "temporalio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tzdata", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "uvicorn", extra = ["standard"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "websockets", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
@@ -133,6 +134,7 @@ requires-dist = [
     { name = "redis", specifier = ">=5.1.0,<6" },
     { name = "sqlalchemy", specifier = ">=2.0.35,<3" },
     { name = "temporalio", specifier = ">=1.18.0,<2" },
+    { name = "tzdata", specifier = ">=2025.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.35.0,<0.36" },
     { name = "websockets", specifier = "~=14.2" },
 ]


### PR DESCRIPTION
## Problem

Named schedule timezones rely on Python's `zoneinfo` module. The slim production backend image contains neither system timezone files nor the Python `tzdata` package, so resolving values such as `America/New_York` raises `ZoneInfoNotFoundError`.

This makes live schedule enrichment unavailable and prevents timezone-aware skip operations, while local development continues to work because the host provides timezone data.

## Solution

Add `tzdata` as a direct backend runtime dependency so Python can resolve IANA timezone names consistently in slim production containers.

## Test plan

- [x] `uv lock --check`
- [x] Named-timezone Temporal schedule unit tests (7 passed)
- [x] Build the production Docker target
- [x] Run `ZoneInfo("America/New_York")` successfully inside the built production image

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `ZoneInfoNotFoundError` in slim production Docker images by adding `tzdata` as an explicit Python runtime dependency, ensuring Python's `zoneinfo` module can resolve IANA timezone names (e.g. `America/New_York`) without relying on host system timezone files.

- **`agentex/pyproject.toml`**: Adds `tzdata>=2025.2` to the `dependencies` list — the standard fix for slim containers that lack `/usr/share/zoneinfo`.
- **`uv.lock`**: Pins `tzdata 2025.2` with verified hashes for the sdist and pure-Python wheel; the `sys_platform` marker (darwin/linux) is consistent with all other backend dependencies.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-line dependency addition with a verified lock file entry and no logic changes.

The change is a single dependency addition (`tzdata>=2025.2`) that directly addresses the described `ZoneInfoNotFoundError` in slim containers. The lock file is consistent, hashes are present, the platform marker matches the rest of the project, and no application logic was touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/pyproject.toml | Adds `tzdata>=2025.2` as a direct runtime dependency so Python's `zoneinfo` module can resolve IANA timezone names in slim production containers that lack system timezone files. |
| uv.lock | Lock file updated to pin `tzdata 2025.2` with hashes for both the sdist and pure-Python wheel; dependency marker correctly restricts installation to `darwin` or `linux`, consistent with all other backend dependencies. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Backend App
    participant ZI as zoneinfo (stdlib)
    participant TZD as tzdata (PyPI package)
    participant SYS as System /usr/share/zoneinfo

    App->>ZI: ZoneInfo("America/New_York")
    ZI->>SYS: Look up timezone file
    alt Slim container (no system tz files)
        SYS-->>ZI: Not found
        ZI->>TZD: Fall back to tzdata package
        TZD-->>ZI: Timezone data found ✓
        ZI-->>App: ZoneInfo object returned
    else Full OS / dev machine
        SYS-->>ZI: Timezone data found ✓
        ZI-->>App: ZoneInfo object returned
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Backend App
    participant ZI as zoneinfo (stdlib)
    participant TZD as tzdata (PyPI package)
    participant SYS as System /usr/share/zoneinfo

    App->>ZI: ZoneInfo("America/New_York")
    ZI->>SYS: Look up timezone file
    alt Slim container (no system tz files)
        SYS-->>ZI: Not found
        ZI->>TZD: Fall back to tzdata package
        TZD-->>ZI: Timezone data found ✓
        ZI-->>App: ZoneInfo object returned
    else Full OS / dev machine
        SYS-->>ZI: Timezone data found ✓
        ZI-->>App: ZoneInfo object returned
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(schedules): include timezone data in..."](https://github.com/scaleapi/scale-agentex/commit/72caf96a770b8bf4689a8761e775e86de0cc0b15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46158905)</sub>

<!-- /greptile_comment -->