### PR TITLE
feat(agentex): materialized Task.current_state for reactive state observability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ Use the escape hatch for "this needs a maintenance window with traffic shifted a
 
 ##### Anti-pattern → linter rule reference
 
-The migration linter at `agentex/scripts/lint_migrations.py` enforces these rules at PR time via `.github/workflows/migration-lint.yml`. It only checks files changed vs the PR base, so existing migrations are not retro-flagged. The mapping below is what the linter catches:
+The migration linter at `agentex/scripts/ci_tools/migration_lint.py` enforces these rules at PR time via `.github/workflows/migration-lint.yml`. It only checks files changed vs the PR base, so existing migrations are not retro-flagged. The mapping below is what the linter catches:
 
 | Anti-pattern | Linter rule |
 |---|---|
@@ -371,7 +371,7 @@ The migration linter at `agentex/scripts/lint_migrations.py` enforces these rule
 Run the linter locally before pushing:
 
 ```bash
-agentex/scripts/lint_migrations.py --base-ref origin/main
+agentex/scripts/ci_tools/migration_lint.py --base origin/main
 ```
 
 ##### Other rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,7 +380,7 @@ Use the escape hatch for "this needs a maintenance window with traffic shifted a
 
 ##### Anti-pattern → linter rule reference
 
-The migration linter at `agentex/scripts/ci_tools/migration_lint.py` enforces these rules at PR time via `.github/workflows/migration-lint.yml`. It only checks files changed vs the PR base, so existing migrations are not retro-flagged. The mapping below is what the linter catches:
+The migration linter at `agentex/scripts/lint_migrations.py` enforces these rules at PR time via `.github/workflows/migration-lint.yml`. It only checks files changed vs the PR base, so existing migrations are not retro-flagged. The mapping below is what the linter catches:
 
 | Anti-pattern | Linter rule |
 |---|---|
@@ -393,7 +393,7 @@ The migration linter at `agentex/scripts/ci_tools/migration_lint.py` enforces th
 Run the linter locally before pushing:
 
 ```bash
-agentex/scripts/ci_tools/migration_lint.py --base origin/main
+agentex/scripts/lint_migrations.py --base-ref origin/main
 ```
 
 ##### Other rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,7 +380,7 @@ Use the escape hatch for "this needs a maintenance window with traffic shifted a
 
 ##### Anti-pattern → linter rule reference
 
-The migration linter at `agentex/scripts/lint_migrations.py` enforces these rules at PR time via `.github/workflows/migration-lint.yml`. It only checks files changed vs the PR base, so existing migrations are not retro-flagged. The mapping below is what the linter catches:
+The migration linter at `agentex/scripts/ci_tools/migration_lint.py` enforces these rules at PR time via `.github/workflows/migration-lint.yml`. It only checks files changed vs the PR base, so existing migrations are not retro-flagged. The mapping below is what the linter catches:
 
 | Anti-pattern | Linter rule |
 |---|---|
@@ -393,7 +393,7 @@ The migration linter at `agentex/scripts/lint_migrations.py` enforces these rule
 Run the linter locally before pushing:
 
 ```bash
-agentex/scripts/lint_migrations.py --base-ref origin/main
+agentex/scripts/ci_tools/migration_lint.py --base origin/main
 ```
 
 ##### Other rules

--- a/agentex/database/migrations/alembic/versions/2026_07_22_1200_add_task_current_state_b2c3d4e5f6a7.py
+++ b/agentex/database/migrations/alembic/versions/2026_07_22_1200_add_task_current_state_b2c3d4e5f6a7.py
@@ -18,10 +18,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Opaque label mirroring an agent's StateMachine current state. Nullable and
-    # additive; agents opt in by emitting it. Metadata-only add, non-blocking.
-    # Idempotent (IF NOT EXISTS) so re-running on an environment that already has
-    # the column is a no-op. Width matches TaskORM.current_state (String(255)).
+    # Nullable additive column; idempotent, metadata-only, non-blocking.
     op.execute(
         "ALTER TABLE tasks ADD COLUMN IF NOT EXISTS current_state VARCHAR(255)"
     )

--- a/agentex/database/migrations/alembic/versions/2026_07_22_1200_add_task_current_state_b2c3d4e5f6a7.py
+++ b/agentex/database/migrations/alembic/versions/2026_07_22_1200_add_task_current_state_b2c3d4e5f6a7.py
@@ -21,8 +21,12 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     # Opaque label mirroring an agent's StateMachine current state. Nullable and
     # additive; agents opt in by emitting it. Metadata-only add, non-blocking.
-    op.add_column('tasks', sa.Column('current_state', sa.String(), nullable=True))
+    # Idempotent (IF NOT EXISTS) so re-running on an environment that already has
+    # the column is a no-op. Width matches TaskORM.current_state (String(255)).
+    op.execute(
+        "ALTER TABLE tasks ADD COLUMN IF NOT EXISTS current_state VARCHAR(255)"
+    )
 
 
 def downgrade() -> None:
-    op.drop_column('tasks', 'current_state')
+    op.execute("ALTER TABLE tasks DROP COLUMN IF EXISTS current_state")

--- a/agentex/database/migrations/alembic/versions/2026_07_22_1200_add_task_current_state_b2c3d4e5f6a7.py
+++ b/agentex/database/migrations/alembic/versions/2026_07_22_1200_add_task_current_state_b2c3d4e5f6a7.py
@@ -8,7 +8,6 @@ Create Date: 2026-07-22 12:00:00.000000
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/agentex/database/migrations/alembic/versions/2026_07_22_1200_add_task_current_state_b2c3d4e5f6a7.py
+++ b/agentex/database/migrations/alembic/versions/2026_07_22_1200_add_task_current_state_b2c3d4e5f6a7.py
@@ -1,0 +1,28 @@
+"""add task current_state
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-07-22 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b2c3d4e5f6a7'
+down_revision: Union[str, None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Opaque label mirroring an agent's StateMachine current state. Nullable and
+    # additive; agents opt in by emitting it. Metadata-only add, non-blocking.
+    op.add_column('tasks', sa.Column('current_state', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('tasks', 'current_state')

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6591,6 +6591,7 @@ components:
         current_state:
           anyOf:
           - type: string
+            maxLength: 255
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.
@@ -6820,6 +6821,7 @@ components:
         current_state:
           anyOf:
           - type: string
+            maxLength: 255
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.
@@ -7411,8 +7413,10 @@ components:
         current_state:
           anyOf:
           - type: string
+            maxLength: 255
           - type: 'null'
-          title: If provided, replaces the task's current_state label.
+          title: If provided, replaces the task's current_state label; pass null to
+            clear it, omit to leave it unchanged.
       type: object
       title: UpdateTaskRequest
     ValidationError:

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6588,6 +6588,12 @@ components:
             type: object
           - type: 'null'
           title: Task metadata
+        current_state:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Opaque label mirroring the agent's StateMachine current state; null
+            when the agent does not emit one. Orthogonal to 'status'.
       type: object
       required:
       - id
@@ -6811,6 +6817,12 @@ components:
             type: object
           - type: 'null'
           title: Task metadata
+        current_state:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Opaque label mirroring the agent's StateMachine current state; null
+            when the agent does not emit one. Orthogonal to 'status'.
         agents:
           anyOf:
           - items:
@@ -7396,6 +7408,11 @@ components:
           - type: 'null'
           title: Optional shallow-merge patch applied to the task's params column.
             Top-level keys overwrite; pass full nested objects to change subfields.
+        current_state:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: If provided, replaces the task's current_state label.
       type: object
       title: UpdateTaskRequest
     ValidationError:

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6591,7 +6591,6 @@ components:
         current_state:
           anyOf:
           - type: string
-            maxLength: 255
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.
@@ -6821,7 +6820,6 @@ components:
         current_state:
           anyOf:
           - type: string
-            maxLength: 255
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6632,8 +6632,10 @@ components:
           anyOf:
           - type: string
           - type: 'null'
-          title: Opaque label mirroring the agent's StateMachine current state; null
-            when the agent does not emit one. Orthogonal to 'status'.
+          title: 'Opaque label mirroring the agent''s StateMachine current state;
+            null when the agent does not emit one. Orthogonal to ''status''. States
+            the SDK emits today: IDLE, WORKING, AWAITING_INPUT. Treat any other value
+            as unknown rather than assuming this set is closed.'
         params:
           anyOf:
           - additionalProperties: true
@@ -6861,8 +6863,10 @@ components:
           anyOf:
           - type: string
           - type: 'null'
-          title: Opaque label mirroring the agent's StateMachine current state; null
-            when the agent does not emit one. Orthogonal to 'status'.
+          title: 'Opaque label mirroring the agent''s StateMachine current state;
+            null when the agent does not emit one. Orthogonal to ''status''. States
+            the SDK emits today: IDLE, WORKING, AWAITING_INPUT. Treat any other value
+            as unknown rather than assuming this set is closed.'
         params:
           anyOf:
           - additionalProperties: true
@@ -6952,8 +6956,10 @@ components:
           anyOf:
           - type: string
           - type: 'null'
-          title: Opaque label mirroring the agent's StateMachine current state; null
-            when the agent does not emit one. Orthogonal to 'status'.
+          title: 'Opaque label mirroring the agent''s StateMachine current state;
+            null when the agent does not emit one. Orthogonal to ''status''. States
+            the SDK emits today: IDLE, WORKING, AWAITING_INPUT. Treat any other value
+            as unknown rather than assuming this set is closed.'
         agents:
           anyOf:
           - items:
@@ -7527,7 +7533,9 @@ components:
           - type: string
             maxLength: 255
           - type: 'null'
-          title: If provided, replaces the task's current_state label.
+          title: If provided, replaces the task's current_state label. Omit to leave
+            it untouched; send "" to clear it back to null (how an operator recovers
+            a task whose agent died mid-state).
       type: object
       title: UpdateTaskRequest
     ValidationError:

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6948,6 +6948,12 @@ components:
             type: object
           - type: 'null'
           title: Task metadata
+        current_state:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Opaque label mirroring the agent's StateMachine current state; null
+            when the agent does not emit one. Orthogonal to 'status'.
         agents:
           anyOf:
           - items:
@@ -7521,8 +7527,7 @@ components:
           - type: string
             maxLength: 255
           - type: 'null'
-          title: If provided, replaces the task's current_state label; pass null to
-            clear it, omit to leave it unchanged.
+          title: If provided, replaces the task's current_state label.
       type: object
       title: UpdateTaskRequest
     ValidationError:

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6637,7 +6637,6 @@ components:
         current_state:
           anyOf:
           - type: string
-            maxLength: 255
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.
@@ -6867,7 +6866,6 @@ components:
         current_state:
           anyOf:
           - type: string
-            maxLength: 255
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6634,6 +6634,12 @@ components:
             type: object
           - type: 'null'
           title: Task metadata
+        current_state:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Opaque label mirroring the agent's StateMachine current state; null
+            when the agent does not emit one. Orthogonal to 'status'.
       type: object
       required:
       - id
@@ -6857,6 +6863,12 @@ components:
             type: object
           - type: 'null'
           title: Task metadata
+        current_state:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Opaque label mirroring the agent's StateMachine current state; null
+            when the agent does not emit one. Orthogonal to 'status'.
         agents:
           anyOf:
           - items:
@@ -7504,6 +7516,11 @@ components:
           - type: 'null'
           title: Optional shallow-merge patch applied to the task's params column.
             Top-level keys overwrite; pass full nested objects to change subfields.
+        current_state:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: If provided, replaces the task's current_state label.
       type: object
       title: UpdateTaskRequest
     ValidationError:

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6622,12 +6622,6 @@ components:
           - type: 'null'
           title: The timestamp when the task's content was cleaned for retention compliance;
             null when active
-        params:
-          anyOf:
-          - additionalProperties: true
-            type: object
-          - type: 'null'
-          title: Task parameters
         task_metadata:
           anyOf:
           - additionalProperties: true
@@ -6640,6 +6634,12 @@ components:
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.
+        params:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Task parameters
       type: object
       required:
       - id
@@ -6851,12 +6851,6 @@ components:
           - type: 'null'
           title: The timestamp when the task's content was cleaned for retention compliance;
             null when active
-        params:
-          anyOf:
-          - additionalProperties: true
-            type: object
-          - type: 'null'
-          title: Task parameters
         task_metadata:
           anyOf:
           - additionalProperties: true
@@ -6869,6 +6863,12 @@ components:
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.
+        params:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Task parameters
         agents:
           anyOf:
           - items:

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6637,6 +6637,7 @@ components:
         current_state:
           anyOf:
           - type: string
+            maxLength: 255
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.
@@ -6866,6 +6867,7 @@ components:
         current_state:
           anyOf:
           - type: string
+            maxLength: 255
           - type: 'null'
           title: Opaque label mirroring the agent's StateMachine current state; null
             when the agent does not emit one. Orthogonal to 'status'.
@@ -7519,8 +7521,10 @@ components:
         current_state:
           anyOf:
           - type: string
+            maxLength: 255
           - type: 'null'
-          title: If provided, replaces the task's current_state label.
+          title: If provided, replaces the task's current_state label; pass null to
+            clear it, omit to leave it unchanged.
       type: object
       title: UpdateTaskRequest
     ValidationError:

--- a/agentex/src/adapters/orm.py
+++ b/agentex/src/adapters/orm.py
@@ -75,11 +75,7 @@ class TaskORM(BaseORM):
     cleaned_at = Column(DateTime(timezone=True), nullable=True)
     params = Column(JSONB, nullable=True)
     task_metadata = Column(JSONB, nullable=True)
-    # Opaque, framework-agnostic label mirroring an agent's StateMachine current
-    # state. Written best-effort by the agent on each transition; reconciled on
-    # read. Orthogonal to `status` (Temporal workflow lifecycle). Bounded: a
-    # state label is short, and the value is echoed onto every task_updated SSE
-    # payload, so we cap it to avoid unbounded stream amplification.
+    # Opaque agent-state label, orthogonal to `status`; capped since it rides every task_updated SSE payload.
     current_state = Column(String(255), nullable=True)
     # Many-to-Many relationship with agents
     agents = relationship("AgentORM", secondary="task_agents", back_populates="tasks")

--- a/agentex/src/adapters/orm.py
+++ b/agentex/src/adapters/orm.py
@@ -75,6 +75,10 @@ class TaskORM(BaseORM):
     cleaned_at = Column(DateTime(timezone=True), nullable=True)
     params = Column(JSONB, nullable=True)
     task_metadata = Column(JSONB, nullable=True)
+    # Opaque, framework-agnostic label mirroring an agent's StateMachine current
+    # state. Written best-effort by the agent on each transition; reconciled on
+    # read. Orthogonal to `status` (Temporal workflow lifecycle).
+    current_state = Column(String, nullable=True)
     # Many-to-Many relationship with agents
     agents = relationship("AgentORM", secondary="task_agents", back_populates="tasks")
 

--- a/agentex/src/adapters/orm.py
+++ b/agentex/src/adapters/orm.py
@@ -77,8 +77,10 @@ class TaskORM(BaseORM):
     task_metadata = Column(JSONB, nullable=True)
     # Opaque, framework-agnostic label mirroring an agent's StateMachine current
     # state. Written best-effort by the agent on each transition; reconciled on
-    # read. Orthogonal to `status` (Temporal workflow lifecycle).
-    current_state = Column(String, nullable=True)
+    # read. Orthogonal to `status` (Temporal workflow lifecycle). Bounded: a
+    # state label is short, and the value is echoed onto every task_updated SSE
+    # payload, so we cap it to avoid unbounded stream amplification.
+    current_state = Column(String(255), nullable=True)
     # Many-to-Many relationship with agents
     agents = relationship("AgentORM", secondary="task_agents", back_populates="tasks")
 

--- a/agentex/src/adapters/orm.py
+++ b/agentex/src/adapters/orm.py
@@ -24,6 +24,7 @@ from src.domain.entities.agents import AgentInputType, AgentStatus
 from src.domain.entities.deployments import DeploymentStatus
 from src.domain.entities.tasks import TaskStatus
 from src.utils.ids import orm_id
+from src.utils.task_constants import CURRENT_STATE_MAX_LENGTH
 
 BaseORM = declarative_base()
 
@@ -76,7 +77,7 @@ class TaskORM(BaseORM):
     params = Column(JSONB, nullable=True)
     task_metadata = Column(JSONB, nullable=True)
     # Opaque agent-state label, orthogonal to `status`; capped since it rides every task_updated SSE payload.
-    current_state = Column(String(255), nullable=True)
+    current_state = Column(String(CURRENT_STATE_MAX_LENGTH), nullable=True)
     # Many-to-Many relationship with agents
     agents = relationship("AgentORM", secondary="task_agents", back_populates="tasks")
 

--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -196,6 +196,7 @@ async def update_task(
         id=task_id,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
+        current_state=request.current_state,
     )
     return Task.model_validate(updated_task_entity)
 
@@ -217,6 +218,7 @@ async def update_task_by_name(
         name=task_name,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
+        current_state=request.current_state,
     )
     return Task.model_validate(updated_task_entity)
 

--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -196,8 +196,7 @@ async def update_task(
         id=task_id,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        # Pass through only when the client actually sent the key, so an explicit
-        # null clears the label while an omitted field leaves it untouched.
+        # Forward only when the client sent the key: explicit null clears, omitted leaves unchanged.
         current_state=(
             request.current_state
             if "current_state" in request.model_fields_set
@@ -224,8 +223,7 @@ async def update_task_by_name(
         name=task_name,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        # Pass through only when the client actually sent the key, so an explicit
-        # null clears the label while an omitted field leaves it untouched.
+        # Forward only when the client sent the key: explicit null clears, omitted leaves unchanged.
         current_state=(
             request.current_state
             if "current_state" in request.model_fields_set

--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -22,7 +22,7 @@ from src.api.schemas.tasks import (
 from src.domain.entities.tasks import TaskStatus as DomainTaskStatus
 from src.domain.services.authorization_service import DAuthorizationService
 from src.domain.use_cases.streams_use_case import DStreamsUseCase
-from src.domain.use_cases.tasks_use_case import DTaskUseCase
+from src.domain.use_cases.tasks_use_case import UNSET, DTaskUseCase
 from src.utils.authorization_shortcuts import (
     DAuthorizedId,
     DAuthorizedName,
@@ -196,7 +196,13 @@ async def update_task(
         id=task_id,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        current_state=request.current_state,
+        # Pass through only when the client actually sent the key, so an explicit
+        # null clears the label while an omitted field leaves it untouched.
+        current_state=(
+            request.current_state
+            if "current_state" in request.model_fields_set
+            else UNSET
+        ),
     )
     return Task.model_validate(updated_task_entity)
 
@@ -218,7 +224,13 @@ async def update_task_by_name(
         name=task_name,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        current_state=request.current_state,
+        # Pass through only when the client actually sent the key, so an explicit
+        # null clears the label while an omitted field leaves it untouched.
+        current_state=(
+            request.current_state
+            if "current_state" in request.model_fields_set
+            else UNSET
+        ),
     )
     return Task.model_validate(updated_task_entity)
 

--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -200,8 +200,7 @@ async def update_task(
         id=task_id,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        # Pass through only when the client actually sent the key, so an explicit
-        # null clears the label while an omitted field leaves it untouched.
+        # Forward only when the client sent the key: explicit null clears, omitted leaves unchanged.
         current_state=(
             request.current_state
             if "current_state" in request.model_fields_set
@@ -228,8 +227,7 @@ async def update_task_by_name(
         name=task_name,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        # Pass through only when the client actually sent the key, so an explicit
-        # null clears the label while an omitted field leaves it untouched.
+        # Forward only when the client sent the key: explicit null clears, omitted leaves unchanged.
         current_state=(
             request.current_state
             if "current_state" in request.model_fields_set

--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -200,6 +200,7 @@ async def update_task(
         id=task_id,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
+        current_state=request.current_state,
     )
     return Task.model_validate(updated_task_entity)
 
@@ -221,6 +222,7 @@ async def update_task_by_name(
         name=task_name,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
+        current_state=request.current_state,
     )
     return Task.model_validate(updated_task_entity)
 

--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -23,7 +23,7 @@ from src.api.schemas.tasks import (
 from src.domain.entities.tasks import TaskStatus as DomainTaskStatus
 from src.domain.services.authorization_service import DAuthorizationService
 from src.domain.use_cases.streams_use_case import DStreamsUseCase
-from src.domain.use_cases.tasks_use_case import UNSET, DTaskUseCase
+from src.domain.use_cases.tasks_use_case import DTaskUseCase
 from src.utils.authorization_shortcuts import (
     DAuthorizedId,
     DAuthorizedName,
@@ -200,12 +200,7 @@ async def update_task(
         id=task_id,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        # Forward only when the client sent the key: explicit null clears, omitted leaves unchanged.
-        current_state=(
-            request.current_state
-            if "current_state" in request.model_fields_set
-            else UNSET
-        ),
+        current_state=request.current_state,
     )
     return Task.model_validate(updated_task_entity)
 
@@ -227,12 +222,7 @@ async def update_task_by_name(
         name=task_name,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        # Forward only when the client sent the key: explicit null clears, omitted leaves unchanged.
-        current_state=(
-            request.current_state
-            if "current_state" in request.model_fields_set
-            else UNSET
-        ),
+        current_state=request.current_state,
     )
     return Task.model_validate(updated_task_entity)
 

--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -23,7 +23,7 @@ from src.api.schemas.tasks import (
 from src.domain.entities.tasks import TaskStatus as DomainTaskStatus
 from src.domain.services.authorization_service import DAuthorizationService
 from src.domain.use_cases.streams_use_case import DStreamsUseCase
-from src.domain.use_cases.tasks_use_case import DTaskUseCase
+from src.domain.use_cases.tasks_use_case import UNSET, DTaskUseCase
 from src.utils.authorization_shortcuts import (
     DAuthorizedId,
     DAuthorizedName,
@@ -200,7 +200,13 @@ async def update_task(
         id=task_id,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        current_state=request.current_state,
+        # Pass through only when the client actually sent the key, so an explicit
+        # null clears the label while an omitted field leaves it untouched.
+        current_state=(
+            request.current_state
+            if "current_state" in request.model_fields_set
+            else UNSET
+        ),
     )
     return Task.model_validate(updated_task_entity)
 
@@ -222,7 +228,13 @@ async def update_task_by_name(
         name=task_name,
         task_metadata=request.task_metadata,
         merge_params=request.merge_params,
-        current_state=request.current_state,
+        # Pass through only when the client actually sent the key, so an explicit
+        # null clears the label while an omitted field leaves it untouched.
+        current_state=(
+            request.current_state
+            if "current_state" in request.model_fields_set
+            else UNSET
+        ),
     )
     return Task.model_validate(updated_task_entity)
 

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -68,9 +68,11 @@ class Task(BaseModel):
         None,
         title="Task metadata",
     )
+    # No max_length on this response field on purpose: input is already bounded
+    # by UpdateTaskRequest + the String(255) column, and enforcing the bound on
+    # the read path would turn a future column-widening into a 500 on every read.
     current_state: str | None = Field(
         None,
-        max_length=CURRENT_STATE_MAX_LENGTH,
         title=(
             "Opaque label mirroring the agent's StateMachine current state; "
             "null when the agent does not emit one. Orthogonal to 'status'."

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -7,6 +7,11 @@ from pydantic import Field
 from src.api.schemas.agents import Agent
 from src.utils.model_utils import BaseModel
 
+# Upper bound on the opaque `current_state` label. Kept in sync with the
+# `TaskORM.current_state` column width (String(255)); a state label is short and
+# the value rides every task_updated SSE payload, so it is capped.
+CURRENT_STATE_MAX_LENGTH = 255
+
 
 class TaskRelationships(str, Enum):
     """Task relationships that can be loaded"""
@@ -65,6 +70,7 @@ class Task(BaseModel):
     )
     current_state: str | None = Field(
         None,
+        max_length=CURRENT_STATE_MAX_LENGTH,
         title=(
             "Opaque label mirroring the agent's StateMachine current state; "
             "null when the agent does not emit one. Orthogonal to 'status'."
@@ -96,7 +102,11 @@ class UpdateTaskRequest(BaseModel):
     )
     current_state: str | None = Field(
         None,
-        title="If provided, replaces the task's current_state label.",
+        max_length=CURRENT_STATE_MAX_LENGTH,
+        title=(
+            "If provided, replaces the task's current_state label; "
+            "pass null to clear it, omit to leave it unchanged."
+        ),
     )
 
 

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -6,9 +6,7 @@ from pydantic import Field
 
 from src.api.schemas.agents import Agent
 from src.utils.model_utils import BaseModel
-
-# Bound on the current_state label; mirrors the String(255) column width.
-CURRENT_STATE_MAX_LENGTH = 255
+from src.utils.task_constants import CURRENT_STATE_MAX_LENGTH
 
 
 class TaskRelationships(str, Enum):

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -63,6 +63,13 @@ class Task(BaseModel):
         None,
         title="Task metadata",
     )
+    current_state: str | None = Field(
+        None,
+        title=(
+            "Opaque label mirroring the agent's StateMachine current state; "
+            "null when the agent does not emit one. Orthogonal to 'status'."
+        ),
+    )
 
 
 class TaskResponse(Task):
@@ -86,6 +93,10 @@ class UpdateTaskRequest(BaseModel):
             "Top-level keys overwrite; pass full nested objects to change "
             "subfields."
         ),
+    )
+    current_state: str | None = Field(
+        None,
+        title="If provided, replaces the task's current_state label.",
     )
 
 

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -7,9 +7,7 @@ from pydantic import Field
 from src.api.schemas.agents import Agent
 from src.utils.model_utils import BaseModel
 
-# Upper bound on the opaque `current_state` label. Kept in sync with the
-# `TaskORM.current_state` column width (String(255)); a state label is short and
-# the value rides every task_updated SSE payload, so it is capped.
+# Bound on the current_state label; mirrors the String(255) column width.
 CURRENT_STATE_MAX_LENGTH = 255
 
 
@@ -68,9 +66,7 @@ class Task(BaseModel):
         None,
         title="Task metadata",
     )
-    # No max_length on this response field on purpose: input is already bounded
-    # by UpdateTaskRequest + the String(255) column, and enforcing the bound on
-    # the read path would turn a future column-widening into a 500 on every read.
+    # No bound on the read path: enforcing it would 500 if the column is ever widened (writes are already bounded).
     current_state: str | None = Field(
         None,
         title=(

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -120,6 +120,13 @@ class TaskSummary(BaseModel):
         None,
         title="Task metadata",
     )
+    current_state: str | None = Field(
+        None,
+        title=(
+            "Opaque label mirroring the agent's StateMachine current state; "
+            "null when the agent does not emit one. Orthogonal to 'status'."
+        ),
+    )
     agents: list["Agent"] | None = Field(
         default=None,
         title="Agents associated with this task (only populated when 'agents' view is requested)",
@@ -142,10 +149,7 @@ class UpdateTaskRequest(BaseModel):
     current_state: str | None = Field(
         None,
         max_length=CURRENT_STATE_MAX_LENGTH,
-        title=(
-            "If provided, replaces the task's current_state label; "
-            "pass null to clear it, omit to leave it unchanged."
-        ),
+        title="If provided, replaces the task's current_state label.",
     )
 
 

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -63,6 +63,13 @@ class Task(BaseModel):
         None,
         title="Task metadata",
     )
+    current_state: str | None = Field(
+        None,
+        title=(
+            "Opaque label mirroring the agent's StateMachine current state; "
+            "null when the agent does not emit one. Orthogonal to 'status'."
+        ),
+    )
 
 
 class TaskResponse(Task):
@@ -129,6 +136,10 @@ class UpdateTaskRequest(BaseModel):
             "Top-level keys overwrite; pass full nested objects to change "
             "subfields."
         ),
+    )
+    current_state: str | None = Field(
+        None,
+        title="If provided, replaces the task's current_state label.",
     )
 
 

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -27,44 +27,21 @@ class TaskStatus(str, Enum):
     DELETED = "DELETED"
 
 
-class Task(BaseModel):
-    id: str = Field(
-        ...,
-        title="Unique Task ID",
-    )
-    name: str | None = Field(
-        None,
-        title="Unique name of the task",
-    )
-    status: TaskStatus | None = Field(
-        None,
-        title="The current status of the task",
-    )
-    status_reason: str | None = Field(
-        None,
-        title="The reason for the current task status",
-    )
-    created_at: datetime | None = Field(
-        None,
-        title="The timestamp when the task was created",
-    )
-    updated_at: datetime | None = Field(
-        None,
-        title="The timestamp when the task was last updated",
-    )
+class _TaskBase(BaseModel):
+    """Shared fields for Task and TaskSummary (everything except `params`)."""
+
+    id: str = Field(..., title="Unique Task ID")
+    name: str | None = Field(None, title="Unique name of the task")
+    status: TaskStatus | None = Field(None, title="The current status of the task")
+    status_reason: str | None = Field(None, title="The reason for the current task status")
+    created_at: datetime | None = Field(None, title="The timestamp when the task was created")
+    updated_at: datetime | None = Field(None, title="The timestamp when the task was last updated")
     cleaned_at: datetime | None = Field(
         None,
         title="The timestamp when the task's content was cleaned for retention compliance; null when active",
     )
-    params: dict[str, Any] | None = Field(
-        None,
-        title="Task parameters",
-    )
-    task_metadata: dict[str, Any] | None = Field(
-        None,
-        title="Task metadata",
-    )
-    # No bound on the read path: enforcing it would 500 if the column is ever widened (writes are already bounded).
+    task_metadata: dict[str, Any] | None = Field(None, title="Task metadata")
+    # Writes are bounded; reads are not, so widening the column won't 500.
     current_state: str | None = Field(
         None,
         title=(
@@ -72,6 +49,10 @@ class Task(BaseModel):
             "null when the agent does not emit one. Orthogonal to 'status'."
         ),
     )
+
+
+class Task(_TaskBase):
+    params: dict[str, Any] | None = Field(None, title="Task parameters")
 
 
 class TaskResponse(Task):
@@ -83,50 +64,11 @@ class TaskResponse(Task):
     )
 
 
-class TaskSummary(BaseModel):
+class TaskSummary(_TaskBase):
     """Lean list-response shape. Omits `params` (the arbitrary create-time
     payload, which can carry per-caller secrets and PII); fetch GET /tasks/{id}
     for the full record."""
 
-    id: str = Field(
-        ...,
-        title="Unique Task ID",
-    )
-    name: str | None = Field(
-        None,
-        title="Unique name of the task",
-    )
-    status: TaskStatus | None = Field(
-        None,
-        title="The current status of the task",
-    )
-    status_reason: str | None = Field(
-        None,
-        title="The reason for the current task status",
-    )
-    created_at: datetime | None = Field(
-        None,
-        title="The timestamp when the task was created",
-    )
-    updated_at: datetime | None = Field(
-        None,
-        title="The timestamp when the task was last updated",
-    )
-    cleaned_at: datetime | None = Field(
-        None,
-        title="The timestamp when the task's content was cleaned for retention compliance; null when active",
-    )
-    task_metadata: dict[str, Any] | None = Field(
-        None,
-        title="Task metadata",
-    )
-    current_state: str | None = Field(
-        None,
-        title=(
-            "Opaque label mirroring the agent's StateMachine current state; "
-            "null when the agent does not emit one. Orthogonal to 'status'."
-        ),
-    )
     agents: list["Agent"] | None = Field(
         default=None,
         title="Agents associated with this task (only populated when 'agents' view is requested)",

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -6,7 +6,7 @@ from pydantic import Field
 
 from src.api.schemas.agents import Agent
 from src.utils.model_utils import BaseModel
-from src.utils.task_constants import CURRENT_STATE_MAX_LENGTH
+from src.utils.task_constants import CURRENT_STATE_DESCRIPTION, CURRENT_STATE_MAX_LENGTH
 
 
 class TaskRelationships(str, Enum):
@@ -42,13 +42,7 @@ class _TaskBase(BaseModel):
     )
     task_metadata: dict[str, Any] | None = Field(None, title="Task metadata")
     # Writes are bounded; reads are not, so widening the column won't 500.
-    current_state: str | None = Field(
-        None,
-        title=(
-            "Opaque label mirroring the agent's StateMachine current state; "
-            "null when the agent does not emit one. Orthogonal to 'status'."
-        ),
-    )
+    current_state: str | None = Field(None, title=CURRENT_STATE_DESCRIPTION)
 
 
 class Task(_TaskBase):
@@ -91,7 +85,11 @@ class UpdateTaskRequest(BaseModel):
     current_state: str | None = Field(
         None,
         max_length=CURRENT_STATE_MAX_LENGTH,
-        title="If provided, replaces the task's current_state label.",
+        title=(
+            "If provided, replaces the task's current_state label. Omit to leave it "
+            'untouched; send "" to clear it back to null (how an operator recovers a '
+            "task whose agent died mid-state)."
+        ),
     )
 
 

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -7,6 +7,11 @@ from pydantic import Field
 from src.api.schemas.agents import Agent
 from src.utils.model_utils import BaseModel
 
+# Upper bound on the opaque `current_state` label. Kept in sync with the
+# `TaskORM.current_state` column width (String(255)); a state label is short and
+# the value rides every task_updated SSE payload, so it is capped.
+CURRENT_STATE_MAX_LENGTH = 255
+
 
 class TaskRelationships(str, Enum):
     """Task relationships that can be loaded"""
@@ -65,6 +70,7 @@ class Task(BaseModel):
     )
     current_state: str | None = Field(
         None,
+        max_length=CURRENT_STATE_MAX_LENGTH,
         title=(
             "Opaque label mirroring the agent's StateMachine current state; "
             "null when the agent does not emit one. Orthogonal to 'status'."
@@ -139,7 +145,11 @@ class UpdateTaskRequest(BaseModel):
     )
     current_state: str | None = Field(
         None,
-        title="If provided, replaces the task's current_state label.",
+        max_length=CURRENT_STATE_MAX_LENGTH,
+        title=(
+            "If provided, replaces the task's current_state label; "
+            "pass null to clear it, omit to leave it unchanged."
+        ),
     )
 
 

--- a/agentex/src/domain/entities/tasks.py
+++ b/agentex/src/domain/entities/tasks.py
@@ -68,7 +68,10 @@ class TaskEntity(BaseModel):
     )
     current_state: str | None = Field(
         None,
-        title="Opaque label mirroring the agent's StateMachine current state",
+        title=(
+            "Opaque label mirroring the agent's StateMachine current state; "
+            "null when the agent does not emit one. Orthogonal to 'status'."
+        ),
     )
 
     # allow extra fields for agents relationships

--- a/agentex/src/domain/entities/tasks.py
+++ b/agentex/src/domain/entities/tasks.py
@@ -66,6 +66,10 @@ class TaskEntity(BaseModel):
         None,
         title="Task metadata",
     )
+    current_state: str | None = Field(
+        None,
+        title="Opaque label mirroring the agent's StateMachine current state",
+    )
 
     # allow extra fields for agents relationships
     model_config = ConfigDict(extra="allow")
@@ -84,4 +88,5 @@ def convert_task_to_entity(task: Task) -> TaskEntity:
         cleaned_at=task.cleaned_at,
         params=task.params,
         task_metadata=task.task_metadata,
+        current_state=task.current_state,
     )

--- a/agentex/src/domain/entities/tasks.py
+++ b/agentex/src/domain/entities/tasks.py
@@ -75,7 +75,10 @@ class TaskEntity(BaseModel):
     )
     current_state: str | None = Field(
         None,
-        title="Opaque label mirroring the agent's StateMachine current state",
+        title=(
+            "Opaque label mirroring the agent's StateMachine current state; "
+            "null when the agent does not emit one. Orthogonal to 'status'."
+        ),
     )
 
     # allow extra fields for agents relationships

--- a/agentex/src/domain/entities/tasks.py
+++ b/agentex/src/domain/entities/tasks.py
@@ -6,6 +6,7 @@ from pydantic import ConfigDict, Field
 
 from src.api.schemas.tasks import Task
 from src.utils.model_utils import BaseModel
+from src.utils.task_constants import CURRENT_STATE_DESCRIPTION
 
 
 class TaskRelationships(str, Enum):
@@ -73,13 +74,7 @@ class TaskEntity(BaseModel):
         None,
         title="Task metadata",
     )
-    current_state: str | None = Field(
-        None,
-        title=(
-            "Opaque label mirroring the agent's StateMachine current state; "
-            "null when the agent does not emit one. Orthogonal to 'status'."
-        ),
-    )
+    current_state: str | None = Field(None, title=CURRENT_STATE_DESCRIPTION)
 
     # allow extra fields for agents relationships
     model_config = ConfigDict(extra="allow")

--- a/agentex/src/domain/entities/tasks.py
+++ b/agentex/src/domain/entities/tasks.py
@@ -87,16 +87,4 @@ class TaskEntity(BaseModel):
 
 def convert_task_to_entity(task: Task) -> TaskEntity:
     """Converts the pydantic model from the API layer to the domain layer"""
-
-    return TaskEntity(
-        id=task.id,
-        name=task.name,
-        status=TaskStatus[task.status.value] if task.status is not None else None,
-        status_reason=task.status_reason,
-        created_at=task.created_at,
-        updated_at=task.updated_at,
-        cleaned_at=task.cleaned_at,
-        params=task.params,
-        task_metadata=task.task_metadata,
-        current_state=task.current_state,
-    )
+    return TaskEntity.model_validate(task)

--- a/agentex/src/domain/entities/tasks.py
+++ b/agentex/src/domain/entities/tasks.py
@@ -73,6 +73,10 @@ class TaskEntity(BaseModel):
         None,
         title="Task metadata",
     )
+    current_state: str | None = Field(
+        None,
+        title="Opaque label mirroring the agent's StateMachine current state",
+    )
 
     # allow extra fields for agents relationships
     model_config = ConfigDict(extra="allow")
@@ -91,4 +95,5 @@ def convert_task_to_entity(task: Task) -> TaskEntity:
         cleaned_at=task.cleaned_at,
         params=task.params,
         task_metadata=task.task_metadata,
+        current_state=task.current_state,
     )

--- a/agentex/src/domain/repositories/task_repository.py
+++ b/agentex/src/domain/repositories/task_repository.py
@@ -264,11 +264,15 @@ class TaskRepository(PostgresCRUDRepository[TaskORM, TaskEntity, TaskRelationshi
         changed ``status``/``params``), this issues a single
         ``UPDATE ... SET <only these columns> WHERE id = :id RETURNING *``.
         Touching only the supplied columns means a concurrent status transition
-        or param merge is never reverted. Returns the updated entity, or
-        ``None`` if no task with ``task_id`` exists.
+        or param merge is never reverted. With a non-empty ``fields`` this returns
+        the updated entity, or ``None`` if no task with ``task_id`` exists.
 
         ``fields`` values are applied verbatim, so passing ``current_state=None``
         clears the column (callers distinguish "clear" from "omit" upstream).
+
+        An empty ``fields`` is a defensive no-op that returns the current task
+        (raising ``ItemDoesNotExist`` if absent); the sole caller never reaches it,
+        as it gates the call behind a non-empty field set.
         """
         if not fields:
             return await self.get(id=task_id)

--- a/agentex/src/domain/repositories/task_repository.py
+++ b/agentex/src/domain/repositories/task_repository.py
@@ -21,6 +21,10 @@ from src.utils.logging import make_logger
 
 logger = make_logger(__name__)
 
+# Columns update_mutable_fields is allowed to set — a code guardrail (not a comment)
+# so a future caller can't route status/params through it and bypass their atomic CAS.
+_MUTABLE_TASK_COLUMNS = frozenset({"task_metadata", "current_state"})
+
 
 class TaskRepository(PostgresCRUDRepository[TaskORM, TaskEntity, TaskRelationships]):
     """Repository for Task entity with relationship loading support"""
@@ -231,41 +235,34 @@ class TaskRepository(PostgresCRUDRepository[TaskORM, TaskEntity, TaskRelationshi
         general-purpose updater.
         """
 
-        async with (
-            self.start_async_db_session(True) as session,
-            async_sql_exception_handler(),
-        ):
-            # ``COALESCE(params, '{}'::jsonb)`` so a NULL existing value
-            # doesn't poison the concat to NULL. Both operands cast to
-            # JSONB explicitly so Postgres picks the JSONB ``||`` operator
-            # (not the text concat overload).
-            existing = func.coalesce(TaskORM.params, cast({}, JSONB))
-            merged = existing.op("||", return_type=JSONB)(cast(patch, JSONB))
-            stmt = (
-                update(TaskORM)
-                .where(TaskORM.id == task_id)
-                .values(params=merged)
-                .returning(TaskORM)
-            )
-            result = await session.execute(stmt)
-            row = result.scalar_one_or_none()
-            await session.commit()
-            if row is None:
-                return None
-            return TaskEntity.model_validate(row)
+        # ``COALESCE(params, '{}'::jsonb)`` so a NULL existing value doesn't poison the
+        # concat; explicit JSONB casts so Postgres picks the jsonb ``||`` (not text concat).
+        existing = func.coalesce(TaskORM.params, cast({}, JSONB))
+        merged = existing.op("||", return_type=JSONB)(cast(patch, JSONB))
+        return await self._update_returning(task_id, {"params": merged})
 
     async def update_mutable_fields(
         self, task_id: str, fields: dict[str, Any]
     ) -> TaskEntity | None:
-        """Atomically ``UPDATE ... SET <only the given columns> WHERE id`` — column-scoped,
-        so (unlike ``update``'s whole-row merge) it can't clobber a concurrently changed
-        ``status``/``params``. Values apply verbatim (``current_state=None`` clears). Returns
-        the updated entity, or ``None`` if the task doesn't exist. Empty ``fields`` is an
-        unreachable defensive no-op (the sole caller gates on a non-empty set).
+        """Atomically set the given caller-mutable columns on one task row via
+        ``UPDATE ... RETURNING`` — column-scoped, so (unlike ``update``'s whole-row merge) it
+        can't clobber a concurrently changed ``status``/``params``. Values apply verbatim
+        (``current_state=None`` clears). Returns the updated entity, or ``None`` if absent.
         """
-        if not fields:
-            return await self.get(id=task_id)
+        unknown = fields.keys() - _MUTABLE_TASK_COLUMNS
+        if unknown:
+            raise ValueError(
+                f"update_mutable_fields may only set {sorted(_MUTABLE_TASK_COLUMNS)}; "
+                f"got disallowed columns {sorted(unknown)}"
+            )
+        return await self._update_returning(task_id, fields)
 
+    async def _update_returning(
+        self, task_id: str, values: dict[str, Any]
+    ) -> TaskEntity | None:
+        """``UPDATE tasks SET <values> WHERE id`` → the updated entity, or ``None`` if no
+        such task exists. Shared by merge_params and update_mutable_fields.
+        """
         async with (
             self.start_async_db_session(True) as session,
             async_sql_exception_handler(),
@@ -273,7 +270,7 @@ class TaskRepository(PostgresCRUDRepository[TaskORM, TaskEntity, TaskRelationshi
             stmt = (
                 update(TaskORM)
                 .where(TaskORM.id == task_id)
-                .values(**fields)
+                .values(**values)
                 .returning(TaskORM)
             )
             result = await session.execute(stmt)

--- a/agentex/src/domain/repositories/task_repository.py
+++ b/agentex/src/domain/repositories/task_repository.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from fastapi import Depends
 from sqlalchemy import cast, distinct, func, select, update
@@ -245,6 +245,42 @@ class TaskRepository(PostgresCRUDRepository[TaskORM, TaskEntity, TaskRelationshi
                 update(TaskORM)
                 .where(TaskORM.id == task_id)
                 .values(params=merged)
+                .returning(TaskORM)
+            )
+            result = await session.execute(stmt)
+            row = result.scalar_one_or_none()
+            await session.commit()
+            if row is None:
+                return None
+            return TaskEntity.model_validate(row)
+
+    async def update_mutable_fields(
+        self, task_id: str, fields: dict[str, Any]
+    ) -> TaskEntity | None:
+        """Atomically set only the given scalar columns on a single task row.
+
+        Unlike ``update`` (a whole-row ``session.merge`` of a possibly-stale
+        entity, which rewrites every column and can clobber a concurrently
+        changed ``status``/``params``), this issues a single
+        ``UPDATE ... SET <only these columns> WHERE id = :id RETURNING *``.
+        Touching only the supplied columns means a concurrent status transition
+        or param merge is never reverted. Returns the updated entity, or
+        ``None`` if no task with ``task_id`` exists.
+
+        ``fields`` values are applied verbatim, so passing ``current_state=None``
+        clears the column (callers distinguish "clear" from "omit" upstream).
+        """
+        if not fields:
+            return await self.get(id=task_id)
+
+        async with (
+            self.start_async_db_session(True) as session,
+            async_sql_exception_handler(),
+        ):
+            stmt = (
+                update(TaskORM)
+                .where(TaskORM.id == task_id)
+                .values(**fields)
                 .returning(TaskORM)
             )
             result = await session.execute(stmt)

--- a/agentex/src/domain/repositories/task_repository.py
+++ b/agentex/src/domain/repositories/task_repository.py
@@ -257,22 +257,11 @@ class TaskRepository(PostgresCRUDRepository[TaskORM, TaskEntity, TaskRelationshi
     async def update_mutable_fields(
         self, task_id: str, fields: dict[str, Any]
     ) -> TaskEntity | None:
-        """Atomically set only the given scalar columns on a single task row.
-
-        Unlike ``update`` (a whole-row ``session.merge`` of a possibly-stale
-        entity, which rewrites every column and can clobber a concurrently
-        changed ``status``/``params``), this issues a single
-        ``UPDATE ... SET <only these columns> WHERE id = :id RETURNING *``.
-        Touching only the supplied columns means a concurrent status transition
-        or param merge is never reverted. With a non-empty ``fields`` this returns
-        the updated entity, or ``None`` if no task with ``task_id`` exists.
-
-        ``fields`` values are applied verbatim, so passing ``current_state=None``
-        clears the column (callers distinguish "clear" from "omit" upstream).
-
-        An empty ``fields`` is a defensive no-op that returns the current task
-        (raising ``ItemDoesNotExist`` if absent); the sole caller never reaches it,
-        as it gates the call behind a non-empty field set.
+        """Atomically ``UPDATE ... SET <only the given columns> WHERE id`` — column-scoped,
+        so (unlike ``update``'s whole-row merge) it can't clobber a concurrently changed
+        ``status``/``params``. Values apply verbatim (``current_state=None`` clears). Returns
+        the updated entity, or ``None`` if the task doesn't exist. Empty ``fields`` is an
+        unreachable defensive no-op (the sole caller gates on a non-empty set).
         """
         if not fields:
             return await self.get(id=task_id)

--- a/agentex/src/domain/repositories/task_repository.py
+++ b/agentex/src/domain/repositories/task_repository.py
@@ -243,11 +243,7 @@ class TaskRepository(PostgresCRUDRepository[TaskORM, TaskEntity, TaskRelationshi
     async def update_mutable_fields(
         self, task_id: str, fields: dict[str, Any]
     ) -> TaskEntity | None:
-        """Atomically set the given caller-mutable columns on one task row via
-        ``UPDATE ... RETURNING`` — column-scoped, so (unlike ``update``'s whole-row merge) it
-        can't clobber a concurrently changed ``status``/``params``. Values apply verbatim
-        (``current_state=None`` clears). Returns the updated entity, or ``None`` if absent.
-        """
+        """Column-scoped atomic update; can't clobber status/params. Returns updated entity or None."""
         unknown = fields.keys() - _MUTABLE_TASK_COLUMNS
         if unknown:
             raise ValueError(
@@ -259,9 +255,7 @@ class TaskRepository(PostgresCRUDRepository[TaskORM, TaskEntity, TaskRelationshi
     async def _update_returning(
         self, task_id: str, values: dict[str, Any]
     ) -> TaskEntity | None:
-        """``UPDATE tasks SET <values> WHERE id`` → the updated entity, or ``None`` if no
-        such task exists. Shared by merge_params and update_mutable_fields.
-        """
+        """UPDATE … SET … WHERE id → updated entity or None. Shared by merge_params and update_mutable_fields."""
         async with (
             self.start_async_db_session(True) as session,
             async_sql_exception_handler(),

--- a/agentex/src/domain/repositories/task_repository.py
+++ b/agentex/src/domain/repositories/task_repository.py
@@ -21,8 +21,7 @@ from src.utils.logging import make_logger
 
 logger = make_logger(__name__)
 
-# Columns update_mutable_fields is allowed to set — a code guardrail (not a comment)
-# so a future caller can't route status/params through it and bypass their atomic CAS.
+# Columns update_mutable_fields is allowed to set (status/params have their own atomic paths).
 _MUTABLE_TASK_COLUMNS = frozenset({"task_metadata", "current_state"})
 
 

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -242,6 +242,40 @@ class AgentTaskService:
 
         return updated_task
 
+    async def update_mutable_fields(
+        self, task_id: str, fields: dict[str, Any]
+    ) -> TaskEntity | None:
+        """Atomically update only the given scalar columns on a task, then
+        publish a task_updated event.
+
+        Column-scoped (see ``TaskRepository.update_mutable_fields``) so it cannot
+        clobber a concurrently changed ``status``/``params`` — unlike
+        ``update_task``'s whole-row merge, which the status-writing callers
+        (delete/fail/forward) still rely on. Returns the updated entity, or
+        ``None`` if the task no longer exists.
+        """
+        updated_task = await self.task_repository.update_mutable_fields(
+            task_id, fields
+        )
+        if updated_task is None:
+            return None
+
+        try:
+            topic = get_task_event_stream_topic(task_id=task_id)
+            await self.stream_repository.send_data(
+                topic,
+                TaskStreamTaskUpdatedEventEntity(
+                    type="task_updated", task=updated_task
+                ).model_dump(mode="json"),
+            )
+            logger.info(f"task_updated event published to topic: {topic}")
+        except Exception as e:
+            logger.error(
+                f"Error sending task_updated event to stream: {e}", exc_info=True
+            )
+
+        return updated_task
+
     async def merge_task_params(self, task_id: str, patch: dict) -> TaskEntity | None:
         """Atomically shallow-merge ``patch`` into ``tasks.params``. Returns
         the updated entity, or ``None`` if no task with ``task_id`` exists.

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -248,9 +248,7 @@ class AgentTaskService:
         """Column-scoped atomic update of the given columns, then publish task_updated.
         Returns the updated entity, or ``None`` if the task no longer exists.
         """
-        updated_task = await self.task_repository.update_mutable_fields(
-            task_id, fields
-        )
+        updated_task = await self.task_repository.update_mutable_fields(task_id, fields)
         if updated_task is None:
             return None
 
@@ -402,7 +400,11 @@ class AgentTaskService:
             new_status=TaskStatus.CANCELED,
             status_reason="Task canceled by user",
         )
-        return updated if updated is not None else await self.task_repository.get(id=task.id)
+        return (
+            updated
+            if updated is not None
+            else await self.task_repository.get(id=task.id)
+        )
 
     async def interrupt_task(
         self, agent: AgentEntity, task: TaskEntity, acp_url: str

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -245,14 +245,8 @@ class AgentTaskService:
     async def update_mutable_fields(
         self, task_id: str, fields: dict[str, Any]
     ) -> TaskEntity | None:
-        """Atomically update only the given scalar columns on a task, then
-        publish a task_updated event.
-
-        Column-scoped (see ``TaskRepository.update_mutable_fields``) so it cannot
-        clobber a concurrently changed ``status``/``params`` — unlike
-        ``update_task``'s whole-row merge, which the status-writing callers
-        (delete/fail/forward) still rely on. Returns the updated entity, or
-        ``None`` if the task no longer exists.
+        """Column-scoped atomic update of the given columns, then publish task_updated.
+        Returns the updated entity, or ``None`` if the task no longer exists.
         """
         updated_task = await self.task_repository.update_mutable_fields(
             task_id, fields

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -250,9 +250,7 @@ class AgentTaskService:
         """Column-scoped atomic update of the given columns, then publish task_updated.
         Returns the updated entity, or ``None`` if the task no longer exists.
         """
-        updated_task = await self.task_repository.update_mutable_fields(
-            task_id, fields
-        )
+        updated_task = await self.task_repository.update_mutable_fields(task_id, fields)
         if updated_task is None:
             return None
 

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -244,6 +244,40 @@ class AgentTaskService:
 
         return updated_task
 
+    async def update_mutable_fields(
+        self, task_id: str, fields: dict[str, Any]
+    ) -> TaskEntity | None:
+        """Atomically update only the given scalar columns on a task, then
+        publish a task_updated event.
+
+        Column-scoped (see ``TaskRepository.update_mutable_fields``) so it cannot
+        clobber a concurrently changed ``status``/``params`` — unlike
+        ``update_task``'s whole-row merge, which the status-writing callers
+        (delete/fail/forward) still rely on. Returns the updated entity, or
+        ``None`` if the task no longer exists.
+        """
+        updated_task = await self.task_repository.update_mutable_fields(
+            task_id, fields
+        )
+        if updated_task is None:
+            return None
+
+        try:
+            topic = get_task_event_stream_topic(task_id=task_id)
+            await self.stream_repository.send_data(
+                topic,
+                TaskStreamTaskUpdatedEventEntity(
+                    type="task_updated", task=updated_task
+                ).model_dump(mode="json"),
+            )
+            logger.info(f"task_updated event published to topic: {topic}")
+        except Exception as e:
+            logger.error(
+                f"Error sending task_updated event to stream: {e}", exc_info=True
+            )
+
+        return updated_task
+
     async def merge_task_params(self, task_id: str, patch: dict) -> TaskEntity | None:
         """Atomically shallow-merge ``patch`` into ``tasks.params``. Returns
         the updated entity, or ``None`` if no task with ``task_id`` exists.

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -222,9 +222,7 @@ class AgentTaskService:
     async def update_mutable_fields(
         self, task_id: str, fields: dict[str, Any]
     ) -> TaskEntity | None:
-        """Column-scoped atomic update of the given columns, then publish task_updated.
-        Returns the updated entity, or ``None`` if the task no longer exists.
-        """
+        """Column-scoped atomic update, then publish task_updated. Returns updated entity or None."""
         updated_task = await self.task_repository.update_mutable_fields(task_id, fields)
         if updated_task is None:
             return None

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -247,14 +247,8 @@ class AgentTaskService:
     async def update_mutable_fields(
         self, task_id: str, fields: dict[str, Any]
     ) -> TaskEntity | None:
-        """Atomically update only the given scalar columns on a task, then
-        publish a task_updated event.
-
-        Column-scoped (see ``TaskRepository.update_mutable_fields``) so it cannot
-        clobber a concurrently changed ``status``/``params`` — unlike
-        ``update_task``'s whole-row merge, which the status-writing callers
-        (delete/fail/forward) still rely on. Returns the updated entity, or
-        ``None`` if the task no longer exists.
+        """Column-scoped atomic update of the given columns, then publish task_updated.
+        Returns the updated entity, or ``None`` if the task no longer exists.
         """
         updated_task = await self.task_repository.update_mutable_fields(
             task_id, fields

--- a/agentex/src/domain/services/task_service.py
+++ b/agentex/src/domain/services/task_service.py
@@ -205,19 +205,7 @@ class AgentTaskService:
         if updated_task is None:
             return None
 
-        try:
-            topic = get_task_event_stream_topic(task_id=task_id)
-            await self.stream_repository.send_data(
-                topic,
-                TaskStreamTaskUpdatedEventEntity(
-                    type="task_updated", task=updated_task
-                ).model_dump(mode="json"),
-            )
-            logger.info(f"task_updated event published to topic: {topic}")
-        except Exception as e:
-            logger.error(
-                f"Error sending task_updated event to stream: {e}", exc_info=True
-            )
+        await self._publish_task_updated(updated_task)
 
         return updated_task
 
@@ -227,20 +215,7 @@ class AgentTaskService:
         """
         updated_task = await self.task_repository.update(task)
 
-        try:
-            # The Redis adapter now handles binary data properly
-            topic = get_task_event_stream_topic(task_id=task.id)
-            await self.stream_repository.send_data(
-                topic,
-                TaskStreamTaskUpdatedEventEntity(
-                    type="task_updated", task=updated_task
-                ).model_dump(mode="json"),
-            )
-            logger.info(f"task_updated event published to topic: {topic}")
-        except Exception as e:
-            logger.error(
-                f"Error sending task_updated event to stream: {e}", exc_info=True
-            )
+        await self._publish_task_updated(updated_task)
 
         return updated_task
 
@@ -254,12 +229,17 @@ class AgentTaskService:
         if updated_task is None:
             return None
 
+        await self._publish_task_updated(updated_task)
+
+        return updated_task
+
+    async def _publish_task_updated(self, task: TaskEntity) -> None:
         try:
-            topic = get_task_event_stream_topic(task_id=task_id)
+            topic = get_task_event_stream_topic(task_id=task.id)
             await self.stream_repository.send_data(
                 topic,
                 TaskStreamTaskUpdatedEventEntity(
-                    type="task_updated", task=updated_task
+                    type="task_updated", task=task
                 ).model_dump(mode="json"),
             )
             logger.info(f"task_updated event published to topic: {topic}")
@@ -267,8 +247,6 @@ class AgentTaskService:
             logger.error(
                 f"Error sending task_updated event to stream: {e}", exc_info=True
             )
-
-        return updated_task
 
     async def merge_task_params(self, task_id: str, patch: dict) -> TaskEntity | None:
         """Atomically shallow-merge ``patch`` into ``tasks.params``. Returns

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -12,9 +12,7 @@ logger = make_logger(__name__)
 
 
 class _Unset:
-    """Sentinel distinguishing "field omitted" from "field explicitly set to null"
-    in a PATCH-style update, so an explicit null can clear a column while an
-    omitted field is left untouched."""
+    """Sentinel: PATCH field omitted (untouched) vs. explicitly null (cleared)."""
 
 
 UNSET: Any = _Unset()
@@ -106,11 +104,8 @@ class TasksUseCase:
         merge_params: dict[str, Any] | None = None,
         current_state: str | None | _Unset = UNSET,
     ) -> TaskEntity:
-        """Update mutable fields on a task entity. This is used by our API since not all fields should be mutable.
-
-        ``current_state`` uses the UNSET sentinel so an explicit null clears the
-        column while an omitted field leaves it untouched. ``task_metadata`` keeps
-        its legacy semantics (``None`` means "not supplied").
+        """Update mutable fields on a task. ``current_state`` uses the UNSET sentinel
+        (explicit null clears, omitted leaves it); ``task_metadata`` None means "not supplied".
         """
 
         if not id and not name:
@@ -134,10 +129,7 @@ class TasksUseCase:
         ):
             return task_entity
 
-        # `merge_params` is a separate atomic JSONB shallow-merge so concurrent
-        # callers don't overwrite each other's fields. Run it first so the
-        # refreshed entity it returns becomes the value we return if no scalar
-        # field updates follow.
+        # Atomic JSONB shallow-merge; run first so its refreshed entity is the fallback return.
         if merge_params:
             merged = await self.task_service.merge_task_params(
                 task_entity.id, merge_params
@@ -145,10 +137,7 @@ class TasksUseCase:
             if merged is not None:
                 task_entity = merged
 
-        # Apply task_metadata/current_state via a single column-scoped atomic
-        # update — one task_updated publish, and (unlike a whole-row merge) no
-        # risk of clobbering a concurrently changed status/params. current_state
-        # rides that publish, powering reactive delivery to stream consumers.
+        # Single column-scoped write → one task_updated publish, no whole-row clobber.
         fields: dict[str, Any] = {}
         if task_metadata is not None:
             fields["task_metadata"] = task_metadata
@@ -159,11 +148,7 @@ class TasksUseCase:
                 task_entity.id, fields
             )
             if updated is None:
-                # The row vanished between the initial read and the write. No live
-                # hard-delete path reaches here today (delete is a soft status
-                # update, already guarded above), so this is defensive — but raise
-                # rather than return stale data, matching the not-found contract
-                # above and the sibling terminal-transition methods.
+                # Row vanished mid-flight (defensive; no live hard-delete path). Raise, don't return stale.
                 raise ItemDoesNotExist(f"Task {id or name} not found")
             task_entity = updated
 

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -11,6 +11,15 @@ from src.utils.logging import make_logger
 logger = make_logger(__name__)
 
 
+class _Unset:
+    """Sentinel distinguishing "field omitted" from "field explicitly set to null"
+    in a PATCH-style update, so an explicit null can clear a column while an
+    omitted field is left untouched."""
+
+
+UNSET: Any = _Unset()
+
+
 class TasksUseCase:
     """
     Use case for managing tasks. Handles CRUD operations and delegates task operations to ACP servers.
@@ -95,12 +104,19 @@ class TasksUseCase:
         name: str | None = None,
         task_metadata: dict[str, Any] | None = None,
         merge_params: dict[str, Any] | None = None,
-        current_state: str | None = None,
+        current_state: str | None | _Unset = UNSET,
     ) -> TaskEntity:
-        """Update mutable fields on a task entity. This is used by our API since not all fields should be mutable."""
+        """Update mutable fields on a task entity. This is used by our API since not all fields should be mutable.
+
+        ``current_state`` uses the UNSET sentinel so an explicit null clears the
+        column while an omitted field leaves it untouched. ``task_metadata`` keeps
+        its legacy semantics (``None`` means "not supplied").
+        """
 
         if not id and not name:
             raise ClientError("Either id or name must be provided")
+
+        current_state_supplied = not isinstance(current_state, _Unset)
 
         # todo: make this a transaction?
         task_entity = await self.task_service.get_task(id=id, name=name)
@@ -111,15 +127,17 @@ class TasksUseCase:
                 raise ItemDoesNotExist(f"Task {name} not found")
 
         # No-op if no mutable field was supplied.
-        if task_metadata is None and merge_params is None and current_state is None:
+        if (
+            task_metadata is None
+            and merge_params is None
+            and not current_state_supplied
+        ):
             return task_entity
 
         # `merge_params` is a separate atomic JSONB shallow-merge so concurrent
-        # callers don't overwrite each other's fields (vs reading→mutating→writing
-        # the whole params dict on task_entity). Run it first so the refreshed
-        # entity it returns becomes the base we apply `task_metadata` on top of;
-        # otherwise the `task_entity = merged` reassignment would discard an
-        # in-memory metadata change made before the merge.
+        # callers don't overwrite each other's fields. Run it first so the
+        # refreshed entity it returns becomes the value we return if no scalar
+        # field updates follow.
         if merge_params:
             merged = await self.task_service.merge_task_params(
                 task_entity.id, merge_params
@@ -127,16 +145,21 @@ class TasksUseCase:
             if merged is not None:
                 task_entity = merged
 
-        # Apply the whole-row field updates (task_metadata, current_state) in a
-        # single update_task write so they emit one task_updated event rather than
-        # two. current_state rides the same publish that already powers reactive
-        # task_updated delivery to stream consumers.
-        if task_metadata is not None or current_state is not None:
-            if task_metadata is not None:
-                task_entity.task_metadata = task_metadata
-            if current_state is not None:
-                task_entity.current_state = current_state
-            task_entity = await self.task_service.update_task(task=task_entity)
+        # Apply task_metadata/current_state via a single column-scoped atomic
+        # update — one task_updated publish, and (unlike a whole-row merge) no
+        # risk of clobbering a concurrently changed status/params. current_state
+        # rides that publish, powering reactive delivery to stream consumers.
+        fields: dict[str, Any] = {}
+        if task_metadata is not None:
+            fields["task_metadata"] = task_metadata
+        if current_state_supplied:
+            fields["current_state"] = current_state
+        if fields:
+            updated = await self.task_service.update_mutable_fields(
+                task_entity.id, fields
+            )
+            if updated is not None:
+                task_entity = updated
 
         return task_entity
 

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -12,7 +12,7 @@ logger = make_logger(__name__)
 
 
 class _Unset:
-    """Sentinel: PATCH field omitted (untouched) vs. explicitly null (cleared)."""
+    """Sentinel for partial updates: field omitted (untouched) vs. explicitly null (cleared)."""
 
 
 UNSET: Any = _Unset()

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -158,8 +158,14 @@ class TasksUseCase:
             updated = await self.task_service.update_mutable_fields(
                 task_entity.id, fields
             )
-            if updated is not None:
-                task_entity = updated
+            if updated is None:
+                # The row vanished between the initial read and the write. No live
+                # hard-delete path reaches here today (delete is a soft status
+                # update, already guarded above), so this is defensive — but raise
+                # rather than return stale data, matching the not-found contract
+                # above and the sibling terminal-transition methods.
+                raise ItemDoesNotExist(f"Task {id or name} not found")
+            task_entity = updated
 
         return task_entity
 

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -95,6 +95,7 @@ class TasksUseCase:
         name: str | None = None,
         task_metadata: dict[str, Any] | None = None,
         merge_params: dict[str, Any] | None = None,
+        current_state: str | None = None,
     ) -> TaskEntity:
         """Update mutable fields on a task entity. This is used by our API since not all fields should be mutable."""
 
@@ -109,8 +110,8 @@ class TasksUseCase:
             else:
                 raise ItemDoesNotExist(f"Task {name} not found")
 
-        # No-op if neither field was supplied.
-        if task_metadata is None and merge_params is None:
+        # No-op if no mutable field was supplied.
+        if task_metadata is None and merge_params is None and current_state is None:
             return task_entity
 
         # `merge_params` is a separate atomic JSONB shallow-merge so concurrent
@@ -126,8 +127,15 @@ class TasksUseCase:
             if merged is not None:
                 task_entity = merged
 
-        if task_metadata is not None:
-            task_entity.task_metadata = task_metadata
+        # Apply the whole-row field updates (task_metadata, current_state) in a
+        # single update_task write so they emit one task_updated event rather than
+        # two. current_state rides the same publish that already powers reactive
+        # task_updated delivery to stream consumers.
+        if task_metadata is not None or current_state is not None:
+            if task_metadata is not None:
+                task_entity.task_metadata = task_metadata
+            if current_state is not None:
+                task_entity.current_state = current_state
             task_entity = await self.task_service.update_task(task=task_entity)
 
         return task_entity

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -17,7 +17,7 @@ logger = make_logger(__name__)
 
 
 class _Unset:
-    """Sentinel: PATCH field omitted (untouched) vs. explicitly null (cleared)."""
+    """Sentinel for partial updates: field omitted (untouched) vs. explicitly null (cleared)."""
 
 
 UNSET: Any = _Unset()

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -17,9 +17,7 @@ logger = make_logger(__name__)
 
 
 class _Unset:
-    """Sentinel distinguishing "field omitted" from "field explicitly set to null"
-    in a PATCH-style update, so an explicit null can clear a column while an
-    omitted field is left untouched."""
+    """Sentinel: PATCH field omitted (untouched) vs. explicitly null (cleared)."""
 
 
 UNSET: Any = _Unset()
@@ -111,11 +109,8 @@ class TasksUseCase:
         merge_params: dict[str, Any] | None = None,
         current_state: str | None | _Unset = UNSET,
     ) -> TaskEntity:
-        """Update mutable fields on a task entity. This is used by our API since not all fields should be mutable.
-
-        ``current_state`` uses the UNSET sentinel so an explicit null clears the
-        column while an omitted field leaves it untouched. ``task_metadata`` keeps
-        its legacy semantics (``None`` means "not supplied").
+        """Update mutable fields on a task. ``current_state`` uses the UNSET sentinel
+        (explicit null clears, omitted leaves it); ``task_metadata`` None means "not supplied".
         """
 
         if not id and not name:
@@ -139,10 +134,7 @@ class TasksUseCase:
         ):
             return task_entity
 
-        # `merge_params` is a separate atomic JSONB shallow-merge so concurrent
-        # callers don't overwrite each other's fields. Run it first so the
-        # refreshed entity it returns becomes the value we return if no scalar
-        # field updates follow.
+        # Atomic JSONB shallow-merge; run first so its refreshed entity is the fallback return.
         if merge_params:
             merged = await self.task_service.merge_task_params(
                 task_entity.id, merge_params
@@ -150,10 +142,7 @@ class TasksUseCase:
             if merged is not None:
                 task_entity = merged
 
-        # Apply task_metadata/current_state via a single column-scoped atomic
-        # update — one task_updated publish, and (unlike a whole-row merge) no
-        # risk of clobbering a concurrently changed status/params. current_state
-        # rides that publish, powering reactive delivery to stream consumers.
+        # Single column-scoped write → one task_updated publish, no whole-row clobber.
         fields: dict[str, Any] = {}
         if task_metadata is not None:
             fields["task_metadata"] = task_metadata
@@ -164,11 +153,7 @@ class TasksUseCase:
                 task_entity.id, fields
             )
             if updated is None:
-                # The row vanished between the initial read and the write. No live
-                # hard-delete path reaches here today (delete is a soft status
-                # update, already guarded above), so this is defensive — but raise
-                # rather than return stale data, matching the not-found contract
-                # above and the sibling terminal-transition methods.
+                # Row vanished mid-flight (defensive; no live hard-delete path). Raise, don't return stale.
                 raise ItemDoesNotExist(f"Task {id or name} not found")
             task_entity = updated
 

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -16,13 +16,6 @@ from src.utils.logging import make_logger
 logger = make_logger(__name__)
 
 
-class _Unset:
-    """Sentinel for partial updates: field omitted (untouched) vs. explicitly null (cleared)."""
-
-
-UNSET: Any = _Unset()
-
-
 class TasksUseCase:
     """
     Use case for managing tasks. Handles CRUD operations and delegates task operations to ACP servers.
@@ -107,16 +100,12 @@ class TasksUseCase:
         name: str | None = None,
         task_metadata: dict[str, Any] | None = None,
         merge_params: dict[str, Any] | None = None,
-        current_state: str | None | _Unset = UNSET,
+        current_state: str | None = None,
     ) -> TaskEntity:
-        """Update mutable fields on a task. ``current_state`` uses the UNSET sentinel
-        (explicit null clears, omitted leaves it); ``task_metadata`` None means "not supplied".
-        """
+        """Update mutable fields on a task; ``None`` for any field means "not supplied"."""
 
         if not id and not name:
             raise ClientError("Either id or name must be provided")
-
-        current_state_supplied = not isinstance(current_state, _Unset)
 
         # todo: make this a transaction?
         task_entity = await self.task_service.get_task(id=id, name=name)
@@ -127,11 +116,7 @@ class TasksUseCase:
                 raise ItemDoesNotExist(f"Task {name} not found")
 
         # No-op if no mutable field was supplied.
-        if (
-            task_metadata is None
-            and merge_params is None
-            and not current_state_supplied
-        ):
+        if task_metadata is None and merge_params is None and current_state is None:
             return task_entity
 
         # Atomic JSONB shallow-merge; run first so its refreshed entity is the fallback return.
@@ -146,7 +131,7 @@ class TasksUseCase:
         fields: dict[str, Any] = {}
         if task_metadata is not None:
             fields["task_metadata"] = task_metadata
-        if current_state_supplied:
+        if current_state is not None:
             fields["current_state"] = current_state
         if fields:
             updated = await self.task_service.update_mutable_fields(

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -16,6 +16,15 @@ from src.utils.logging import make_logger
 logger = make_logger(__name__)
 
 
+class _Unset:
+    """Sentinel distinguishing "field omitted" from "field explicitly set to null"
+    in a PATCH-style update, so an explicit null can clear a column while an
+    omitted field is left untouched."""
+
+
+UNSET: Any = _Unset()
+
+
 class TasksUseCase:
     """
     Use case for managing tasks. Handles CRUD operations and delegates task operations to ACP servers.
@@ -100,12 +109,19 @@ class TasksUseCase:
         name: str | None = None,
         task_metadata: dict[str, Any] | None = None,
         merge_params: dict[str, Any] | None = None,
-        current_state: str | None = None,
+        current_state: str | None | _Unset = UNSET,
     ) -> TaskEntity:
-        """Update mutable fields on a task entity. This is used by our API since not all fields should be mutable."""
+        """Update mutable fields on a task entity. This is used by our API since not all fields should be mutable.
+
+        ``current_state`` uses the UNSET sentinel so an explicit null clears the
+        column while an omitted field leaves it untouched. ``task_metadata`` keeps
+        its legacy semantics (``None`` means "not supplied").
+        """
 
         if not id and not name:
             raise ClientError("Either id or name must be provided")
+
+        current_state_supplied = not isinstance(current_state, _Unset)
 
         # todo: make this a transaction?
         task_entity = await self.task_service.get_task(id=id, name=name)
@@ -116,15 +132,17 @@ class TasksUseCase:
                 raise ItemDoesNotExist(f"Task {name} not found")
 
         # No-op if no mutable field was supplied.
-        if task_metadata is None and merge_params is None and current_state is None:
+        if (
+            task_metadata is None
+            and merge_params is None
+            and not current_state_supplied
+        ):
             return task_entity
 
         # `merge_params` is a separate atomic JSONB shallow-merge so concurrent
-        # callers don't overwrite each other's fields (vs reading→mutating→writing
-        # the whole params dict on task_entity). Run it first so the refreshed
-        # entity it returns becomes the base we apply `task_metadata` on top of;
-        # otherwise the `task_entity = merged` reassignment would discard an
-        # in-memory metadata change made before the merge.
+        # callers don't overwrite each other's fields. Run it first so the
+        # refreshed entity it returns becomes the value we return if no scalar
+        # field updates follow.
         if merge_params:
             merged = await self.task_service.merge_task_params(
                 task_entity.id, merge_params
@@ -132,16 +150,21 @@ class TasksUseCase:
             if merged is not None:
                 task_entity = merged
 
-        # Apply the whole-row field updates (task_metadata, current_state) in a
-        # single update_task write so they emit one task_updated event rather than
-        # two. current_state rides the same publish that already powers reactive
-        # task_updated delivery to stream consumers.
-        if task_metadata is not None or current_state is not None:
-            if task_metadata is not None:
-                task_entity.task_metadata = task_metadata
-            if current_state is not None:
-                task_entity.current_state = current_state
-            task_entity = await self.task_service.update_task(task=task_entity)
+        # Apply task_metadata/current_state via a single column-scoped atomic
+        # update — one task_updated publish, and (unlike a whole-row merge) no
+        # risk of clobbering a concurrently changed status/params. current_state
+        # rides that publish, powering reactive delivery to stream consumers.
+        fields: dict[str, Any] = {}
+        if task_metadata is not None:
+            fields["task_metadata"] = task_metadata
+        if current_state_supplied:
+            fields["current_state"] = current_state
+        if fields:
+            updated = await self.task_service.update_mutable_fields(
+                task_entity.id, fields
+            )
+            if updated is not None:
+                task_entity = updated
 
         return task_entity
 

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -115,11 +115,9 @@ class TasksUseCase:
             else:
                 raise ItemDoesNotExist(f"Task {name} not found")
 
-        # No-op if no mutable field was supplied.
         if task_metadata is None and merge_params is None and current_state is None:
             return task_entity
 
-        # Atomic JSONB shallow-merge; run first so its refreshed entity is the fallback return.
         if merge_params:
             merged = await self.task_service.merge_task_params(
                 task_entity.id, merge_params
@@ -127,7 +125,6 @@ class TasksUseCase:
             if merged is not None:
                 task_entity = merged
 
-        # Single column-scoped write → one task_updated publish, no whole-row clobber.
         fields: dict[str, Any] = {}
         if task_metadata is not None:
             fields["task_metadata"] = task_metadata
@@ -138,7 +135,6 @@ class TasksUseCase:
                 task_entity.id, fields
             )
             if updated is None:
-                # Row vanished mid-flight (defensive; no live hard-delete path). Raise, don't return stale.
                 raise ItemDoesNotExist(f"Task {id or name} not found")
             task_entity = updated
 

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -102,7 +102,8 @@ class TasksUseCase:
         merge_params: dict[str, Any] | None = None,
         current_state: str | None = None,
     ) -> TaskEntity:
-        """Update mutable fields on a task; ``None`` for any field means "not supplied"."""
+        """Update mutable fields on a task; ``None`` for any field means "not supplied".
+        ``current_state=""`` clears the label."""
 
         if not id and not name:
             raise ClientError("Either id or name must be provided")
@@ -129,7 +130,9 @@ class TasksUseCase:
         if task_metadata is not None:
             fields["task_metadata"] = task_metadata
         if current_state is not None:
-            fields["current_state"] = current_state
+            # "" is the explicit clear: an empty label carries no meaning, and without
+            # it a task whose agent died mid-state would stay pinned forever.
+            fields["current_state"] = current_state or None
         if fields:
             updated = await self.task_service.update_mutable_fields(
                 task_entity.id, fields

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -100,6 +100,7 @@ class TasksUseCase:
         name: str | None = None,
         task_metadata: dict[str, Any] | None = None,
         merge_params: dict[str, Any] | None = None,
+        current_state: str | None = None,
     ) -> TaskEntity:
         """Update mutable fields on a task entity. This is used by our API since not all fields should be mutable."""
 
@@ -114,8 +115,8 @@ class TasksUseCase:
             else:
                 raise ItemDoesNotExist(f"Task {name} not found")
 
-        # No-op if neither field was supplied.
-        if task_metadata is None and merge_params is None:
+        # No-op if no mutable field was supplied.
+        if task_metadata is None and merge_params is None and current_state is None:
             return task_entity
 
         # `merge_params` is a separate atomic JSONB shallow-merge so concurrent
@@ -131,8 +132,15 @@ class TasksUseCase:
             if merged is not None:
                 task_entity = merged
 
-        if task_metadata is not None:
-            task_entity.task_metadata = task_metadata
+        # Apply the whole-row field updates (task_metadata, current_state) in a
+        # single update_task write so they emit one task_updated event rather than
+        # two. current_state rides the same publish that already powers reactive
+        # task_updated delivery to stream consumers.
+        if task_metadata is not None or current_state is not None:
+            if task_metadata is not None:
+                task_entity.task_metadata = task_metadata
+            if current_state is not None:
+                task_entity.current_state = current_state
             task_entity = await self.task_service.update_task(task=task_entity)
 
         return task_entity

--- a/agentex/src/domain/use_cases/tasks_use_case.py
+++ b/agentex/src/domain/use_cases/tasks_use_case.py
@@ -163,8 +163,14 @@ class TasksUseCase:
             updated = await self.task_service.update_mutable_fields(
                 task_entity.id, fields
             )
-            if updated is not None:
-                task_entity = updated
+            if updated is None:
+                # The row vanished between the initial read and the write. No live
+                # hard-delete path reaches here today (delete is a soft status
+                # update, already guarded above), so this is defensive — but raise
+                # rather than return stale data, matching the not-found contract
+                # above and the sibling terminal-transition methods.
+                raise ItemDoesNotExist(f"Task {id or name} not found")
+            task_entity = updated
 
         return task_entity
 

--- a/agentex/src/utils/task_constants.py
+++ b/agentex/src/utils/task_constants.py
@@ -1,0 +1,3 @@
+# Single source for the current_state bound: the request-validation limit
+# (UpdateTaskRequest) and the storage limit (TaskORM.current_state column width).
+CURRENT_STATE_MAX_LENGTH = 255

--- a/agentex/src/utils/task_constants.py
+++ b/agentex/src/utils/task_constants.py
@@ -1,3 +1,2 @@
-# Single source for the current_state bound: the request-validation limit
-# (UpdateTaskRequest) and the storage limit (TaskORM.current_state column width).
+# Single source for the current_state bound (request validation + column width).
 CURRENT_STATE_MAX_LENGTH = 255

--- a/agentex/src/utils/task_constants.py
+++ b/agentex/src/utils/task_constants.py
@@ -1,2 +1,14 @@
 # Single source for the current_state bound (request validation + column width).
 CURRENT_STATE_MAX_LENGTH = 255
+
+# States the agent SDK's StateMachine emits today. The column stays opaque so
+# agent-specific states need no platform change; this is the vocabulary a
+# consumer can rely on being present.
+KNOWN_CURRENT_STATES = ("IDLE", "WORKING", "AWAITING_INPUT")
+
+CURRENT_STATE_DESCRIPTION = (
+    "Opaque label mirroring the agent's StateMachine current state; null when the "
+    "agent does not emit one. Orthogonal to 'status'. States the SDK emits today: "
+    + ", ".join(KNOWN_CURRENT_STATES)
+    + ". Treat any other value as unknown rather than assuming this set is closed."
+)

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -683,6 +683,85 @@ class TestTasksAPIIntegration:
         assert response_data["task_metadata"]["configuration"]["version"] == "2.0.0"
         assert response_data["task_metadata"]["metrics"]["complexity_score"] == 75
 
+    async def test_update_task_current_state(
+        self, isolated_client, isolated_repositories
+    ):
+        """PUT /tasks/{id} writes current_state; null/omitted leaves it unset."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-agent",
+            description="Agent for current_state update testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-current-state",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for current_state",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        # Fresh task: current_state present in response and null by default.
+        response = await isolated_client.get(f"/tasks/{created_task.id}")
+        assert response.status_code == 200
+        assert response.json()["current_state"] is None
+
+        # Setting current_state persists and echoes back.
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"current_state": "awaiting_input"}
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "awaiting_input"
+
+        # Point-read reflects the committed value (source of truth).
+        response = await isolated_client.get(f"/tasks/{created_task.id}")
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "awaiting_input"
+
+        # Updating only task_metadata leaves current_state untouched (no clobber).
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"task_metadata": {"k": "v"}}
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "awaiting_input"
+
+    async def test_update_task_request_ignores_unknown_fields(
+        self, isolated_client, isolated_repositories
+    ):
+        """Guards the extra="ignore" assumption a newer SDK relies on: a payload
+        carrying fields the server doesn't model must 200 (drop them), not 422.
+        Breaks loudly if UpdateTaskRequest ever switches to extra="forbid"."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="unknown-fields-agent",
+            description="Agent for unknown-field compat testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-unknown-fields",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for unknown-field compat",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}",
+            json={"current_state": "working", "field_from_a_newer_sdk": "ignored"},
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "working"
+
     async def test_update_task_endpoint_validation(
         self, isolated_client, isolated_repositories
     ):

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -686,7 +686,8 @@ class TestTasksAPIIntegration:
     async def test_update_task_current_state(
         self, isolated_client, isolated_repositories
     ):
-        """PUT /tasks/{id} writes current_state; null/omitted leaves it unset."""
+        """PUT /tasks/{id} writes current_state; explicit null clears it while an
+        omitted field leaves it untouched; point-read is source of truth."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),
@@ -723,12 +724,143 @@ class TestTasksAPIIntegration:
         assert response.status_code == 200
         assert response.json()["current_state"] == "awaiting_input"
 
-        # Updating only task_metadata leaves current_state untouched (no clobber).
+        # Updating only task_metadata (current_state omitted) does not clobber it.
         response = await isolated_client.put(
             f"/tasks/{created_task.id}", json={"task_metadata": {"k": "v"}}
         )
         assert response.status_code == 200
         assert response.json()["current_state"] == "awaiting_input"
+
+        # Explicit null clears the label (distinct from omitting the field).
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"current_state": None}
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] is None
+        response = await isolated_client.get(f"/tasks/{created_task.id}")
+        assert response.json()["current_state"] is None
+
+    async def test_update_task_current_state_and_metadata_together(
+        self, isolated_client, isolated_repositories
+    ):
+        """current_state + task_metadata in one PUT both persist (single write),
+        without clobbering status."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-combined-agent",
+            description="Agent for combined update testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-combined-update",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for combined update",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}",
+            json={"current_state": "step_2", "task_metadata": {"stage": "two"}},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["current_state"] == "step_2"
+        assert body["task_metadata"] == {"stage": "two"}
+        assert body["status"] == "RUNNING"
+
+    async def test_update_task_current_state_by_name(
+        self, isolated_client, isolated_repositories
+    ):
+        """PUT /tasks/name/{name} forwards current_state too."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-by-name-agent",
+            description="Agent for by-name current_state testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-current-state-by-name",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for by-name current_state",
+        )
+        await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            "/tasks/name/task-for-current-state-by-name",
+            json={"current_state": "working"},
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "working"
+
+    async def test_update_task_current_state_empty_string(
+        self, isolated_client, isolated_repositories
+    ):
+        """Empty string is a valid label distinct from null (guards against a
+        future falsy check treating "" as "unset")."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-empty-agent",
+            description="Agent for empty-string current_state testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-current-state-empty",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for empty current_state",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"current_state": ""}
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == ""
+
+    async def test_update_task_current_state_too_long_rejected(
+        self, isolated_client, isolated_repositories
+    ):
+        """current_state exceeding the max length is rejected with 422."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-toolong-agent",
+            description="Agent for max-length current_state testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-current-state-toolong",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for over-long current_state",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"current_state": "x" * 256}
+        )
+        assert response.status_code == 422
 
     async def test_update_task_request_ignores_unknown_fields(
         self, isolated_client, isolated_repositories

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -686,8 +686,7 @@ class TestTasksAPIIntegration:
     async def test_update_task_current_state(
         self, isolated_client, isolated_repositories
     ):
-        """PUT /tasks/{id} writes current_state; explicit null clears it while an
-        omitted field leaves it untouched; point-read is source of truth."""
+        """PUT current_state: explicit null clears, omitted leaves it, point-read reconciles."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),
@@ -743,8 +742,7 @@ class TestTasksAPIIntegration:
     async def test_update_task_current_state_and_metadata_together(
         self, isolated_client, isolated_repositories
     ):
-        """current_state + task_metadata in one PUT both persist (single write),
-        without clobbering status."""
+        """current_state + task_metadata in one PUT both persist without clobbering status."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),
@@ -807,8 +805,7 @@ class TestTasksAPIIntegration:
     async def test_update_task_current_state_empty_string(
         self, isolated_client, isolated_repositories
     ):
-        """Empty string is a valid label distinct from null (guards against a
-        future falsy check treating "" as "unset")."""
+        """Empty string is a valid label distinct from null (guards a falsy-check regression)."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),
@@ -865,9 +862,7 @@ class TestTasksAPIIntegration:
     async def test_update_task_request_ignores_unknown_fields(
         self, isolated_client, isolated_repositories
     ):
-        """Guards the extra="ignore" assumption a newer SDK relies on: a payload
-        carrying fields the server doesn't model must 200 (drop them), not 422.
-        Breaks loudly if UpdateTaskRequest ever switches to extra="forbid"."""
+        """Unknown fields are ignored (200, not 422) — guards the extra="ignore" SDK-compat assumption."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -58,6 +58,18 @@ class TestTasksAPIIntegration:
         return tasks
 
     @pytest_asyncio.fixture
+    async def test_running_task(self, isolated_repositories, test_agent):
+        """Create a minimal running task for tests that don't care about its name"""
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name=f"running-task-{orm_id()[:8]}",
+            status=TaskStatus.RUNNING,
+            status_reason="Running task for testing",
+        )
+        return await task_repo.create(agent_id=test_agent.id, task=task)
+
+    @pytest_asyncio.fixture
     async def test_task_with_params(self, isolated_repositories, test_agent):
         """Create a test task with params directly via repository"""
         task_repo = isolated_repositories["task_repository"]
@@ -506,8 +518,7 @@ class TestTasksAPIIntegration:
     async def test_list_tasks_omits_params_in_response(
         self, isolated_client, test_task_with_params
     ):
-        """The list summary must omit `params` (secrets/PII) but still carry the small
-        opaque `current_state` label; fetch a single task for the full record."""
+        """List summary omits params but carries current_state."""
         # When - Request all tasks
         response = await isolated_client.get("/tasks")
 
@@ -678,27 +689,10 @@ class TestTasksAPIIntegration:
         assert response_data["task_metadata"]["metrics"]["complexity_score"] == 75
 
     async def test_update_task_current_state(
-        self, isolated_client, isolated_repositories
+        self, isolated_client, test_running_task
     ):
         """PUT current_state: set it, omitted leaves it untouched, point-read reconciles."""
-        agent_repo = isolated_repositories["agent_repository"]
-        agent = AgentEntity(
-            id=orm_id(),
-            name="current-state-agent",
-            description="Agent for current_state update testing",
-            acp_url="http://test-acp:8000",
-            acp_type=ACPType.SYNC,
-        )
-        await agent_repo.create(agent)
-
-        task_repo = isolated_repositories["task_repository"]
-        task = TaskEntity(
-            id=orm_id(),
-            name="task-for-current-state",
-            status=TaskStatus.RUNNING,
-            status_reason="Test task for current_state",
-        )
-        created_task = await task_repo.create(agent_id=agent.id, task=task)
+        created_task = test_running_task
 
         # Fresh task: current_state present in response and null by default.
         response = await isolated_client.get(f"/tasks/{created_task.id}")
@@ -725,27 +719,10 @@ class TestTasksAPIIntegration:
         assert response.json()["current_state"] == "awaiting_input"
 
     async def test_update_task_current_state_and_metadata_together(
-        self, isolated_client, isolated_repositories
+        self, isolated_client, test_running_task
     ):
         """current_state + task_metadata in one PUT both persist without clobbering status."""
-        agent_repo = isolated_repositories["agent_repository"]
-        agent = AgentEntity(
-            id=orm_id(),
-            name="current-state-combined-agent",
-            description="Agent for combined update testing",
-            acp_url="http://test-acp:8000",
-            acp_type=ACPType.SYNC,
-        )
-        await agent_repo.create(agent)
-
-        task_repo = isolated_repositories["task_repository"]
-        task = TaskEntity(
-            id=orm_id(),
-            name="task-for-combined-update",
-            status=TaskStatus.RUNNING,
-            status_reason="Test task for combined update",
-        )
-        created_task = await task_repo.create(agent_id=agent.id, task=task)
+        created_task = test_running_task
 
         response = await isolated_client.put(
             f"/tasks/{created_task.id}",
@@ -758,19 +735,9 @@ class TestTasksAPIIntegration:
         assert body["status"] == "RUNNING"
 
     async def test_update_task_current_state_by_name(
-        self, isolated_client, isolated_repositories
+        self, isolated_client, isolated_repositories, test_agent
     ):
         """PUT /tasks/name/{name} forwards current_state too."""
-        agent_repo = isolated_repositories["agent_repository"]
-        agent = AgentEntity(
-            id=orm_id(),
-            name="current-state-by-name-agent",
-            description="Agent for by-name current_state testing",
-            acp_url="http://test-acp:8000",
-            acp_type=ACPType.SYNC,
-        )
-        await agent_repo.create(agent)
-
         task_repo = isolated_repositories["task_repository"]
         task = TaskEntity(
             id=orm_id(),
@@ -778,7 +745,7 @@ class TestTasksAPIIntegration:
             status=TaskStatus.RUNNING,
             status_reason="Test task for by-name current_state",
         )
-        await task_repo.create(agent_id=agent.id, task=task)
+        await task_repo.create(agent_id=test_agent.id, task=task)
 
         response = await isolated_client.put(
             "/tasks/name/task-for-current-state-by-name",
@@ -788,87 +755,30 @@ class TestTasksAPIIntegration:
         assert response.json()["current_state"] == "working"
 
     async def test_update_task_current_state_empty_string(
-        self, isolated_client, isolated_repositories
+        self, isolated_client, test_running_task
     ):
         """Empty string is a valid label distinct from null (guards a falsy-check regression)."""
-        agent_repo = isolated_repositories["agent_repository"]
-        agent = AgentEntity(
-            id=orm_id(),
-            name="current-state-empty-agent",
-            description="Agent for empty-string current_state testing",
-            acp_url="http://test-acp:8000",
-            acp_type=ACPType.SYNC,
-        )
-        await agent_repo.create(agent)
-
-        task_repo = isolated_repositories["task_repository"]
-        task = TaskEntity(
-            id=orm_id(),
-            name="task-for-current-state-empty",
-            status=TaskStatus.RUNNING,
-            status_reason="Test task for empty current_state",
-        )
-        created_task = await task_repo.create(agent_id=agent.id, task=task)
-
         response = await isolated_client.put(
-            f"/tasks/{created_task.id}", json={"current_state": ""}
+            f"/tasks/{test_running_task.id}", json={"current_state": ""}
         )
         assert response.status_code == 200
         assert response.json()["current_state"] == ""
 
     async def test_update_task_current_state_too_long_rejected(
-        self, isolated_client, isolated_repositories
+        self, isolated_client, test_running_task
     ):
         """current_state exceeding the max length is rejected with 422."""
-        agent_repo = isolated_repositories["agent_repository"]
-        agent = AgentEntity(
-            id=orm_id(),
-            name="current-state-toolong-agent",
-            description="Agent for max-length current_state testing",
-            acp_url="http://test-acp:8000",
-            acp_type=ACPType.SYNC,
-        )
-        await agent_repo.create(agent)
-
-        task_repo = isolated_repositories["task_repository"]
-        task = TaskEntity(
-            id=orm_id(),
-            name="task-for-current-state-toolong",
-            status=TaskStatus.RUNNING,
-            status_reason="Test task for over-long current_state",
-        )
-        created_task = await task_repo.create(agent_id=agent.id, task=task)
-
         response = await isolated_client.put(
-            f"/tasks/{created_task.id}", json={"current_state": "x" * 256}
+            f"/tasks/{test_running_task.id}", json={"current_state": "x" * 256}
         )
         assert response.status_code == 422
 
     async def test_update_task_request_ignores_unknown_fields(
-        self, isolated_client, isolated_repositories
+        self, isolated_client, test_running_task
     ):
         """Unknown fields are ignored (200, not 422) — guards the extra="ignore" SDK-compat assumption."""
-        agent_repo = isolated_repositories["agent_repository"]
-        agent = AgentEntity(
-            id=orm_id(),
-            name="unknown-fields-agent",
-            description="Agent for unknown-field compat testing",
-            acp_url="http://test-acp:8000",
-            acp_type=ACPType.SYNC,
-        )
-        await agent_repo.create(agent)
-
-        task_repo = isolated_repositories["task_repository"]
-        task = TaskEntity(
-            id=orm_id(),
-            name="task-for-unknown-fields",
-            status=TaskStatus.RUNNING,
-            status_reason="Test task for unknown-field compat",
-        )
-        created_task = await task_repo.create(agent_id=agent.id, task=task)
-
         response = await isolated_client.put(
-            f"/tasks/{created_task.id}",
+            f"/tasks/{test_running_task.id}",
             json={"current_state": "working", "field_from_a_newer_sdk": "ignored"},
         )
         assert response.status_code == 200

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -678,7 +678,7 @@ class TestTasksAPIIntegration:
     async def test_update_task_current_state(
         self, isolated_client, isolated_repositories
     ):
-        """PUT current_state: explicit null clears, omitted leaves it, point-read reconciles."""
+        """PUT current_state: set it, omitted leaves it untouched, point-read reconciles."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),
@@ -721,15 +721,6 @@ class TestTasksAPIIntegration:
         )
         assert response.status_code == 200
         assert response.json()["current_state"] == "awaiting_input"
-
-        # Explicit null clears the label (distinct from omitting the field).
-        response = await isolated_client.put(
-            f"/tasks/{created_task.id}", json={"current_state": None}
-        )
-        assert response.status_code == 200
-        assert response.json()["current_state"] is None
-        response = await isolated_client.get(f"/tasks/{created_task.id}")
-        assert response.json()["current_state"] is None
 
     async def test_update_task_current_state_and_metadata_together(
         self, isolated_client, isolated_repositories

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -754,15 +754,24 @@ class TestTasksAPIIntegration:
         assert response.status_code == 200
         assert response.json()["current_state"] == "working"
 
-    async def test_update_task_current_state_empty_string(
+    async def test_update_task_current_state_empty_string_clears(
         self, isolated_client, test_running_task
     ):
-        """Empty string is a valid label distinct from null (guards a falsy-check regression)."""
+        """Empty string clears the label, so a task stuck mid-state is recoverable."""
+        response = await isolated_client.put(
+            f"/tasks/{test_running_task.id}", json={"current_state": "WORKING"}
+        )
+        assert response.json()["current_state"] == "WORKING"
+
         response = await isolated_client.put(
             f"/tasks/{test_running_task.id}", json={"current_state": ""}
         )
         assert response.status_code == 200
-        assert response.json()["current_state"] == ""
+        assert response.json()["current_state"] is None
+
+        # The clear is persisted, not just echoed.
+        response = await isolated_client.get(f"/tasks/{test_running_task.id}")
+        assert response.json()["current_state"] is None
 
     async def test_update_task_current_state_too_long_rejected(
         self, isolated_client, test_running_task

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -678,7 +678,8 @@ class TestTasksAPIIntegration:
     async def test_update_task_current_state(
         self, isolated_client, isolated_repositories
     ):
-        """PUT /tasks/{id} writes current_state; null/omitted leaves it unset."""
+        """PUT /tasks/{id} writes current_state; explicit null clears it while an
+        omitted field leaves it untouched; point-read is source of truth."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),
@@ -715,12 +716,143 @@ class TestTasksAPIIntegration:
         assert response.status_code == 200
         assert response.json()["current_state"] == "awaiting_input"
 
-        # Updating only task_metadata leaves current_state untouched (no clobber).
+        # Updating only task_metadata (current_state omitted) does not clobber it.
         response = await isolated_client.put(
             f"/tasks/{created_task.id}", json={"task_metadata": {"k": "v"}}
         )
         assert response.status_code == 200
         assert response.json()["current_state"] == "awaiting_input"
+
+        # Explicit null clears the label (distinct from omitting the field).
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"current_state": None}
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] is None
+        response = await isolated_client.get(f"/tasks/{created_task.id}")
+        assert response.json()["current_state"] is None
+
+    async def test_update_task_current_state_and_metadata_together(
+        self, isolated_client, isolated_repositories
+    ):
+        """current_state + task_metadata in one PUT both persist (single write),
+        without clobbering status."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-combined-agent",
+            description="Agent for combined update testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-combined-update",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for combined update",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}",
+            json={"current_state": "step_2", "task_metadata": {"stage": "two"}},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["current_state"] == "step_2"
+        assert body["task_metadata"] == {"stage": "two"}
+        assert body["status"] == "RUNNING"
+
+    async def test_update_task_current_state_by_name(
+        self, isolated_client, isolated_repositories
+    ):
+        """PUT /tasks/name/{name} forwards current_state too."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-by-name-agent",
+            description="Agent for by-name current_state testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-current-state-by-name",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for by-name current_state",
+        )
+        await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            "/tasks/name/task-for-current-state-by-name",
+            json={"current_state": "working"},
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "working"
+
+    async def test_update_task_current_state_empty_string(
+        self, isolated_client, isolated_repositories
+    ):
+        """Empty string is a valid label distinct from null (guards against a
+        future falsy check treating "" as "unset")."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-empty-agent",
+            description="Agent for empty-string current_state testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-current-state-empty",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for empty current_state",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"current_state": ""}
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == ""
+
+    async def test_update_task_current_state_too_long_rejected(
+        self, isolated_client, isolated_repositories
+    ):
+        """current_state exceeding the max length is rejected with 422."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-toolong-agent",
+            description="Agent for max-length current_state testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-current-state-toolong",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for over-long current_state",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"current_state": "x" * 256}
+        )
+        assert response.status_code == 422
 
     async def test_update_task_request_ignores_unknown_fields(
         self, isolated_client, isolated_repositories

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -506,8 +506,8 @@ class TestTasksAPIIntegration:
     async def test_list_tasks_omits_params_in_response(
         self, isolated_client, test_task_with_params
     ):
-        """The list summary must omit `params` even when the task has them
-        (they can carry secrets/PII); fetch a single task for the full record."""
+        """The list summary must omit `params` (secrets/PII) but still carry the small
+        opaque `current_state` label; fetch a single task for the full record."""
         # When - Request all tasks
         response = await isolated_client.get("/tasks")
 
@@ -521,6 +521,8 @@ class TestTasksAPIIntegration:
         )
         assert params_task is not None, "Task should be in the list"
         assert "params" not in params_task
+        # current_state is a non-sensitive opaque label, so it IS in the lean summary.
+        assert "current_state" in params_task
 
     #
     async def test_get_task_by_id_includes_params_in_response(

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -675,6 +675,85 @@ class TestTasksAPIIntegration:
         assert response_data["task_metadata"]["configuration"]["version"] == "2.0.0"
         assert response_data["task_metadata"]["metrics"]["complexity_score"] == 75
 
+    async def test_update_task_current_state(
+        self, isolated_client, isolated_repositories
+    ):
+        """PUT /tasks/{id} writes current_state; null/omitted leaves it unset."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="current-state-agent",
+            description="Agent for current_state update testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-current-state",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for current_state",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        # Fresh task: current_state present in response and null by default.
+        response = await isolated_client.get(f"/tasks/{created_task.id}")
+        assert response.status_code == 200
+        assert response.json()["current_state"] is None
+
+        # Setting current_state persists and echoes back.
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"current_state": "awaiting_input"}
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "awaiting_input"
+
+        # Point-read reflects the committed value (source of truth).
+        response = await isolated_client.get(f"/tasks/{created_task.id}")
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "awaiting_input"
+
+        # Updating only task_metadata leaves current_state untouched (no clobber).
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}", json={"task_metadata": {"k": "v"}}
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "awaiting_input"
+
+    async def test_update_task_request_ignores_unknown_fields(
+        self, isolated_client, isolated_repositories
+    ):
+        """Guards the extra="ignore" assumption a newer SDK relies on: a payload
+        carrying fields the server doesn't model must 200 (drop them), not 422.
+        Breaks loudly if UpdateTaskRequest ever switches to extra="forbid"."""
+        agent_repo = isolated_repositories["agent_repository"]
+        agent = AgentEntity(
+            id=orm_id(),
+            name="unknown-fields-agent",
+            description="Agent for unknown-field compat testing",
+            acp_url="http://test-acp:8000",
+            acp_type=ACPType.SYNC,
+        )
+        await agent_repo.create(agent)
+
+        task_repo = isolated_repositories["task_repository"]
+        task = TaskEntity(
+            id=orm_id(),
+            name="task-for-unknown-fields",
+            status=TaskStatus.RUNNING,
+            status_reason="Test task for unknown-field compat",
+        )
+        created_task = await task_repo.create(agent_id=agent.id, task=task)
+
+        response = await isolated_client.put(
+            f"/tasks/{created_task.id}",
+            json={"current_state": "working", "field_from_a_newer_sdk": "ignored"},
+        )
+        assert response.status_code == 200
+        assert response.json()["current_state"] == "working"
+
     async def test_update_task_endpoint_validation(
         self, isolated_client, isolated_repositories
     ):

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -678,8 +678,7 @@ class TestTasksAPIIntegration:
     async def test_update_task_current_state(
         self, isolated_client, isolated_repositories
     ):
-        """PUT /tasks/{id} writes current_state; explicit null clears it while an
-        omitted field leaves it untouched; point-read is source of truth."""
+        """PUT current_state: explicit null clears, omitted leaves it, point-read reconciles."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),
@@ -735,8 +734,7 @@ class TestTasksAPIIntegration:
     async def test_update_task_current_state_and_metadata_together(
         self, isolated_client, isolated_repositories
     ):
-        """current_state + task_metadata in one PUT both persist (single write),
-        without clobbering status."""
+        """current_state + task_metadata in one PUT both persist without clobbering status."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),
@@ -799,8 +797,7 @@ class TestTasksAPIIntegration:
     async def test_update_task_current_state_empty_string(
         self, isolated_client, isolated_repositories
     ):
-        """Empty string is a valid label distinct from null (guards against a
-        future falsy check treating "" as "unset")."""
+        """Empty string is a valid label distinct from null (guards a falsy-check regression)."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),
@@ -857,9 +854,7 @@ class TestTasksAPIIntegration:
     async def test_update_task_request_ignores_unknown_fields(
         self, isolated_client, isolated_repositories
     ):
-        """Guards the extra="ignore" assumption a newer SDK relies on: a payload
-        carrying fields the server doesn't model must 200 (drop them), not 422.
-        Breaks loudly if UpdateTaskRequest ever switches to extra="forbid"."""
+        """Unknown fields are ignored (200, not 422) — guards the extra="ignore" SDK-compat assumption."""
         agent_repo = isolated_repositories["agent_repository"]
         agent = AgentEntity(
             id=orm_id(),

--- a/agentex/tests/integration/test_task_stream.py
+++ b/agentex/tests/integration/test_task_stream.py
@@ -275,6 +275,9 @@ class TestTaskEventStream:
                 await stream_task
         except (TimeoutError, asyncio.CancelledError):
             stream_task.cancel()
+            # Re-await so the task's own cancellation cleanup runs and no
+            # "Task exception was never retrieved" warning leaks at teardown.
+            await asyncio.gather(stream_task, return_exceptions=True)
 
         task_updated_events = [
             e for e in stream_events if e.get("type") == "task_updated"

--- a/agentex/tests/integration/test_task_stream.py
+++ b/agentex/tests/integration/test_task_stream.py
@@ -233,8 +233,7 @@ class TestTaskEventStream:
     async def test_current_state_update_triggers_stream_event(
         self, test_agent_and_task, tasks_use_case, streams_use_case
     ):
-        """current_state rides the existing task_updated event, so a client
-        subscribed to the task stream is pushed the new state reactively."""
+        """current_state rides the existing task_updated event (reactive push to subscribers)."""
         _agent, task = test_agent_and_task
 
         stream_events = []
@@ -260,23 +259,20 @@ class TestTaskEventStream:
                 pass
 
         stream_task = asyncio.create_task(collect_stream_events())
-        # Let the subscription establish before the update; the stream is
-        # tail-only, so an event published before we subscribe would be missed.
+        # Let the tail-only subscription establish before the update, or the event is missed.
         await asyncio.sleep(0.1)
 
         updated_task = await tasks_use_case.update_mutable_fields_on_task(
             id=task.id, current_state="awaiting_input"
         )
 
-        # Wait until the collector sees task_updated (it breaks on it) rather
-        # than guessing a fixed delay; the timeout is only a failure ceiling.
+        # Wait for the collector to see task_updated (it breaks on it); timeout is only a ceiling.
         try:
             async with asyncio.timeout(5):
                 await stream_task
         except (TimeoutError, asyncio.CancelledError):
             stream_task.cancel()
-            # Re-await so the task's own cancellation cleanup runs and no
-            # "Task exception was never retrieved" warning leaks at teardown.
+            # Re-await so cancellation cleanup runs and no dangling-task warning leaks at teardown.
             await asyncio.gather(stream_task, return_exceptions=True)
 
         task_updated_events = [

--- a/agentex/tests/integration/test_task_stream.py
+++ b/agentex/tests/integration/test_task_stream.py
@@ -230,6 +230,64 @@ class TestTaskEventStream:
 
         print("✅ Task metadata update successfully triggered stream event")
 
+    async def test_current_state_update_triggers_stream_event(
+        self, test_agent_and_task, tasks_use_case, streams_use_case
+    ):
+        """current_state rides the existing task_updated event, so a client
+        subscribed to the task stream is pushed the new state reactively."""
+        _agent, task = test_agent_and_task
+
+        stream_events = []
+
+        async def collect_stream_events():
+            try:
+                async for event_data in streams_use_case.stream_task_events(
+                    task_id=task.id
+                ):
+                    if event_data.startswith("data: "):
+                        import json
+
+                        event_json = event_data[6:].strip()
+                        if event_json:
+                            try:
+                                event = json.loads(event_json)
+                                stream_events.append(event)
+                                if event.get("type") == "task_updated":
+                                    break
+                            except json.JSONDecodeError:
+                                pass
+            except asyncio.CancelledError:
+                pass
+
+        stream_task = asyncio.create_task(collect_stream_events())
+        await asyncio.sleep(0.1)
+
+        updated_task = await tasks_use_case.update_mutable_fields_on_task(
+            id=task.id, current_state="awaiting_input"
+        )
+
+        await asyncio.sleep(0.5)
+
+        stream_task.cancel()
+        try:
+            await stream_task
+        except asyncio.CancelledError:
+            pass
+
+        task_updated_events = [
+            e for e in stream_events if e.get("type") == "task_updated"
+        ]
+        assert len(task_updated_events) >= 1, (
+            f"Expected task_updated event, got events: {[e.get('type') for e in stream_events]}"
+        )
+        event_task = task_updated_events[0]["task"]
+        assert event_task["id"] == task.id
+        assert event_task["current_state"] == "awaiting_input"
+
+        assert updated_task.current_state == "awaiting_input"
+
+        print("✅ current_state update successfully triggered stream event")
+
     async def test_get_task_returns_updated_metadata_after_stream_update(
         self, test_agent_and_task, tasks_use_case
     ):

--- a/agentex/tests/integration/test_task_stream.py
+++ b/agentex/tests/integration/test_task_stream.py
@@ -260,19 +260,21 @@ class TestTaskEventStream:
                 pass
 
         stream_task = asyncio.create_task(collect_stream_events())
+        # Let the subscription establish before the update; the stream is
+        # tail-only, so an event published before we subscribe would be missed.
         await asyncio.sleep(0.1)
 
         updated_task = await tasks_use_case.update_mutable_fields_on_task(
             id=task.id, current_state="awaiting_input"
         )
 
-        await asyncio.sleep(0.5)
-
-        stream_task.cancel()
+        # Wait until the collector sees task_updated (it breaks on it) rather
+        # than guessing a fixed delay; the timeout is only a failure ceiling.
         try:
-            await stream_task
-        except asyncio.CancelledError:
-            pass
+            async with asyncio.timeout(5):
+                await stream_task
+        except (TimeoutError, asyncio.CancelledError):
+            stream_task.cancel()
 
         task_updated_events = [
             e for e in stream_events if e.get("type") == "task_updated"

--- a/agentex/tests/integration/test_task_stream.py
+++ b/agentex/tests/integration/test_task_stream.py
@@ -287,8 +287,6 @@ class TestTaskEventStream:
 
         assert updated_task.current_state == "awaiting_input"
 
-        print("✅ current_state update successfully triggered stream event")
-
     async def test_get_task_returns_updated_metadata_after_stream_update(
         self, test_agent_and_task, tasks_use_case
     ):

--- a/agentex/tests/unit/services/test_task_service.py
+++ b/agentex/tests/unit/services/test_task_service.py
@@ -941,8 +941,7 @@ class TestAgentTaskService:
     async def test_update_task_current_state_publishes_stream_event(
         self, task_service, agent_repository, sample_agent, redis_stream_repository
     ):
-        """update_task persists current_state and carries it on the published
-        task_updated event, so subscribed clients see the new state."""
+        """update_task persists current_state and carries it on the task_updated event."""
         await create_or_get_agent(agent_repository, sample_agent)
         created_task = await task_service.create_task(
             agent=sample_agent, task_name="task-for-current-state"
@@ -967,8 +966,7 @@ class TestAgentTaskService:
     async def test_update_mutable_fields_persists_and_publishes(
         self, task_service, agent_repository, sample_agent, redis_stream_repository
     ):
-        """update_mutable_fields writes only the given columns and publishes a
-        task_updated event carrying them."""
+        """update_mutable_fields persists the given columns and publishes task_updated."""
         await create_or_get_agent(agent_repository, sample_agent)
         created_task = await task_service.create_task(
             agent=sample_agent, task_name="task-for-mutable-fields"
@@ -994,10 +992,9 @@ class TestAgentTaskService:
     async def test_update_mutable_fields_leaves_status_untouched(
         self, task_service, agent_repository, sample_agent, redis_stream_repository
     ):
-        """The primitive is column-scoped: writing current_state does not touch
-        status. (The use-case-level clobber regression — a stale read racing a
-        status transition — is guarded in test_tasks_use_case.py; this only pins
-        that the repository UPDATE sets no columns beyond those supplied.)"""
+        """The primitive is column-scoped: writing current_state leaves status untouched
+        (the use-case stale-read clobber regression is guarded in test_tasks_use_case.py).
+        """
         await create_or_get_agent(agent_repository, sample_agent)
         created_task = await task_service.create_task(
             agent=sample_agent, task_name="task-for-noclobber"

--- a/agentex/tests/unit/services/test_task_service.py
+++ b/agentex/tests/unit/services/test_task_service.py
@@ -964,6 +964,62 @@ class TestAgentTaskService:
         assert event_data["type"] == "task_updated"
         assert event_data["task"]["current_state"] == "working"
 
+    async def test_update_mutable_fields_persists_and_publishes(
+        self, task_service, agent_repository, sample_agent, redis_stream_repository
+    ):
+        """update_mutable_fields writes only the given columns and publishes a
+        task_updated event carrying them."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        created_task = await task_service.create_task(
+            agent=sample_agent, task_name="task-for-mutable-fields"
+        )
+
+        redis_stream_repository.send_data = AsyncMock()
+        result = await task_service.update_mutable_fields(
+            created_task.id,
+            {"current_state": "working", "task_metadata": {"a": 1}},
+        )
+
+        assert result.current_state == "working"
+        assert result.task_metadata == {"a": 1}
+        retrieved = await task_service.get_task(id=created_task.id)
+        assert retrieved.current_state == "working"
+        assert retrieved.task_metadata == {"a": 1}
+
+        redis_stream_repository.send_data.assert_called_once()
+        event_data = redis_stream_repository.send_data.call_args[0][1]
+        assert event_data["type"] == "task_updated"
+        assert event_data["task"]["current_state"] == "working"
+
+    async def test_update_mutable_fields_does_not_clobber_status(
+        self, task_service, agent_repository, sample_agent, redis_stream_repository
+    ):
+        """Regression (blocker): a current_state write must not revert a status
+        changed by another writer. update_mutable_fields is column-scoped, so a
+        task that went terminal is not resurrected to its earlier status."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        created_task = await task_service.create_task(
+            agent=sample_agent, task_name="task-for-noclobber"
+        )
+
+        # Another writer moves the task to a terminal status.
+        await task_service.transition_task_status(
+            task_id=created_task.id,
+            expected_status=TaskStatus.RUNNING,
+            new_status=TaskStatus.COMPLETED,
+            status_reason="done",
+        )
+
+        redis_stream_repository.send_data = AsyncMock()
+        result = await task_service.update_mutable_fields(
+            created_task.id, {"current_state": "late"}
+        )
+
+        assert result.current_state == "late"
+        assert result.status == TaskStatus.COMPLETED
+        retrieved = await task_service.get_task(id=created_task.id)
+        assert retrieved.status == TaskStatus.COMPLETED
+
     async def test_get_task_preserves_task_metadata(
         self, task_service, agent_repository, sample_agent
     ):

--- a/agentex/tests/unit/services/test_task_service.py
+++ b/agentex/tests/unit/services/test_task_service.py
@@ -991,12 +991,13 @@ class TestAgentTaskService:
         assert event_data["type"] == "task_updated"
         assert event_data["task"]["current_state"] == "working"
 
-    async def test_update_mutable_fields_does_not_clobber_status(
+    async def test_update_mutable_fields_leaves_status_untouched(
         self, task_service, agent_repository, sample_agent, redis_stream_repository
     ):
-        """Regression (blocker): a current_state write must not revert a status
-        changed by another writer. update_mutable_fields is column-scoped, so a
-        task that went terminal is not resurrected to its earlier status."""
+        """The primitive is column-scoped: writing current_state does not touch
+        status. (The use-case-level clobber regression — a stale read racing a
+        status transition — is guarded in test_tasks_use_case.py; this only pins
+        that the repository UPDATE sets no columns beyond those supplied.)"""
         await create_or_get_agent(agent_repository, sample_agent)
         created_task = await task_service.create_task(
             agent=sample_agent, task_name="task-for-noclobber"

--- a/agentex/tests/unit/services/test_task_service.py
+++ b/agentex/tests/unit/services/test_task_service.py
@@ -938,6 +938,32 @@ class TestAgentTaskService:
         assert event_data["type"] == "task_updated"
         assert event_data["task"]["task_metadata"] == updated_metadata
 
+    async def test_update_task_current_state_publishes_stream_event(
+        self, task_service, agent_repository, sample_agent, redis_stream_repository
+    ):
+        """update_task persists current_state and carries it on the published
+        task_updated event, so subscribed clients see the new state."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        created_task = await task_service.create_task(
+            agent=sample_agent, task_name="task-for-current-state"
+        )
+
+        created_task.current_state = "working"
+        redis_stream_repository.send_data = AsyncMock()
+
+        result = await task_service.update_task(created_task)
+
+        assert result.current_state == "working"
+        retrieved_task = await task_service.get_task(id=created_task.id)
+        assert retrieved_task.current_state == "working"
+
+        redis_stream_repository.send_data.assert_called_once()
+        call_args = redis_stream_repository.send_data.call_args
+        assert call_args[0][0] == f"task:{created_task.id}"
+        event_data = call_args[0][1]
+        assert event_data["type"] == "task_updated"
+        assert event_data["task"]["current_state"] == "working"
+
     async def test_get_task_preserves_task_metadata(
         self, task_service, agent_repository, sample_agent
     ):

--- a/agentex/tests/unit/services/test_task_service.py
+++ b/agentex/tests/unit/services/test_task_service.py
@@ -992,9 +992,7 @@ class TestAgentTaskService:
     async def test_update_mutable_fields_leaves_status_untouched(
         self, task_service, agent_repository, sample_agent, redis_stream_repository
     ):
-        """The primitive is column-scoped: writing current_state leaves status untouched
-        (the use-case stale-read clobber regression is guarded in test_tasks_use_case.py).
-        """
+        """Writing current_state leaves status untouched (column-scoped update)."""
         await create_or_get_agent(agent_repository, sample_agent)
         created_task = await task_service.create_task(
             agent=sample_agent, task_name="task-for-noclobber"

--- a/agentex/tests/unit/use_cases/test_tasks_use_case.py
+++ b/agentex/tests/unit/use_cases/test_tasks_use_case.py
@@ -675,7 +675,12 @@ class TestTasksUseCaseMetadataUpdate:
         assert updated.status == TaskStatus.RUNNING
 
     async def test_update_current_state_does_not_clobber_concurrent_status(
-        self, tasks_use_case, task_service, task_repository, agent_repository, sample_agent
+        self,
+        tasks_use_case,
+        task_service,
+        task_repository,
+        agent_repository,
+        sample_agent,
     ):
         """Regression: a stale RUNNING read racing a COMPLETED transition must not revert
         status on the current_state write. Fails on the old whole-row merge, passes column-scoped.

--- a/agentex/tests/unit/use_cases/test_tasks_use_case.py
+++ b/agentex/tests/unit/use_cases/test_tasks_use_case.py
@@ -3,6 +3,7 @@ Unit tests for TasksUseCase - status transition logic via explicit status
 methods (complete_task, fail_task, etc.) and metadata updates.
 """
 
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -591,6 +592,101 @@ class TestTasksUseCaseMetadataUpdate:
         # Then
         assert updated.task_metadata == {"stage": "tuned"}
         assert updated.params == {"model": "gpt-4", "temperature": 0.7}
+
+    async def test_update_current_state(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """current_state persists and leaves status/task_metadata untouched."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent,
+            task_name="current-state-test",
+            task_metadata={"keep": "me"},
+        )
+
+        updated = await tasks_use_case.update_mutable_fields_on_task(
+            id=task.id, current_state="working"
+        )
+
+        assert updated.current_state == "working"
+        assert updated.status == TaskStatus.RUNNING
+        assert updated.task_metadata == {"keep": "me"}
+
+    async def test_update_current_state_noop_when_omitted(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """Omitting current_state (the UNSET default) leaves it untouched."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="current-state-omitted-test"
+        )
+        await tasks_use_case.update_mutable_fields_on_task(
+            id=task.id, current_state="set-once"
+        )
+
+        # A later metadata-only update must not clear current_state.
+        updated = await tasks_use_case.update_mutable_fields_on_task(
+            id=task.id, task_metadata={"a": 1}
+        )
+
+        assert updated.current_state == "set-once"
+
+    async def test_update_current_state_clears_on_explicit_null(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """Passing current_state=None explicitly clears the label (vs omitting)."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="current-state-clear-test"
+        )
+        await tasks_use_case.update_mutable_fields_on_task(
+            id=task.id, current_state="working"
+        )
+
+        cleared = await tasks_use_case.update_mutable_fields_on_task(
+            id=task.id, current_state=None
+        )
+
+        assert cleared.current_state is None
+
+    async def test_update_current_state_and_metadata_single_atomic_write(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """Supplying current_state + task_metadata together persists both via a
+        single atomic write (one publish), and does not clobber status."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="current-state-combined-test"
+        )
+
+        spy = AsyncMock(wraps=task_service.update_mutable_fields)
+        task_service.update_mutable_fields = spy
+
+        updated = await tasks_use_case.update_mutable_fields_on_task(
+            id=task.id,
+            task_metadata={"stage": "two"},
+            current_state="working",
+        )
+
+        spy.assert_awaited_once()
+        assert updated.current_state == "working"
+        assert updated.task_metadata == {"stage": "two"}
+        assert updated.status == TaskStatus.RUNNING
+
+    async def test_update_current_state_on_deleted_task_raises(
+        self, tasks_use_case, task_service, agent_repository, sample_agent
+    ):
+        """Updating current_state on a deleted task raises not found."""
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="current-state-deleted-test"
+        )
+        await tasks_use_case.delete_task(id=task.id)
+
+        with pytest.raises(ItemDoesNotExist):
+            await tasks_use_case.update_mutable_fields_on_task(
+                id=task.id, current_state="working"
+            )
 
     async def test_update_metadata_on_deleted_task_raises(
         self, tasks_use_case, task_service, agent_repository, sample_agent

--- a/agentex/tests/unit/use_cases/test_tasks_use_case.py
+++ b/agentex/tests/unit/use_cases/test_tasks_use_case.py
@@ -639,9 +639,12 @@ class TestTasksUseCaseMetadataUpdate:
         task = await task_service.create_task(
             agent=sample_agent, task_name="current-state-clear-test"
         )
-        await tasks_use_case.update_mutable_fields_on_task(
+        was_set = await tasks_use_case.update_mutable_fields_on_task(
             id=task.id, current_state="working"
         )
+        # Confirm it was actually set, so the clear below is a real transition
+        # (not a null→null no-op that would pass trivially).
+        assert was_set.current_state == "working"
 
         cleared = await tasks_use_case.update_mutable_fields_on_task(
             id=task.id, current_state=None
@@ -672,6 +675,48 @@ class TestTasksUseCaseMetadataUpdate:
         assert updated.current_state == "working"
         assert updated.task_metadata == {"stage": "two"}
         assert updated.status == TaskStatus.RUNNING
+
+    async def test_update_current_state_does_not_clobber_concurrent_status(
+        self, tasks_use_case, task_service, task_repository, agent_repository, sample_agent
+    ):
+        """Regression (round-one blocker): a current_state write must not revert a
+        status changed concurrently. Reproduces the exact staleness the old
+        whole-row-merge path needed — the use case reads the entity while RUNNING,
+        the task goes COMPLETED before the write lands, and the write must keep
+        COMPLETED. Fails on the old update_task/merge path (reverts to RUNNING),
+        passes on the column-scoped update.
+        """
+        await create_or_get_agent(agent_repository, sample_agent)
+        task = await task_service.create_task(
+            agent=sample_agent, task_name="current-state-clobber-test"
+        )
+
+        # Snapshot the entity as the use case would have read it, BEFORE the
+        # concurrent transition — this is the stale read the bug wrote back.
+        stale_entity = await task_service.get_task(id=task.id)
+        assert stale_entity.status == TaskStatus.RUNNING
+
+        # Another writer moves the task to a terminal status after that read.
+        await task_service.transition_task_status(
+            task_id=task.id,
+            expected_status=TaskStatus.RUNNING,
+            new_status=TaskStatus.COMPLETED,
+            status_reason="done",
+        )
+
+        # Force the use case to operate on the stale (pre-transition) read.
+        task_service.get_task = AsyncMock(return_value=stale_entity)
+
+        updated = await tasks_use_case.update_mutable_fields_on_task(
+            id=task.id, current_state="late"
+        )
+
+        # The write set current_state without reverting the terminal status.
+        assert updated.current_state == "late"
+        assert updated.status == TaskStatus.COMPLETED
+        persisted = await task_repository.get(id=task.id)
+        assert persisted.status == TaskStatus.COMPLETED
+        assert persisted.current_state == "late"
 
     async def test_update_current_state_on_deleted_task_raises(
         self, tasks_use_case, task_service, agent_repository, sample_agent

--- a/agentex/tests/unit/use_cases/test_tasks_use_case.py
+++ b/agentex/tests/unit/use_cases/test_tasks_use_case.py
@@ -642,8 +642,7 @@ class TestTasksUseCaseMetadataUpdate:
         was_set = await tasks_use_case.update_mutable_fields_on_task(
             id=task.id, current_state="working"
         )
-        # Confirm it was actually set, so the clear below is a real transition
-        # (not a null→null no-op that would pass trivially).
+        # Confirm it was set, so the clear below is a real transition (not a trivial null→null).
         assert was_set.current_state == "working"
 
         cleared = await tasks_use_case.update_mutable_fields_on_task(
@@ -655,8 +654,7 @@ class TestTasksUseCaseMetadataUpdate:
     async def test_update_current_state_and_metadata_single_atomic_write(
         self, tasks_use_case, task_service, agent_repository, sample_agent
     ):
-        """Supplying current_state + task_metadata together persists both via a
-        single atomic write (one publish), and does not clobber status."""
+        """current_state + task_metadata together persist via one atomic write (one publish)."""
         await create_or_get_agent(agent_repository, sample_agent)
         task = await task_service.create_task(
             agent=sample_agent, task_name="current-state-combined-test"
@@ -679,20 +677,15 @@ class TestTasksUseCaseMetadataUpdate:
     async def test_update_current_state_does_not_clobber_concurrent_status(
         self, tasks_use_case, task_service, task_repository, agent_repository, sample_agent
     ):
-        """Regression (round-one blocker): a current_state write must not revert a
-        status changed concurrently. Reproduces the exact staleness the old
-        whole-row-merge path needed — the use case reads the entity while RUNNING,
-        the task goes COMPLETED before the write lands, and the write must keep
-        COMPLETED. Fails on the old update_task/merge path (reverts to RUNNING),
-        passes on the column-scoped update.
+        """Regression: a stale RUNNING read racing a COMPLETED transition must not revert
+        status on the current_state write. Fails on the old whole-row merge, passes column-scoped.
         """
         await create_or_get_agent(agent_repository, sample_agent)
         task = await task_service.create_task(
             agent=sample_agent, task_name="current-state-clobber-test"
         )
 
-        # Snapshot the entity as the use case would have read it, BEFORE the
-        # concurrent transition — this is the stale read the bug wrote back.
+        # Snapshot the entity BEFORE the transition — the stale read the old bug wrote back.
         stale_entity = await task_service.get_task(id=task.id)
         assert stale_entity.status == TaskStatus.RUNNING
 

--- a/agentex/tests/unit/use_cases/test_tasks_use_case.py
+++ b/agentex/tests/unit/use_cases/test_tasks_use_case.py
@@ -662,9 +662,7 @@ class TestTasksUseCaseMetadataUpdate:
         agent_repository,
         sample_agent,
     ):
-        """Regression: a stale RUNNING read racing a COMPLETED transition must not revert
-        status on the current_state write. Fails on the old whole-row merge, passes column-scoped.
-        """
+        """Stale-read race: current_state write must not revert a concurrent status transition."""
         await create_or_get_agent(agent_repository, sample_agent)
         task = await task_service.create_task(
             agent=sample_agent, task_name="current-state-clobber-test"

--- a/agentex/tests/unit/use_cases/test_tasks_use_case.py
+++ b/agentex/tests/unit/use_cases/test_tasks_use_case.py
@@ -615,7 +615,7 @@ class TestTasksUseCaseMetadataUpdate:
     async def test_update_current_state_noop_when_omitted(
         self, tasks_use_case, task_service, agent_repository, sample_agent
     ):
-        """Omitting current_state (the UNSET default) leaves it untouched."""
+        """Omitting current_state leaves an already-set value untouched."""
         await create_or_get_agent(agent_repository, sample_agent)
         task = await task_service.create_task(
             agent=sample_agent, task_name="current-state-omitted-test"
@@ -630,26 +630,6 @@ class TestTasksUseCaseMetadataUpdate:
         )
 
         assert updated.current_state == "set-once"
-
-    async def test_update_current_state_clears_on_explicit_null(
-        self, tasks_use_case, task_service, agent_repository, sample_agent
-    ):
-        """Passing current_state=None explicitly clears the label (vs omitting)."""
-        await create_or_get_agent(agent_repository, sample_agent)
-        task = await task_service.create_task(
-            agent=sample_agent, task_name="current-state-clear-test"
-        )
-        was_set = await tasks_use_case.update_mutable_fields_on_task(
-            id=task.id, current_state="working"
-        )
-        # Confirm it was set, so the clear below is a real transition (not a trivial null→null).
-        assert was_set.current_state == "working"
-
-        cleared = await tasks_use_case.update_mutable_fields_on_task(
-            id=task.id, current_state=None
-        )
-
-        assert cleared.current_state is None
 
     async def test_update_current_state_and_metadata_single_atomic_write(
         self, tasks_use_case, task_service, agent_repository, sample_agent


### PR DESCRIPTION
## Summary

Adds a first-class, opaque `Task.current_state` field so any consumer can read the agent's state-machine position without reinventing it from stream heuristics.

- Nullable `str` (max 255), default-null, orthogonal to `task.status`.
- Written via `PUT /tasks/{id}` through a column-scoped atomic `UPDATE … RETURNING` — can't clobber concurrent `status`/`params` writes.
- Appears on `Task`, `TaskResponse`, `TaskSummary` (list), and the `task_updated` SSE event.
- Additive and backward-compatible: nullable default-null, old servers ignore the new field.

## Why this exists

`task.status` is the Temporal workflow lifecycle — it stays `RUNNING` from task creation until the agent completes, whether the agent is mid-turn or sitting idle waiting for input. Every frontend that needs to answer "is the agent working right now?" has had to reinvent the answer: smuggling state onto the message stream as a `DataContent` marker, inferring from `streaming_status` (which flickers between orchestrator steps), or polling. Those heuristics produce real user-facing bugs — a composer left enabled while the agent is answering, a copy button shown before the response is done.

## How it flows

The agent SDK's `StateMachine` transitions between states (e.g. `IDLE` → `WORKING` → `AWAITING_INPUT`). On each transition, the SDK writes the new state to the platform via `PUT /tasks/{id}` with `{ "current_state": "IDLE" }` — this happens automatically, not something the agent developer calls manually. The platform persists it and publishes a `task_updated` SSE event carrying the full task.

The frontend reads it from the stream it's already consuming — no new endpoint, no new subscription:

```ts
// SSE stream (reactive push — you're already listening to this)
eventSource.addEventListener('message', (e) => {
  const event = JSON.parse(e.data);
  if (event.type === 'task_updated') {
    setAgentState(event.task.current_state); // "IDLE", "WORKING", etc.
  }
});

// Point-read (initial load / reconnect — self-heals a lost SSE event)
const task = await fetch(`/tasks/${taskId}`).then(r => r.json());
setAgentState(task.current_state);
```

**Follow-up:** the SDK-side wiring (StateMachine → `PUT current_state`) is a separate change in agentex-python.

## Changes

| Layer | What |
|-------|------|
| Migration | Idempotent `ADD COLUMN IF NOT EXISTS current_state VARCHAR(255)` |
| ORM | `TaskORM.current_state` column |
| Domain | `TaskEntity.current_state` field |
| Repository | `update_mutable_fields` (allowlisted to `task_metadata`/`current_state`) sharing `_update_returning` with `merge_params` |
| Service | `update_mutable_fields` → `_publish_task_updated` (extracted helper, used by all three write paths) |
| Schemas | `_TaskBase` base class shared by `Task` and `TaskSummary` (DRY); `UpdateTaskRequest.current_state` (bounded) |
| API | Both PUT routes thread `current_state`; `None` = not supplied |
| OpenAPI | Regenerated |

## Test coverage

Route (set / omit / no-clobber / over-length 422), list-shape (summary carries it, still omits `params`), stream (`task_updated` carries `current_state`), service (persist + publish, status no-clobber), use-case (single atomic write, stale-read clobber regression), compat (unknown-field ignore).

## Limitations

Best-effort write — a lost event heals on the next read; a fully-failed write can leave the field stale, and a crashed agent leaves it pinned at its last state (e.g. `WORKING`) indefinitely, since nothing else writes the column. A UI that gates its composer on this field must therefore treat `status` reaching a terminal value as overriding `current_state`. `PUT {"current_state": ""}` clears the label back to null, so a stuck task is recoverable through the API; omitting the field leaves it untouched. Authoritative idle detection (heartbeat/TTL) is still a follow-up.

The column stays opaque so agent-specific states need no platform change, which means the platform will accept a typo'd state as readily as a real one. `KNOWN_CURRENT_STATES` documents the vocabulary the SDK emits today (`IDLE`, `WORKING`, `AWAITING_INPUT`) and it surfaces in the OpenAPI field description; consumers should treat any other value as unknown rather than assuming the set is closed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a nullable, materialized task state label that is atomically persisted and propagated through task reads, summaries, OpenAPI, and `task_updated` stream events.
- Adds the `tasks.current_state` migration and ORM/domain mappings.
- Extends both task update routes with bounded state updates and explicit empty-string clearing.
- Publishes the updated task through the existing Redis-backed SSE path.
- Adds API, service, use-case, and stream regression coverage.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/database/migrations/alembic/versions/2026_07_22_1200_add_task_current_state_b2c3d4e5f6a7.py | Adds a nullable VARCHAR(255) column through an idempotent migration on the repository’s single Alembic head. |
| agentex/src/domain/repositories/task_repository.py | Introduces an allowlisted, column-scoped UPDATE RETURNING path shared with the existing atomic params merge infrastructure. |
| agentex/src/domain/use_cases/tasks_use_case.py | Threads current-state updates through the use case while preserving omitted values and translating an empty string into a null clear. |
| agentex/src/domain/services/task_service.py | Centralizes best-effort task_updated publication and uses it after mutable-field persistence. |
| agentex/src/api/schemas/tasks.py | Adds current_state to full and summary task responses and bounds update requests to the database column width. |
| agentex/src/domain/entities/tasks.py | Adds the domain field and simplifies API-to-domain task conversion; no publishable follow-up finding was established. |
| agentex/openapi.yaml | Regenerates the public task schemas and update request contract with the new state field. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SDK as Agent SDK
    participant API as Tasks API
    participant UC as TasksUseCase
    participant Repo as TaskRepository
    participant PG as PostgreSQL
    participant Redis as Redis Stream
    participant Client as SSE Client
    SDK->>API: "PUT /tasks/{id} current_state"
    API->>UC: update_mutable_fields_on_task
    UC->>Repo: update_mutable_fields
    Repo->>PG: UPDATE current_state RETURNING task
    PG-->>Repo: Updated TaskEntity
    Repo-->>UC: Updated TaskEntity
    UC->>Redis: Publish task_updated
    Redis-->>Client: Full task with current_state
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(agentex): allow clearing current\_st..."](https://github.com/scaleapi/scale-agentex/commit/ceec152565c8fe51d1062034d8d051a03e1106d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53824897)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Agentex task execution, persistence, and live streaming](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/backend-task-streaming.md)
- Knowledge Base — [Persistence and storage](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/persistence-and-storage.md)
- Knowledge Base — [Backend API and request pipeline](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/backend-api-and-request-pipeline.md)
- Knowledge Base — [Repository Operations and Delivery](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/repository-operations-and-delivery.md)
</details>

<!-- /greptile_comment -->