### PR TITLE
feat(otel): add Datadog fan-out collector config + local traces pipeline

### DIFF
--- a/agentex/otel/otel-collector-config.datadog.yaml
+++ b/agentex/otel/otel-collector-config.datadog.yaml
@@ -1,0 +1,76 @@
+# OpenTelemetry Collector configuration WITH Datadog fan-out.
+#
+# Duplicates traces and metrics to BOTH the LGTM path (Prometheus / Tempo) and
+# Datadog. This is the "collector sink" phase of the ddtrace -> LGTM migration:
+# once the app stops emitting to Datadog directly via ddtrace, the collector
+# keeps Datadog fed, so there is no gap in Datadog coverage.
+#
+# Because a single OTel SDK produces the spans, the SAME trace_id is exported to
+# both backends -- one trace, two destinations.
+#
+# Requirements / usage:
+#   - Uses the otel/opentelemetry-collector-contrib image (datadog exporter),
+#     which docker-compose already runs.
+#   - Set DD_API_KEY (required) and optionally DD_SITE (default datadoghq.com).
+#   - Optionally set TEMPO_OTLP_ENDPOINT to also fan traces out to Tempo; if
+#     unset, the Tempo exporter is simply not referenced (see pipelines below).
+#   - Enable by mounting THIS file at /etc/otel-collector-config.yaml instead of
+#     otel-collector-config.yaml (docker-compose volume / --config).
+#
+# This file is OPT-IN and does not change the default (keyless) local collector.
+# It is also the reference pattern for the Helm-managed production collector.
+#
+# IMPORTANT (migration safety): deploy + verify this Datadog fan-out in an
+# environment BEFORE disabling app-side ddtrace there. Never remove the app's
+# Datadog source until the collector is confirmed exporting to Datadog, or that
+# environment loses traces.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+exporters:
+  debug:
+    verbosity: normal
+
+  # LGTM metrics path.
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    namespace: agentex
+    send_timestamps: true
+    metric_expiration: 5m
+
+  # Datadog fan-out. Traces + metrics are duplicated here in addition to the
+  # LGTM path, so Datadog is fed by the collector rather than by app ddtrace.
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: ${env:DD_SITE:-datadoghq.com}
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    # Traces fan out to Datadog (and console). Add an OTLP/Tempo exporter here
+    # when a Tempo endpoint is available to also feed the LGTM trace backend.
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog, debug]
+    # Metrics fan out to both the LGTM (Prometheus) path and Datadog.
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, datadog, debug]

--- a/agentex/otel/otel-collector-config.yaml
+++ b/agentex/otel/otel-collector-config.yaml
@@ -1,5 +1,10 @@
 # OpenTelemetry Collector configuration for local development
-# Receives OTLP metrics and exports to console + Prometheus
+# Receives OTLP metrics + traces and exports to console + Prometheus.
+#
+# For the Datadog fan-out variant (exports to Datadog in addition to the LGTM
+# path -- used during the ddtrace -> LGTM migration so Datadog keeps receiving
+# telemetry once the app stops emitting via ddtrace directly), see
+# otel-collector-config.datadog.yaml.
 
 receivers:
   otlp:
@@ -39,3 +44,7 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [debug, prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]


### PR DESCRIPTION
## What this PR does
Adds the **Datadog fan-out** for the OTel Collector — the "collector sink" phase of the ddtrace → LGTM migration.

- **New `agentex/otel/otel-collector-config.datadog.yaml`** — opt-in collector config that duplicates **traces + metrics** to *both* the LGTM path (Prometheus/Tempo) and **Datadog** (`datadog` exporter). One OTel SDK produces the spans, so the **same `trace_id`** is exported to both backends.
- **`agentex/otel/otel-collector-config.yaml`** — adds a **`traces` pipeline** to the default local config (it previously had metrics only), so OTel traces emitted by the app are handled locally instead of dropped.

## Why
Once the app stops emitting to Datadog directly via `ddtrace` (later in the migration), Datadog must be fed *somewhere* or coverage goes dark. Feeding it from the collector keeps Datadog whole while the app moves to a single OTel SDK.

## Safety / rollout
- **Opt-in:** the fan-out lives in a separate file (mount it instead of the default). Requires `DD_API_KEY` (+ optional `DD_SITE`, default `datadoghq.com`). The default local collector stays keyless and unchanged.
- Uses the `otel/opentelemetry-collector-contrib` image already run by docker-compose (datadog exporter included).
- **Migration invariant (documented in the file header):** deploy + verify this fan-out in an environment **before** disabling app-side ddtrace there — never remove the app's Datadog source until the collector is confirmed exporting to Datadog, or that environment loses traces (this is especially important for customer VPCs).
- Reference pattern for the Helm-managed production collector (prod collector config is not in this repo).

## Verification
Both YAML files parse; pipelines/exporters confirmed (`metrics`/`traces` present; `datadog` exporter wired into both pipelines in the fan-out file).

## Follow-up (not in this PR)
Add an OTLP/Tempo trace exporter to the fan-out `traces` pipeline once a Tempo endpoint is available (placeholder documented in the file).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR advances the ddtrace → LGTM migration by adding an opt-in OTel Collector config (`otel-collector-config.datadog.yaml`) that fans traces and metrics to both Datadog and the LGTM stack from a single OTel SDK, and by wiring up a `traces` pipeline in the default local collector config that previously only handled metrics.

- **New Datadog fan-out file** — defines `otlp` receiver, `batch` processor, and `prometheus` + `datadog` + `debug` exporters; both `traces` and `metrics` pipelines are populated. Requires `DD_API_KEY`; `DD_SITE` defaults to `datadoghq.com`. Intended as the reference pattern for the Helm-managed production collector.
- **Default local config** — gains a `traces` pipeline (receiver → batch → debug) so OTel traces are no longer silently dropped during local development.
- **Safety invariant documented** — the file header calls out explicitly that this fan-out must be deployed and verified *before* disabling app-side ddtrace in any environment.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the Datadog fan-out is completely opt-in and the default local config change is additive only.

The two files are YAML-only config changes with no code execution risk. The local config addition (traces pipeline) is trivially correct. The Datadog fan-out file is well-structured and the migration safety note is explicit. Two quality issues are worth addressing before this file is promoted to staging: the misleading TEMPO_OTLP_ENDPOINT comment that implies conditional logic not yet implemented, and the debug exporter lacking the sampling guard that the local config uses — omitting it will produce unsampled console output for every span and metric in production deployments.

agentex/otel/otel-collector-config.datadog.yaml — the TEMPO_OTLP_ENDPOINT comment and the unsampled debug exporter warrant a second look before this file is mounted in staging or used as the Helm reference.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/otel/otel-collector-config.datadog.yaml | New opt-in Datadog fan-out collector config; well-structured with two issues: a misleading TEMPO_OTLP_ENDPOINT comment implying conditional behaviour that isn't implemented, and missing debug-exporter sampling that the local config applies. |
| agentex/otel/otel-collector-config.yaml | Adds a traces pipeline (receivers → batch processor → debug exporter) to the existing local collector config; straightforward and correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    App["App (OTel SDK)"]

    subgraph Default["Default Local Collector (otel-collector-config.yaml)"]
        OTLPLocal["OTLP Receiver\n(gRPC :4317 / HTTP :4318)"]
        BatchLocal["batch processor"]
        DebugLocal["debug exporter\n(verbosity: detailed + sampling)"]
        PromLocal["prometheus exporter\n(:8889)"]
        OTLPLocal --> BatchLocal
        BatchLocal -->|metrics| DebugLocal
        BatchLocal -->|metrics| PromLocal
        BatchLocal -->|traces| DebugLocal
    end

    subgraph Fanout["Datadog Fan-out Collector (otel-collector-config.datadog.yaml)"]
        OTLPFan["OTLP Receiver\n(gRPC :4317 / HTTP :4318)"]
        BatchFan["batch processor"]
        DebugFan["debug exporter\n(verbosity: normal)"]
        PromFan["prometheus exporter\n(:8889)"]
        DDExp["datadog exporter\n(DD_API_KEY + DD_SITE)"]
        OTLPFan --> BatchFan
        BatchFan -->|metrics| PromFan
        BatchFan -->|metrics| DDExp
        BatchFan -->|metrics| DebugFan
        BatchFan -->|traces| DDExp
        BatchFan -->|traces| DebugFan
    end

    App -->|"OTLP (local dev)"| OTLPLocal
    App -->|"OTLP (staging/prod opt-in)"| OTLPFan
    DDExp -->|"Datadog API"| DD[("Datadog")]
    PromFan --> Grafana[("Grafana / Prometheus")]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fotel%2Fotel-collector-config.datadog.yaml%3A15-16%0A**TEMPO_OTLP_ENDPOINT%20comment%20implies%20conditional%20behaviour%20that%20doesn't%20exist**%0A%0AThe%20requirements%20header%20says%20%22Optionally%20set%20%60TEMPO_OTLP_ENDPOINT%60%20to%20also%20fan%20traces%20out%20to%20Tempo%3B%20if%20unset%2C%20the%20Tempo%20exporter%20is%20simply%20not%20referenced.%22%20However%2C%20no%20%60otlp%2Ftempo%60%20exporter%20is%20defined%20in%20%60exporters%3A%60%20and%20no%20pipeline%20references%20it%20%E2%80%94%20the%20env%20var%20does%20nothing%20right%20now.%20An%20operator%20who%20reads%20this%2C%20sets%20%60TEMPO_OTLP_ENDPOINT%60%2C%20and%20deploys%20will%20get%20silent%20loss%20of%20the%20expected%20Tempo%20routing%20with%20no%20error%20from%20the%20collector.%20The%20phrase%20%22if%20unset%2C%20the%20Tempo%20exporter%20is%20simply%20not%20referenced%22%20actively%20suggests%20conditional%20logic%20that%20doesn't%20exist%20yet.%20Consider%20rewording%20to%20%22Tempo%20fan-out%20is%20not%20yet%20implemented%20%E2%80%94%20see%20follow-up%20ticket%22%20to%20avoid%20the%20false%20impression.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fotel%2Fotel-collector-config.datadog.yaml%3A42-43%0A**Debug%20exporter%20lacks%20sampling%20%E2%80%94%20will%20log%20every%20span%20and%20metric%20in%20production**%0A%0AThe%20local%20config%20%28%60otel-collector-config.yaml%60%29%20configures%20%60sampling_initial%3A%205%60%20and%20%60sampling_thereafter%3A%20200%60%20on%20the%20%60debug%60%20exporter%2C%20capping%20console%20output%20at%20about%201-in-200%20records%20after%20warmup.%20The%20Datadog%20fan-out%20config%2C%20described%20as%20%22the%20reference%20pattern%20for%20the%20Helm-managed%20production%20collector%2C%22%20omits%20those%20settings.%20With%20%60verbosity%3A%20normal%60%2C%20every%20span%20in%20the%20%60traces%60%20pipeline%20and%20every%20metric%20data%20point%20in%20the%20%60metrics%60%20pipeline%20will%20be%20printed%20to%20stdout.%20In%20a%20staging%20or%20production%20deployment%20this%20generates%20significant%20log%20volume%20and%20cost.%20Either%20add%20the%20same%20sampling%20knobs%20or%20remove%20%60debug%60%20from%20the%20Datadog-facing%20pipelines%20if%20console%20output%20isn't%20useful%20there.%0A%0A&pr=374&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fotel%2Fotel-collector-config.datadog.yaml%3A15-16%0A**TEMPO_OTLP_ENDPOINT%20comment%20implies%20conditional%20behaviour%20that%20doesn't%20exist**%0A%0AThe%20requirements%20header%20says%20%22Optionally%20set%20%60TEMPO_OTLP_ENDPOINT%60%20to%20also%20fan%20traces%20out%20to%20Tempo%3B%20if%20unset%2C%20the%20Tempo%20exporter%20is%20simply%20not%20referenced.%22%20However%2C%20no%20%60otlp%2Ftempo%60%20exporter%20is%20defined%20in%20%60exporters%3A%60%20and%20no%20pipeline%20references%20it%20%E2%80%94%20the%20env%20var%20does%20nothing%20right%20now.%20An%20operator%20who%20reads%20this%2C%20sets%20%60TEMPO_OTLP_ENDPOINT%60%2C%20and%20deploys%20will%20get%20silent%20loss%20of%20the%20expected%20Tempo%20routing%20with%20no%20error%20from%20the%20collector.%20The%20phrase%20%22if%20unset%2C%20the%20Tempo%20exporter%20is%20simply%20not%20referenced%22%20actively%20suggests%20conditional%20logic%20that%20doesn't%20exist%20yet.%20Consider%20rewording%20to%20%22Tempo%20fan-out%20is%20not%20yet%20implemented%20%E2%80%94%20see%20follow-up%20ticket%22%20to%20avoid%20the%20false%20impression.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fotel%2Fotel-collector-config.datadog.yaml%3A42-43%0A**Debug%20exporter%20lacks%20sampling%20%E2%80%94%20will%20log%20every%20span%20and%20metric%20in%20production**%0A%0AThe%20local%20config%20%28%60otel-collector-config.yaml%60%29%20configures%20%60sampling_initial%3A%205%60%20and%20%60sampling_thereafter%3A%20200%60%20on%20the%20%60debug%60%20exporter%2C%20capping%20console%20output%20at%20about%201-in-200%20records%20after%20warmup.%20The%20Datadog%20fan-out%20config%2C%20described%20as%20%22the%20reference%20pattern%20for%20the%20Helm-managed%20production%20collector%2C%22%20omits%20those%20settings.%20With%20%60verbosity%3A%20normal%60%2C%20every%20span%20in%20the%20%60traces%60%20pipeline%20and%20every%20metric%20data%20point%20in%20the%20%60metrics%60%20pipeline%20will%20be%20printed%20to%20stdout.%20In%20a%20staging%20or%20production%20deployment%20this%20generates%20significant%20log%20volume%20and%20cost.%20Either%20add%20the%20same%20sampling%20knobs%20or%20remove%20%60debug%60%20from%20the%20Datadog-facing%20pipelines%20if%20console%20output%20isn't%20useful%20there.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=374&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22obs%2Fcollector-datadog-fanout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22obs%2Fcollector-datadog-fanout%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aagentex%2Fotel%2Fotel-collector-config.datadog.yaml%3A15-16%0A**TEMPO_OTLP_ENDPOINT%20comment%20implies%20conditional%20behaviour%20that%20doesn't%20exist**%0A%0AThe%20requirements%20header%20says%20%22Optionally%20set%20%60TEMPO_OTLP_ENDPOINT%60%20to%20also%20fan%20traces%20out%20to%20Tempo%3B%20if%20unset%2C%20the%20Tempo%20exporter%20is%20simply%20not%20referenced.%22%20However%2C%20no%20%60otlp%2Ftempo%60%20exporter%20is%20defined%20in%20%60exporters%3A%60%20and%20no%20pipeline%20references%20it%20%E2%80%94%20the%20env%20var%20does%20nothing%20right%20now.%20An%20operator%20who%20reads%20this%2C%20sets%20%60TEMPO_OTLP_ENDPOINT%60%2C%20and%20deploys%20will%20get%20silent%20loss%20of%20the%20expected%20Tempo%20routing%20with%20no%20error%20from%20the%20collector.%20The%20phrase%20%22if%20unset%2C%20the%20Tempo%20exporter%20is%20simply%20not%20referenced%22%20actively%20suggests%20conditional%20logic%20that%20doesn't%20exist%20yet.%20Consider%20rewording%20to%20%22Tempo%20fan-out%20is%20not%20yet%20implemented%20%E2%80%94%20see%20follow-up%20ticket%22%20to%20avoid%20the%20false%20impression.%0A%0A%23%23%23%20Issue%202%20of%202%0Aagentex%2Fotel%2Fotel-collector-config.datadog.yaml%3A42-43%0A**Debug%20exporter%20lacks%20sampling%20%E2%80%94%20will%20log%20every%20span%20and%20metric%20in%20production**%0A%0AThe%20local%20config%20%28%60otel-collector-config.yaml%60%29%20configures%20%60sampling_initial%3A%205%60%20and%20%60sampling_thereafter%3A%20200%60%20on%20the%20%60debug%60%20exporter%2C%20capping%20console%20output%20at%20about%201-in-200%20records%20after%20warmup.%20The%20Datadog%20fan-out%20config%2C%20described%20as%20%22the%20reference%20pattern%20for%20the%20Helm-managed%20production%20collector%2C%22%20omits%20those%20settings.%20With%20%60verbosity%3A%20normal%60%2C%20every%20span%20in%20the%20%60traces%60%20pipeline%20and%20every%20metric%20data%20point%20in%20the%20%60metrics%60%20pipeline%20will%20be%20printed%20to%20stdout.%20In%20a%20staging%20or%20production%20deployment%20this%20generates%20significant%20log%20volume%20and%20cost.%20Either%20add%20the%20same%20sampling%20knobs%20or%20remove%20%60debug%60%20from%20the%20Datadog-facing%20pipelines%20if%20console%20output%20isn't%20useful%20there.%0A%0A&repo=scaleapi%2Fscale-agentex&pr=374&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
agentex/otel/otel-collector-config.datadog.yaml:15-16
**TEMPO_OTLP_ENDPOINT comment implies conditional behaviour that doesn't exist**

The requirements header says "Optionally set `TEMPO_OTLP_ENDPOINT` to also fan traces out to Tempo; if unset, the Tempo exporter is simply not referenced." However, no `otlp/tempo` exporter is defined in `exporters:` and no pipeline references it — the env var does nothing right now. An operator who reads this, sets `TEMPO_OTLP_ENDPOINT`, and deploys will get silent loss of the expected Tempo routing with no error from the collector. The phrase "if unset, the Tempo exporter is simply not referenced" actively suggests conditional logic that doesn't exist yet. Consider rewording to "Tempo fan-out is not yet implemented — see follow-up ticket" to avoid the false impression.

### Issue 2 of 2
agentex/otel/otel-collector-config.datadog.yaml:42-43
**Debug exporter lacks sampling — will log every span and metric in production**

The local config (`otel-collector-config.yaml`) configures `sampling_initial: 5` and `sampling_thereafter: 200` on the `debug` exporter, capping console output at about 1-in-200 records after warmup. The Datadog fan-out config, described as "the reference pattern for the Helm-managed production collector," omits those settings. With `verbosity: normal`, every span in the `traces` pipeline and every metric data point in the `metrics` pipeline will be printed to stdout. In a staging or production deployment this generates significant log volume and cost. Either add the same sampling knobs or remove `debug` from the Datadog-facing pipelines if console output isn't useful there.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(otel): add Datadog fan-out collecto..."](https://github.com/scaleapi/scale-agentex/commit/78f5f883d4832323a747f2496db5a27ac1c394ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46571204)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->