### PR TITLE
fix(tasks): omit `params` from the list-tasks response

### DIFF
--- a/agentex-ui/lib/task-utils.test.ts
+++ b/agentex-ui/lib/task-utils.test.ts
@@ -5,69 +5,49 @@ import { createTaskName } from '@/lib/task-utils';
 import type { TaskListResponse } from 'agentex/resources';
 
 describe('createTaskName', () => {
-  it('returns description when params.description is a string', () => {
+  it('returns task_metadata.display_name when present', () => {
     const task = {
       id: '123',
-      params: {
-        description: 'Test task description',
-      },
-    } as TaskListResponse.TaskListResponseItem;
+      task_metadata: { display_name: 'My task' },
+    } as unknown as TaskListResponse.TaskListResponseItem;
 
-    expect(createTaskName(task)).toBe('Test task description');
+    expect(createTaskName(task)).toBe('My task');
   });
 
-  it('returns "Unnamed task" when params.description is missing', () => {
+  it('strips the legacy scheduled-message prefix from display_name', () => {
     const task = {
-      params: {},
-    } as TaskListResponse.TaskListResponseItem;
-
-    expect(createTaskName(task)).toBe('Unnamed task');
-  });
-
-  it('returns "Unnamed task" when params is missing', () => {
-    const task = {} as TaskListResponse.TaskListResponseItem;
-
-    expect(createTaskName(task)).toBe('Unnamed task');
-  });
-
-  it('returns "Unnamed task" when params.description is not a string', () => {
-    const task = {
-      params: {
-        description: 123,
+      id: '123',
+      task_metadata: {
+        display_name: 'Scheduled Message: Daily digest',
+        schedule_id: 'sched-1',
       },
+    } as unknown as TaskListResponse.TaskListResponseItem;
+
+    expect(createTaskName(task)).toBe('Daily digest');
+  });
+
+  it('falls back to the task name when there is no display_name', () => {
+    const task = {
+      id: '123',
+      name: 'my-task-name',
+    } as unknown as TaskListResponse.TaskListResponseItem;
+
+    expect(createTaskName(task)).toBe('my-task-name');
+  });
+
+  it('returns "Unnamed task" when neither display_name nor name is set', () => {
+    const task = {
+      id: '123',
     } as unknown as TaskListResponse.TaskListResponseItem;
 
     expect(createTaskName(task)).toBe('Unnamed task');
   });
 
-  it('returns "Unnamed task" when params.description is null', () => {
+  it('returns "Unnamed task" when name is an empty string', () => {
     const task = {
-      params: {
-        description: null,
-      },
+      id: '123',
+      name: '',
     } as unknown as TaskListResponse.TaskListResponseItem;
-
-    expect(createTaskName(task)).toBe('Unnamed task');
-  });
-
-  it('returns "Unnamed task" when params.description is undefined', () => {
-    const task = {
-      id: '123',
-      params: {
-        description: undefined,
-      },
-    } as TaskListResponse.TaskListResponseItem;
-
-    expect(createTaskName(task)).toBe('Unnamed task');
-  });
-
-  it('returns "Unnamed task" for empty string description', () => {
-    const task = {
-      id: '123',
-      params: {
-        description: '',
-      },
-    } as TaskListResponse.TaskListResponseItem;
 
     expect(createTaskName(task)).toBe('Unnamed task');
   });

--- a/agentex-ui/lib/task-utils.ts
+++ b/agentex-ui/lib/task-utils.ts
@@ -20,11 +20,8 @@ export function createTaskName(
     return displayName;
   }
 
-  if (
-    task?.params?.description &&
-    typeof task.params.description === 'string'
-  ) {
-    return task.params.description;
+  if (typeof task?.name === 'string' && task.name) {
+    return task.name;
   }
 
   return 'Unnamed task';

--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -555,7 +555,8 @@ paths:
       tags:
       - Tasks
       summary: List Tasks
-      description: List all tasks.
+      description: List tasks. Returns a lean summary per task and omits `params`;
+        fetch GET /tasks/{task_id} for the full record including `params`.
       operationId: list_tasks_tasks_get
       parameters:
       - name: agent_id
@@ -641,7 +642,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/TaskResponse'
+                  $ref: '#/components/schemas/TaskSummary'
                 title: Response List Tasks Tasks Get
         '422':
           description: Validation Error
@@ -6845,6 +6846,68 @@ components:
           title: Optional reason for the status change
       type: object
       title: TaskStatusReasonRequest
+    TaskSummary:
+      properties:
+        id:
+          type: string
+          title: Unique Task ID
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Unique name of the task
+        status:
+          anyOf:
+          - $ref: '#/components/schemas/TaskStatus'
+          - type: 'null'
+          title: The current status of the task
+        status_reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: The reason for the current task status
+        created_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: The timestamp when the task was created
+        updated_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: The timestamp when the task was last updated
+        cleaned_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: The timestamp when the task's content was cleaned for retention compliance;
+            null when active
+        task_metadata:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Task metadata
+        agents:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/Agent'
+            type: array
+          - type: 'null'
+          title: Agents associated with this task (only populated when 'agents' view
+            is requested)
+      type: object
+      required:
+      - id
+      title: TaskSummary
+      description: 'Lean list-response shape. Omits `params` (the arbitrary create-time
+
+        payload, which can carry per-caller secrets and PII); fetch GET /tasks/{id}
+
+        for the full record.'
     TextContent:
       properties:
         type:

--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -17,6 +17,7 @@ from src.api.schemas.tasks import (
     TaskResponse,
     TaskStatus,
     TaskStatusReasonRequest,
+    TaskSummary,
     UpdateTaskRequest,
 )
 from src.domain.entities.tasks import TaskStatus as DomainTaskStatus
@@ -73,9 +74,12 @@ async def get_task_by_name(
 
 @router.get(
     "",
-    response_model=list[TaskResponse],
+    response_model=list[TaskSummary],
     summary="List Tasks",
-    description="List all tasks.",
+    description=(
+        "List tasks. Returns a lean summary per task and omits `params`; "
+        "fetch GET /tasks/{task_id} for the full record including `params`."
+    ),
 )
 async def list_tasks(
     task_use_case: DTaskUseCase,
@@ -143,7 +147,7 @@ async def list_tasks(
         order_direction=order_direction,
         relationships=relationships,
     )
-    return [TaskResponse.model_validate(task_entity) for task_entity in task_entities]
+    return [TaskSummary.model_validate(task_entity) for task_entity in task_entities]
 
 
 @router.delete(

--- a/agentex/src/api/schemas/tasks.py
+++ b/agentex/src/api/schemas/tasks.py
@@ -74,6 +74,49 @@ class TaskResponse(Task):
     )
 
 
+class TaskSummary(BaseModel):
+    """Lean list-response shape. Omits `params` (the arbitrary create-time
+    payload, which can carry per-caller secrets and PII); fetch GET /tasks/{id}
+    for the full record."""
+
+    id: str = Field(
+        ...,
+        title="Unique Task ID",
+    )
+    name: str | None = Field(
+        None,
+        title="Unique name of the task",
+    )
+    status: TaskStatus | None = Field(
+        None,
+        title="The current status of the task",
+    )
+    status_reason: str | None = Field(
+        None,
+        title="The reason for the current task status",
+    )
+    created_at: datetime | None = Field(
+        None,
+        title="The timestamp when the task was created",
+    )
+    updated_at: datetime | None = Field(
+        None,
+        title="The timestamp when the task was last updated",
+    )
+    cleaned_at: datetime | None = Field(
+        None,
+        title="The timestamp when the task's content was cleaned for retention compliance; null when active",
+    )
+    task_metadata: dict[str, Any] | None = Field(
+        None,
+        title="Task metadata",
+    )
+    agents: list["Agent"] | None = Field(
+        default=None,
+        title="Agents associated with this task (only populated when 'agents' view is requested)",
+    )
+
+
 class UpdateTaskRequest(BaseModel):
     task_metadata: dict[str, Any] | None = Field(
         None,

--- a/agentex/tests/integration/api/tasks/test_tasks_api.py
+++ b/agentex/tests/integration/api/tasks/test_tasks_api.py
@@ -141,6 +141,10 @@ class TestTasksAPIIntegration:
         for task in tasks:
             assert "id" in task and isinstance(task["id"], str)
 
+            # The list is a lean summary and must never carry `params` (the
+            # arbitrary create-time payload that can hold secrets/PII).
+            assert "params" not in task
+
             # Check if this is our test task
             if task["id"] == test_task.id:
                 found_test_task = True
@@ -499,32 +503,24 @@ class TestTasksAPIIntegration:
         assert response.status_code == 404
 
     #
-    async def test_list_tasks_includes_params_in_response(
+    async def test_list_tasks_omits_params_in_response(
         self, isolated_client, test_task_with_params
     ):
-        """Test that list tasks endpoint includes params field in response"""
+        """The list summary must omit `params` even when the task has them
+        (they can carry secrets/PII); fetch a single task for the full record."""
         # When - Request all tasks
         response = await isolated_client.get("/tasks")
 
-        # Then - Should succeed and include params in response
+        # Then - The task is present but its params are not serialized
         assert response.status_code == 200
         tasks = response.json()
         assert isinstance(tasks, list)
 
-        # Find our test task with params
         params_task = next(
             (task for task in tasks if task["id"] == test_task_with_params.id), None
         )
-        assert params_task is not None, "Task with params should be in the list"
-
-        # Verify params field exists and has correct structure
-        assert "params" in params_task
-        assert params_task["params"] is not None
-        assert params_task["params"]["model"] == "gpt-4"
-        assert params_task["params"]["temperature"] == 0.8
-        assert params_task["params"]["max_tokens"] == 2000
-        assert params_task["params"]["nested"]["setting"] == "value"
-        assert params_task["params"]["nested"]["numbers"] == [1, 2, 3]
+        assert params_task is not None, "Task should be in the list"
+        assert "params" not in params_task
 
     #
     async def test_get_task_by_id_includes_params_in_response(
@@ -579,26 +575,22 @@ class TestTasksAPIIntegration:
         assert task_data["params"]["nested"]["numbers"] == [1, 2, 3]
 
     #
-    async def test_list_tasks_handles_null_params_correctly(
+    async def test_list_tasks_omits_params_for_null_params_task(
         self, isolated_client, test_task
     ):
-        """Test that list tasks handles tasks with null params correctly"""
+        """A task created without params also has no `params` key in the list."""
         # When - Request all tasks (test_task has null params)
         response = await isolated_client.get("/tasks")
 
-        # Then - Should succeed and handle null params
+        # Then - The task is present with no params field
         assert response.status_code == 200
         tasks = response.json()
 
-        # Find our test task without params
         null_params_task = next(
             (task for task in tasks if task["id"] == test_task.id), None
         )
         assert null_params_task is not None
-
-        # Verify params field exists and is null
-        assert "params" in null_params_task
-        assert null_params_task["params"] is None
+        assert "params" not in null_params_task
 
     #
     async def test_get_task_by_id_handles_null_params_correctly(


### PR DESCRIPTION
## Summary

`GET /tasks` (list) returned the full task object, the same `TaskResponse` the single-task GET returns, so every item included `params`: the arbitrary, caller-supplied create-time payload. Callers routinely stash sensitive material there (credentials, tokens, PII). Because the list is broadly scoped, that turned a single list call into a bulk read of every task's `params`.

This makes the list a lean summary (`TaskSummary`, no `params`) and keeps the full record on the single-task fetch. A list response should carry only what a collection view needs; the full record belongs on the item fetch.

**Scope:** the list response only. Behavior of `GET /tasks/{id}`, `GET /tasks/name/{name}`, `POST`/`PATCH`, and the domain/repository layers is unchanged.

## Endpoint contract (after)

```mermaid
flowchart TD
    Client(["Client"])
    Client -->|"GET /tasks (list)"| Summary["list of TaskSummary<br/>id, name, status, status_reason,<br/>created_at, updated_at, cleaned_at,<br/>task_metadata, agents"]
    Client -->|"GET /tasks/{id} (detail)"| Full["TaskResponse<br/>(all summary fields) + params"]
    Summary -. "need params for one task?" .-> Client
    Client ==>|"fetch that id"| Full

    classDef lean fill:#e8f5e9,stroke:#43a047,color:#1b5e20;
    classDef full fill:#fdecea,stroke:#e53935,color:#b71c1c;
    class Summary lean;
    class Full full;
```

- **List** returns the lean summary for every task, cheap, and safe to return in bulk.
- **Detail** still returns everything, including `params`, and is fetched one id at a time (and is subject to the same per-request authorization as before).

## Schema

`TaskSummary` is a deliberate allowlist. It is a standalone model (not a subclass of `Task`) so `params` cannot leak in via inheritance, and because `BaseModel` ignores extra fields, validating a `TaskEntity` (which still carries `params`) into a `TaskSummary` drops `params` at serialization.

```mermaid
classDiagram
    class TaskSummary {
      +id
      +name
      +status
      +status_reason
      +created_at
      +updated_at
      +cleaned_at
      +task_metadata
      +agents
    }
    class TaskResponse {
      +id
      +name
      +status
      +status_reason
      +created_at
      +updated_at
      +cleaned_at
      +task_metadata
      +agents
      +params
    }
    note for TaskSummary "list response, omits params"
    note for TaskResponse "single-task detail, includes params (may carry credentials or PII)"
```

The two share the same safe fields; only `TaskResponse` exposes `params`.

## Before / after

```jsonc
// BEFORE - one item in the list response
{
  "id": "0c1f8e2a-…",
  "name": "…",
  "status": "RUNNING",
  "created_at": "…", "updated_at": "…", "cleaned_at": null,
  "task_metadata": { "display_name": "…" },
  "params": {
    "auth_token": "…",        // whatever the caller stored at create time,
    "user_email": "…",        // e.g. credentials and PII, returned in bulk
    "…": "…"
  }
}

// AFTER - same item, lean summary (no params)
{
  "id": "0c1f8e2a-…",
  "name": "…",
  "status": "RUNNING",
  "created_at": "…", "updated_at": "…", "cleaned_at": null,
  "task_metadata": { "display_name": "…" },
  "agents": null
}
```

What changes across a whole list call:

```mermaid
flowchart LR
    subgraph Before["Before: GET /tasks"]
        direction TB
        b["N tasks × full object<br/>N × params (creds/PII)"]
    end
    subgraph After["After: GET /tasks"]
        direction TB
        a["N tasks × lean summary<br/>0 × params"]
    end
    Before --> After
    classDef bad fill:#fdecea,stroke:#e53935,color:#b71c1c;
    classDef good fill:#e8f5e9,stroke:#43a047,color:#1b5e20;
    class Before bad;
    class After good;
```

## Field reference

| Field | In list (`TaskSummary`) | In detail (`TaskResponse`) | Notes |
|---|---|---|---|
| `id` | yes | yes | System-assigned task id |
| `name` | yes | yes | Optional, caller-supplied |
| `status` / `status_reason` | yes | yes | Lifecycle state |
| `created_at` / `updated_at` / `cleaned_at` | yes | yes | Timestamps |
| `task_metadata` | yes | yes | Display / routing / filter metadata (the list can filter on it) |
| `agents` | yes | yes | Populated only with `?relationships=agents` |
| **`params`** | **no** | yes | Arbitrary create-time payload; may carry credentials/PII |

## Breaking change and migration

Removing `params` from the list is an intentional, security-motivated breaking change for typed consumers that read `params` off a **list** item.

```mermaid
flowchart TD
    Q{"Reading params off a list item?"}
    Q -->|No| OK["No change needed"]
    Q -->|Yes| Fix["Fetch the task by id, then read params"]
    classDef ok fill:#e8f5e9,stroke:#43a047,color:#1b5e20;
    class OK ok;
```

The SDKs are generated from `agentex/openapi.yaml` (Stainless), so the list-item type regenerates automatically on merge; consumers pick up the change when they bump the SDK. This PR regenerates and commits `openapi.yaml` (the `list_tasks` 200 now references `TaskSummary`), which the `openapi-spec` CI check enforces.

## Consumers touched in this PR

- **Developer UI** (`agentex-ui`): `createTaskName` fell back to `params.description` for the task label; switched to the task `name` (`task_metadata.display_name → name → "Unnamed task"`). No other code reads `params` off a listed task.

## Implementation

- `src/api/schemas/tasks.py`: add `TaskSummary` (allowlist, omits `params`).
- `src/api/routes/tasks.py`: `list_tasks` `response_model=list[TaskSummary]`, returns `TaskSummary.model_validate(...)` per entity. Single-task routes unchanged.
- `agentex-ui/lib/task-utils.ts` + test: name-derivation fallback.
- `agentex/openapi.yaml`: regenerated.

## Follow-ups / known limitations

- **`task_metadata` is still free-form (`dict[str, Any]`)** and partly caller-influenced. By convention it holds non-secret display/routing/filter metadata (and the list can filter on it), so it stays in the summary. If we want the list to be strict rather than convention-safe, a follow-up could give `task_metadata` a typed shape so callers cannot stash sensitive data that the list would surface.
- **Concurrency is out of scope**: unrelated to this change; not touched here.

## Test plan

```mermaid
flowchart LR
    subgraph list["GET /tasks"]
        L1["task present in list"]
        L2["params NOT in item"]
    end
    subgraph get["GET /tasks/{id}"]
        G1["params present + correct"]
    end
    list --> get
```

- Integration (`tests/integration/api/tasks/test_tasks_api.py`): list omits `params` for both populated- and null-`params` tasks; the schema test asserts `params` absent on list items; single-task GET (by id and by name) still returns `params`.
- UI unit (`agentex-ui/lib/task-utils.test.ts`): task-name derivation from `display_name` / `name`.
- `openapi.yaml` regenerated and committed.
- Verified directly that `TaskSummary.model_validate({... "params": {...}})` drops `params` while `TaskResponse` keeps it; `ruff` clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an information-disclosure issue where `GET /tasks` (list) returned the full `TaskResponse` — including `params`, an arbitrary caller-supplied payload that can hold credentials and PII — for every task in a single call. The fix introduces a standalone `TaskSummary` allowlist model that omits `params`, updates the list route's `response_model`, regenerates the OpenAPI spec, and adapts the UI's task-name derivation to use `task.name` instead of `params.description`.

- **`TaskSummary`** is a standalone `BaseModel` (not a subclass of `Task`) so `params` cannot leak via inheritance; Pydantic v2's default `extra='ignore'` ensures `model_validate` silently drops the field.
- **Single-task routes** (`GET /tasks/{id}`, `GET /tasks/name/{name}`, lifecycle endpoints) are unchanged and continue to return `params`.
- **UI** now derives the task label from `task_metadata.display_name → task.name → 'Unnamed task'` instead of the now-absent `params.description`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, well-scoped fix that strips a sensitive field from a bulk endpoint without touching any single-task or write paths.

The allowlist model is correctly designed as a standalone BaseModel (no Task inheritance), and Pydantic v2's default extra-field behaviour ensures params is silently dropped at serialization. The custom BaseModel in model_utils.py does not set extra='allow', so there is no bypass path. Single-task routes, lifecycle endpoints, and the domain layer are untouched. Integration tests verify the before/after contract for both populated- and null-params tasks, and the UI fallback is covered by unit tests.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/api/schemas/tasks.py | Adds TaskSummary as a standalone BaseModel allowlist that omits params; correct approach — no inheritance from Task prevents accidental field leakage. |
| agentex/src/api/routes/tasks.py | list_tasks response_model changed to list[TaskSummary] and serialization updated; single-task and lifecycle routes are correctly unchanged. |
| agentex-ui/lib/task-utils.ts | createTaskName fallback updated from params.description to task.name; correct adaptation to the new TaskSummary shape. |
| agentex-ui/lib/task-utils.test.ts | Tests updated to cover the new name-derivation logic (display_name, prefix stripping, task.name fallback, Unnamed task); coverage looks complete. |
| agentex/tests/integration/api/tasks/test_tasks_api.py | Integration tests flipped to assert params absent from list items and still present on single-task GET; covers both populated and null-params tasks. |
| agentex/openapi.yaml | list_tasks 200 response now references TaskSummary; TaskSummary schema added with correct allowlist fields matching the Python model. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/list-tasks-..."](https://github.com/scaleapi/scale-agentex/commit/6977d674da8fe6b211021d4a4402dc168812cb87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47039695)</sub>

<!-- /greptile_comment -->