### PR TITLE
fix(authz): fall back to body principal in _register_in_auth

### DIFF
--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -220,6 +220,9 @@ async def register_agent(
             acp_type=request.acp_type,
             registration_metadata=request.registration_metadata,
             agent_input_type=request.agent_input_type,
+            # Same fallback as check/grant above: the use case prefers the
+            # middleware principal and only reads this on the whitelisted path.
+            body_principal_context=request.principal_context,
         )
         if enforce_ownership:
             await authorization_service.grant(

--- a/agentex/src/domain/use_cases/agents_use_case.py
+++ b/agentex/src/domain/use_cases/agents_use_case.py
@@ -57,7 +57,11 @@ class AgentsUseCase:
                 "authorization deregister failed for agent %s; swallowed", agent_id
             )
 
-    async def _register_in_auth(self, agent_id: str) -> bool:
+    async def _register_in_auth(
+        self,
+        agent_id: str,
+        body_principal_context: Any = None,
+    ) -> bool:
         """Register a newly created agent in the authorization graph.
 
         Called before the row is persisted so a failure aborts the create with no
@@ -67,28 +71,49 @@ class AgentsUseCase:
         ownership and there is nothing to attribute it to. Returns whether a
         register call was actually made so compensation can avoid deregistering
         a resource it never registered.
+
+        Prefer the middleware-derived principal (an authenticated user or service
+        account). The whitelisted ``/agents/register`` path clears the middleware
+        principal; the pod SDK ships the manifest-declared identity in the request
+        body instead, and ``body_principal_context`` carries that through so
+        ownership can still be minted from the manifest identity. Mirrors the
+        route-layer fallback the ``register_agent`` route applies to
+        ``check``/``grant``.
         """
         principal_context = self.authorization_service.principal_context
-        # principal_context is `Any` (a dict from /v1/authn), not a typed model,
-        # so attribute access via getattr always yields None and silently skips
-        # the Spark resource registration. Read from the dict (fall back to attr
-        # access for any object-shaped principal).
-        if isinstance(principal_context, dict):
-            user_id = principal_context.get("user_id")
-            service_account_id = principal_context.get("service_account_id")
-        else:
-            user_id = getattr(principal_context, "user_id", None)
-            service_account_id = getattr(principal_context, "service_account_id", None)
-        if user_id is None and service_account_id is None:
+        if not self._has_resolvable_creator(principal_context):
+            principal_context = body_principal_context
+        if not self._has_resolvable_creator(principal_context):
             logger.warning(
                 "Skipping authorization registration for agent: no creator resolvable",
                 extra={"agent_id": agent_id},
             )
             return False
         await self.authorization_service.register_resource(
-            AgentexResource.agent(agent_id)
+            AgentexResource.agent(agent_id),
+            principal_context=principal_context,
         )
         return True
+
+    @staticmethod
+    def _has_resolvable_creator(principal_context: Any) -> bool:
+        """Whether a creator identity (user or service account) is present.
+
+        ``principal_context`` is ``Any`` (dict from ``/v1/authn`` or an object
+        for tests), so attribute access via getattr on a dict always yields
+        None. Read from the dict when applicable, fall back to attr access.
+        """
+        if principal_context is None:
+            return False
+        if isinstance(principal_context, dict):
+            return bool(
+                principal_context.get("user_id")
+                or principal_context.get("service_account_id")
+            )
+        return bool(
+            getattr(principal_context, "user_id", None)
+            or getattr(principal_context, "service_account_id", None)
+        )
 
     async def register_agent(
         self,
@@ -99,6 +124,7 @@ class AgentsUseCase:
         acp_type: ACPType = ACPType.ASYNC,
         registration_metadata: dict[str, Any] | None = None,
         agent_input_type: AgentInputType | None = None,
+        body_principal_context: Any = None,
     ) -> AgentEntity:
         deployment_id = (registration_metadata or {}).get("deployment_id")
 
@@ -208,7 +234,9 @@ class AgentsUseCase:
             # failure here aborts the create with no orphaned row. Only the
             # genuine-create path registers — the update paths above must not,
             # or re-registering would rewrite the owner to the current caller.
-            registered_in_auth = await self._register_in_auth(agent.id)
+            registered_in_auth = await self._register_in_auth(
+                agent.id, body_principal_context=body_principal_context
+            )
             # This is a problem only if multiple pods spin up and then make a request all at the same time.
             # In that case, the first pod will create the agent and the rest should succeed silently
             try:

--- a/agentex/src/domain/use_cases/agents_use_case.py
+++ b/agentex/src/domain/use_cases/agents_use_case.py
@@ -42,16 +42,19 @@ class AgentsUseCase:
         self.authorization_service = authorization_service
 
     async def _safe_deregister(
-        self, agent_id: str, principal_context: Any = None
+        self, agent_id: str, principal_context: Any = ...
     ) -> None:
         """Best-effort removal of an agent from the authorization graph.
 
         Swallows and logs any failure so a compensating/post-delete deregister
         never masks the in-flight error (create) or fails a delete that already
-        succeeded. ``principal_context`` should be the same resolved principal
-        that was used for the preceding ``register_resource`` call so that
-        register and deregister are symmetric on all paths (including the
-        whitelisted pod path where the middleware principal is None).
+        succeeded. When ``principal_context`` is passed explicitly, use the same
+        resolved principal that was used for the preceding ``register_resource``
+        call so register and deregister are symmetric on all paths (including
+        the whitelisted pod path where the middleware principal is None). The
+        default forwards ``AuthorizationService``'s Ellipsis sentinel so the
+        middleware principal is used; a ``None`` default would defeat that
+        fallback and reach the gateway as-is.
         """
         try:
             await self.authorization_service.deregister_resource(

--- a/agentex/src/domain/use_cases/agents_use_case.py
+++ b/agentex/src/domain/use_cases/agents_use_case.py
@@ -41,16 +41,22 @@ class AgentsUseCase:
         self.temporal_adapter = temporal_adapter
         self.authorization_service = authorization_service
 
-    async def _safe_deregister(self, agent_id: str) -> None:
+    async def _safe_deregister(
+        self, agent_id: str, principal_context: Any = None
+    ) -> None:
         """Best-effort removal of an agent from the authorization graph.
 
         Swallows and logs any failure so a compensating/post-delete deregister
         never masks the in-flight error (create) or fails a delete that already
-        succeeded.
+        succeeded. ``principal_context`` should be the same resolved principal
+        that was used for the preceding ``register_resource`` call so that
+        register and deregister are symmetric on all paths (including the
+        whitelisted pod path where the middleware principal is None).
         """
         try:
             await self.authorization_service.deregister_resource(
-                AgentexResource.agent(agent_id)
+                AgentexResource.agent(agent_id),
+                principal_context=principal_context,
             )
         except Exception:
             logger.exception(
@@ -61,16 +67,16 @@ class AgentsUseCase:
         self,
         agent_id: str,
         body_principal_context: Any = None,
-    ) -> bool:
+    ) -> tuple[bool, Any]:
         """Register a newly created agent in the authorization graph.
 
         Called before the row is persisted so a failure aborts the create with no
         orphaned row; the _safe_deregister compensation undoes it. Skipped with a
         warning when no creator identity is resolvable on the principal context:
         an agent has no parent edge, so the principal is the sole anchor for
-        ownership and there is nothing to attribute it to. Returns whether a
-        register call was actually made so compensation can avoid deregistering
-        a resource it never registered.
+        ownership and there is nothing to attribute it to. Returns a tuple of
+        (registered, resolved_principal_context) so the caller can pass the same
+        principal to _safe_deregister — keeping register and deregister symmetric.
 
         Prefer the middleware-derived principal (an authenticated user or service
         account). The whitelisted ``/agents/register`` path clears the middleware
@@ -88,12 +94,12 @@ class AgentsUseCase:
                 "Skipping authorization registration for agent: no creator resolvable",
                 extra={"agent_id": agent_id},
             )
-            return False
+            return False, None
         await self.authorization_service.register_resource(
             AgentexResource.agent(agent_id),
             principal_context=principal_context,
         )
-        return True
+        return True, principal_context
 
     @staticmethod
     def _has_resolvable_creator(principal_context: Any) -> bool:
@@ -234,7 +240,7 @@ class AgentsUseCase:
             # failure here aborts the create with no orphaned row. Only the
             # genuine-create path registers — the update paths above must not,
             # or re-registering would rewrite the owner to the current caller.
-            registered_in_auth = await self._register_in_auth(
+            registered_in_auth, resolved_principal = await self._register_in_auth(
                 agent.id, body_principal_context=body_principal_context
             )
             # This is a problem only if multiple pods spin up and then make a request all at the same time.
@@ -249,11 +255,15 @@ class AgentsUseCase:
                 # registration and re-fetch the persisted agent so downstream
                 # code (complete_deployment_registration) uses the correct agent_id
                 if registered_in_auth:
-                    await self._safe_deregister(agent.id)
+                    await self._safe_deregister(
+                        agent.id, principal_context=resolved_principal
+                    )
                 agent = await self.agent_repo.get(name=name)
             except Exception:
                 if registered_in_auth:
-                    await self._safe_deregister(agent.id)
+                    await self._safe_deregister(
+                        agent.id, principal_context=resolved_principal
+                    )
                 raise
         await self.complete_deployment_registration(
             agent, acp_url, registration_metadata
@@ -304,7 +314,7 @@ class AgentsUseCase:
         # Record ownership before persisting, same as register_agent's genuine
         # create branch. The early return above for an existing agent means we
         # only ever register on a true first-time build create.
-        registered_in_auth = await self._register_in_auth(agent.id)
+        registered_in_auth, resolved_principal = await self._register_in_auth(agent.id)
         # If multiple builds for the same new agent race, the first wins and the
         # rest re-fetch the persisted row instead of erroring.
         try:
@@ -315,11 +325,15 @@ class AgentsUseCase:
             )
             # undo our ownership registration from _register_in_auth
             if registered_in_auth:
-                await self._safe_deregister(agent.id)
+                await self._safe_deregister(
+                    agent.id, principal_context=resolved_principal
+                )
             agent = await self.agent_repo.get(name=name)
         except Exception:
             if registered_in_auth:
-                await self._safe_deregister(agent.id)
+                await self._safe_deregister(
+                    agent.id, principal_context=resolved_principal
+                )
             raise
         return agent
 

--- a/agentex/tests/integration/use_cases/test_agent_authz_dual_write.py
+++ b/agentex/tests/integration/use_cases/test_agent_authz_dual_write.py
@@ -96,7 +96,7 @@ class TestAgentRegisterOnCreate:
         # what makes a registration failure abort the request cleanly.
         observed = {}
 
-        async def _record_existence(resource, parent=None):
+        async def _record_existence(resource, parent=None, *, principal_context=None):
             observed["row_exists_at_register"] = await _agent_exists(
                 agent_repo, resource.selector
             )

--- a/agentex/tests/integration/use_cases/test_agent_authz_dual_write.py
+++ b/agentex/tests/integration/use_cases/test_agent_authz_dual_write.py
@@ -264,6 +264,72 @@ class TestAgentRegisterOnCreate:
         authorization_service.grant.assert_not_awaited()
         authorization_service.revoke.assert_not_awaited()
 
+    async def test_create_falls_back_to_body_principal_when_middleware_missing(
+        self,
+    ):
+        # Pod self-registration via whitelisted /agents/register clears the
+        # middleware principal, so the SDK ships the manifest-declared identity
+        # in the request body. The use case must accept that body principal so
+        # ownership is still minted from the manifest identity — otherwise the
+        # agent registers but has no owner tuple and is invisible to the UI.
+        agent_repo = Mock()
+        agent_repo.get = AsyncMock(side_effect=ItemDoesNotExist("absent"))
+        agent_repo.create = AsyncMock(side_effect=lambda item: item)
+        use_case, authorization_service = _build_use_case(
+            agent_repository=agent_repo,
+            principal=_principal(user_id=None, service_account_id=None),
+        )
+
+        # Dict shape matches what /v1/authn returns and what the SDK decodes
+        # from AUTH_PRINCIPAL_B64 (see scale-agentex-python registration.py).
+        body_principal = {
+            "service_account_id": "sa-from-manifest",
+            "account_id": "acct-1",
+        }
+
+        agent = await use_case.register_agent(
+            name=f"dw-body-fallback-{uuid4().hex[:8]}",
+            description="body principal fallback",
+            acp_url="http://new-acp",
+            body_principal_context=body_principal,
+        )
+
+        authorization_service.register_resource.assert_awaited_once()
+        call = authorization_service.register_resource.call_args
+        registered_resource: AgentexResource = call.args[0]
+        assert registered_resource.type == AgentexResourceType.agent
+        assert registered_resource.selector == agent.id
+        # The body principal must be forwarded to the gateway so it doesn't
+        # fall back to the (unset) middleware principal.
+        assert call.kwargs.get("principal_context") == body_principal
+
+    async def test_middleware_principal_takes_precedence_over_body(self):
+        # An authenticated caller (via CLI/UI) sets the middleware principal.
+        # Even if a body principal is also sent, the authenticated identity
+        # from the middleware must win — the body is only a fallback for the
+        # whitelisted pod path.
+        agent_repo = Mock()
+        agent_repo.get = AsyncMock(side_effect=ItemDoesNotExist("absent"))
+        agent_repo.create = AsyncMock(side_effect=lambda item: item)
+        middleware_principal = _principal(user_id="user-from-middleware")
+        use_case, authorization_service = _build_use_case(
+            agent_repository=agent_repo,
+            principal=middleware_principal,
+        )
+
+        body_principal = {"service_account_id": "sa-should-not-win"}
+
+        await use_case.register_agent(
+            name=f"dw-middleware-wins-{uuid4().hex[:8]}",
+            description="middleware principal wins",
+            acp_url="http://new-acp",
+            body_principal_context=body_principal,
+        )
+
+        authorization_service.register_resource.assert_awaited_once()
+        call = authorization_service.register_resource.call_args
+        assert call.kwargs.get("principal_context") is middleware_principal
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio

--- a/agentex/tests/integration/use_cases/test_agent_authz_dual_write.py
+++ b/agentex/tests/integration/use_cases/test_agent_authz_dual_write.py
@@ -199,6 +199,37 @@ class TestAgentRegisterOnCreate:
         compensated = authorization_service.deregister_resource.call_args.args[0]
         assert compensated.selector == registered.selector
 
+    async def test_duplicate_compensates_with_body_principal_on_whitelisted_path(self):
+        # Whitelisted path: middleware principal is None, body principal used for
+        # register. Compensation deregister must forward the same body principal —
+        # not None — so register and deregister are symmetric.
+        existing = _existing_agent(f"dw-dup-body-{uuid4().hex[:8]}")
+        agent_repo = Mock()
+        agent_repo.get = AsyncMock(side_effect=[ItemDoesNotExist("absent"), existing])
+        agent_repo.create = AsyncMock(side_effect=DuplicateItemError("exists"))
+        use_case, authorization_service = _build_use_case(
+            agent_repository=agent_repo,
+            principal=_principal(user_id=None, service_account_id=None),
+        )
+
+        body_principal = {
+            "service_account_id": "sa-from-manifest",
+            "account_id": "acct-1",
+        }
+
+        result = await use_case.register_agent(
+            name=existing.name,
+            description="dup on whitelisted path",
+            acp_url="http://new-acp",
+            body_principal_context=body_principal,
+        )
+
+        assert result.id == existing.id
+        authorization_service.register_resource.assert_awaited_once()
+        authorization_service.deregister_resource.assert_awaited_once()
+        deregister_call = authorization_service.deregister_resource.call_args
+        assert deregister_call.kwargs.get("principal_context") == body_principal
+
     async def test_update_path_does_not_register(self):
         # register_agent called with an agent_id is an update, not a create: it
         # must NOT register, or ownership would be rewritten to the caller.


### PR DESCRIPTION
## Summary

The whitelisted `/agents/register` path clears the middleware principal. The pod SDK ships the manifest-declared identity in the request body, but `_register_in_auth` was still reading only from the middleware and silently skipping ownership registration. This threads the body-supplied principal into the use case as a fallback, mirroring what #325 (`cae5f94`) already did for the route's `check`/`grant` fallback.

Symptom pre-fix: agent registration succeeds, no error logs, WARN `Skipping authorization registration for agent: no creator resolvable` fires at `agents_use_case.py:83`, and the agent has no owner tuple in `agentex_permissions` — invisible to the SGP UI listing.

## Root cause

Bisected across three commits on the same code path:

| Commit | Date | What it did |
|---|---|---|
| `14796e9` (#270) | Jun 3 | Moved ownership registration into `_register_in_auth`, keyed off `self.authorization_service.principal_context`. |
| `63f89e7` (#292) | Jun 9 | Route-layer `_has_resolvable_creator` guard — skips `check`/`grant` when middleware principal is missing (i.e. the whitelisted pod path). |
| `cae5f94` (#325) | Jun 18 | Route-layer fallback to the body's `principal_context` for `check`/`grant`. |

`cae5f94` recovered ownership grants for authenticated CLI/UI callers via the route layer, but the use case's `register_resource` call inside `_register_in_auth` was still reading only from the middleware. Result: every pod-based deploy since Jun 3 that lands on the whitelisted route lost its owner tuple.

## What this change does

1. `agentex/src/domain/use_cases/agents_use_case.py`
   - `_register_in_auth` accepts an optional `body_principal_context` and uses it as fallback when the middleware principal isn't resolvable. Passes the resolved principal explicitly to `register_resource(..., principal_context=...)` so it doesn't silently default to the (None) middleware principal.
   - Extracts the dict-vs-object identity check into a private `_has_resolvable_creator` staticmethod (same shape as the one in `agents.py:53`).
   - `register_agent` accepts and forwards `body_principal_context`.
2. `agentex/src/api/routes/agents.py`
   - Route passes `body_principal_context=request.principal_context` when calling the use case, matching the precedence already applied to `check`/`grant`.
3. `agentex/tests/integration/use_cases/test_agent_authz_dual_write.py`
   - `test_create_falls_back_to_body_principal_when_middleware_missing` — covers the whitelisted pod path with a body-supplied service account.
   - `test_middleware_principal_takes_precedence_over_body` — regression guard confirming authenticated CLI/UI callers keep using the middleware identity.

## What this change does NOT do

- `register_build` is intentionally left alone. That route isn't whitelisted, so the middleware principal is always set for legitimate callers — there's no trigger for the fallback there. Keeping the fix scoped to the actual regression.
- `_has_resolvable_creator` is now duplicated between `agents.py` (route) and `agents_use_case.py` (use case). De-duping into a shared util would be an unrelated refactor and would need to sit somewhere neutral (not in `api/`, since the domain shouldn't import from it). Happy to do that in a follow-up if a reviewer prefers.

## Symptom (from Rocket beta)

<img width="3024" height="1492" alt="image" src="https://github.com/user-attachments/assets/ee5c0211-96d1-43f3-a191-2b2fa64294ae" />


The manifest for this agent declared a valid service account:

```yaml
auth:
  principal:
    service_account_id: {{SERVICE_ACCOUNT_ID}}
    account_id: {{ACCOUNT_ID}}
```

The SDK correctly base64-encodes this into `AUTH_PRINCIPAL_B64` and ships it in the register body's `principal_context` field (see `scale-agentex-python/src/agentex/lib/utils/registration.py`). The service was just not reading it in `_register_in_auth`.

Manual backfill of the `agentex_permissions` row (via `POST /private/v5/agentex/permissions` on egp-api-backend) restored visibility, confirming the SGP permissions row is what was missing.

## Test plan

- [x] New: `test_create_falls_back_to_body_principal_when_middleware_missing`
- [x] New: `test_middleware_principal_takes_precedence_over_body`
- [x] Existing 7 Mock-based tests in `TestAgentRegisterOnCreate` still pass locally (9/9 passed, 6 Docker-only tests deselected)
- [ ] Verify on beta: deploy a fresh agent from a Rocket manifest, confirm the `agentex_permissions` row is written automatically (no manual backfill required) and the agent shows up in the SGP UI listing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a missing body-principal fallback in `_register_in_auth` that caused pod self-registrations on the whitelisted `/agents/register` path to silently skip the `agentex_permissions` ownership write, leaving agents invisible to the SGP UI. It mirrors the same fallback that commit `cae5f94` (#325) already applied to the route-layer `check`/`grant` calls.

- `_register_in_auth` now falls back to `body_principal_context` when `authorization_service.principal_context` is unresolvable, and passes the resolved principal explicitly to `register_resource` so the middleware-None path is no longer silently bypassed.
- `_safe_deregister` was updated to accept an explicit `principal_context` (defaulting to the `...` Ellipsis sentinel that `AuthorizationService` already uses to mean "use middleware") so register and deregister remain symmetric on all paths, including duplicate-race compensation.
- Three new integration tests cover the body-principal fallback, compensation symmetry on the whitelisted path, and middleware-principal precedence.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge. The change is narrowly scoped to the whitelisted pod registration path and does not affect any authenticated caller flows.
- The root cause is clearly identified and the fix is minimal: a two-level fallback (`middleware → body → skip`) that mirrors a pattern already validated in the route layer. The `...` Ellipsis sentinel is correctly propagated as the default for `_safe_deregister`, preserving the middleware-principal behavior on the delete path. All three compensation branches (register failure, persist failure, duplicate race) are symmetric with the resolved principal, and the new integration tests directly exercise the whitelisted-path scenario, the compensation case, and the precedence rule.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/agents_use_case.py | Core fix: `_register_in_auth` now falls back to `body_principal_context` when the middleware principal is unresolvable, and passes the resolved principal explicitly to `register_resource`; `_safe_deregister` correctly uses `...` as its default sentinel; `_has_resolvable_creator` extracted as a clean static method. All compensation paths (`DuplicateItemError` and general `Exception`) are symmetric with the new resolved principal. |
| agentex/src/api/routes/agents.py | One-line addition: forwards `body_principal_context=request.principal_context` to the use case, mirroring the same fallback already applied to `check`/`grant`. Minimal and correct. |
| agentex/tests/integration/use_cases/test_agent_authz_dual_write.py | Three new tests cover the whitelisted-path fallback, register/deregister symmetry with body principal on duplicate race, and middleware-principal precedence. The `_record_existence` side-effect correctly gains `*, principal_context=None` to match the new kwarg. Existing tests remain unaffected. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SDK as Pod SDK
    participant Route as agents.py (route)
    participant UC as AgentsUseCase
    participant Auth as AuthorizationService

    Note over Route: middleware_principal = None (whitelisted path)
    SDK->>Route: "POST /agents/register (body: principal_context={service_account_id:…})"
    Route->>Route: _has_resolvable_creator(middleware_principal) → False
    Route->>Route: "principal_context = request.principal_context (body fallback)"
    Route->>Route: "enforce_ownership = True"
    Route->>Auth: "check(agent:*, CREATE, principal_context=body_principal)"
    Route->>UC: "register_agent(…, body_principal_context=body_principal)"
    UC->>UC: _register_in_auth(agent_id, body_principal_context)
    UC->>UC: _has_resolvable_creator(middleware_principal) → False
    UC->>UC: "principal_context = body_principal_context"
    UC->>Auth: "register_resource(agent:id, principal_context=body_principal)"
    UC-->>Route: "agent_entity, resolved_principal=body_principal"
    Route->>Auth: "grant(agent:id, principal_context=body_principal)"
    Route-->>SDK: RegisterAgentResponse

    Note over UC: On DuplicateItemError compensation:
    UC->>Auth: "deregister_resource(agent:id, principal_context=resolved_principal)"
```
</details>

<sub>Reviews (8): Last reviewed commit: ["Merge branch &#39;main&#39; into akam/fix-authz-..."](https://github.com/scaleapi/scale-agentex/commit/17a4dc40c6e19530181d12fe51946c4228ab3d69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46529087)</sub>

<!-- /greptile_comment -->