### PR TITLE
feat(observability): RPC + workflow + DB-pool metrics for the agent JSON-RPC endpoint

### DIFF
--- a/agentex/otel/otel-collector-config.yaml
+++ b/agentex/otel/otel-collector-config.yaml
@@ -21,10 +21,14 @@ exporters:
     sampling_initial: 5
     sampling_thereafter: 200
 
-  # Expose Prometheus endpoint for scraping
+  # Expose Prometheus endpoint for scraping.
+  # No `namespace:` on purpose — the cluster's otel-operator -> daemonset
+  # pipeline adds no prefix, so metric names there are exactly their instrument
+  # names (e.g. agentex_rpc_requests_total, db_client_connection_wait_time_seconds).
+  # A namespace here would double-prefix agentex.* metrics (agentex_agentex_...)
+  # and make locally-tested PromQL diverge from Mimir.
   prometheus:
     endpoint: 0.0.0.0:8889
-    namespace: agentex
     send_timestamps: true
     metric_expiration: 5m
 

--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -45,7 +45,6 @@ from src.utils.authorization_shortcuts import (
 )
 from src.utils.logging import make_logger
 from src.utils.rpc_metrics import (
-    RPC_STATUS_OK,
     record_rpc_request,
 )
 from src.utils.task_authorization import check_task_or_collapse_to_404
@@ -606,7 +605,7 @@ async def _handle_sync_rpc(
             method=request.method.value,
             streaming=False,
             duration_s=time.perf_counter() - start,
-            status_code=str(error.code),
+            error_code=error.code,
             error_type=type(e).__name__,
         )
         return AgentRPCResponse(id=request.id, error=error.model_dump(), result=None)
@@ -617,7 +616,7 @@ async def _handle_sync_rpc(
             method=request.method.value,
             streaming=False,
             duration_s=time.perf_counter() - start,
-            status_code=str(error.code),
+            error_code=error.code,
             error_type=type(e).__name__,
         )
         return AgentRPCResponse(id=request.id, error=error.model_dump(), result=None)
@@ -680,7 +679,7 @@ async def _handle_streaming_rpc(
                 method=request.method.value,
                 streaming=True,
                 duration_s=time.perf_counter() - start,
-                status_code=RPC_STATUS_OK if error_type is None else "-32603",
+                error_code=None if error_type is None else -32603,
                 error_type=error_type,
             )
             # CRITICAL: Ensure the async iterator is properly closed

--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -1,5 +1,4 @@
 import secrets
-import time
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -45,7 +44,7 @@ from src.utils.authorization_shortcuts import (
 )
 from src.utils.logging import make_logger
 from src.utils.rpc_metrics import (
-    record_rpc_request,
+    rpc_request_timing,
 )
 from src.utils.task_authorization import check_task_or_collapse_to_404
 
@@ -553,73 +552,62 @@ async def _handle_sync_rpc(
     request_headers: dict[str, str] | None = None,
 ) -> AgentRPCResponse:
     """Handle synchronous JSON-RPC requests."""
-    start = time.perf_counter()
-    try:
-        result_entity = await agents_acp_use_case.handle_rpc_request(
-            agent_id=agent_id,
-            agent_name=agent_name,
-            method=request.method,
-            params=request.params,
-            request_headers=request_headers,
-        )
+    with rpc_request_timing(request.method.value, streaming=False) as rpc_call:
+        try:
+            result_entity = await agents_acp_use_case.handle_rpc_request(
+                agent_id=agent_id,
+                agent_name=agent_name,
+                method=request.method,
+                params=request.params,
+                request_headers=request_headers,
+            )
 
-        if isinstance(result_entity, AsyncIterator):
-            raise ValueError(f"Expected non-async iterator, got {type(result_entity)}")
+            if isinstance(result_entity, AsyncIterator):
+                raise ValueError(
+                    f"Expected non-async iterator, got {type(result_entity)}"
+                )
 
-        if isinstance(result_entity, list):
-            serialized_result = [item.model_dump() for item in result_entity]
-        else:
-            serialized_result = result_entity.model_dump()
+            if isinstance(result_entity, list):
+                serialized_result = [item.model_dump() for item in result_entity]
+            else:
+                serialized_result = result_entity.model_dump()
 
-        # if request.method == AgentRPCMethod.MESSAGE_SEND:
-        #     if isinstance(result_entity, list):
-        #         result = [TaskMessage.model_validate(task_message_entity) for task_message_entity in result_entity]
-        #     else:
-        #         raise ValueError(f"Expected list of TaskMessage entities, got {type(result_entity)}")
-        # elif request.method == AgentRPCMethod.TASK_CREATE:
-        #     result = Task.model_validate(result_entity)
-        # elif request.method == AgentRPCMethod.TASK_CANCEL:
-        #     result = Task.model_validate(result_entity)
-        # elif request.method == AgentRPCMethod.EVENT_SEND:
-        #     result = Event.model_validate(result_entity)
-        # else:
-        #     raise ValueError(f"Unsupported method: {request.method}")
-        # logger.info(f"AgentRPCResponse Result: {result}")
-        record_rpc_request(
-            method=request.method.value,
-            streaming=False,
-            duration_s=time.perf_counter() - start,
-        )
-        return AgentRPCResponse.model_validate(
-            {
-                "id": request.id,
-                "result": serialized_result,
-                "error": None,
-            }
-        )
+            # if request.method == AgentRPCMethod.MESSAGE_SEND:
+            #     if isinstance(result_entity, list):
+            #         result = [TaskMessage.model_validate(task_message_entity) for task_message_entity in result_entity]
+            #     else:
+            #         raise ValueError(f"Expected list of TaskMessage entities, got {type(result_entity)}")
+            # elif request.method == AgentRPCMethod.TASK_CREATE:
+            #     result = Task.model_validate(result_entity)
+            # elif request.method == AgentRPCMethod.TASK_CANCEL:
+            #     result = Task.model_validate(result_entity)
+            # elif request.method == AgentRPCMethod.EVENT_SEND:
+            #     result = Event.model_validate(result_entity)
+            # else:
+            #     raise ValueError(f"Unsupported method: {request.method}")
+            # logger.info(f"AgentRPCResponse Result: {result}")
+            return AgentRPCResponse.model_validate(
+                {
+                    "id": request.id,
+                    "result": serialized_result,
+                    "error": None,
+                }
+            )
 
-    except ValidationError as e:
-        logger.error(f"Validation error in RPC request: {e}", exc_info=True)
-        error = JSONRPCError(code=-32602, message=f"Invalid parameters: {e}")
-        record_rpc_request(
-            method=request.method.value,
-            streaming=False,
-            duration_s=time.perf_counter() - start,
-            error_code=error.code,
-            error_type=type(e).__name__,
-        )
-        return AgentRPCResponse(id=request.id, error=error.model_dump(), result=None)
-    except Exception as e:
-        logger.error(f"Error handling JSON-RPC request: {e}", exc_info=True)
-        error = JSONRPCError(code=-32603, message=str(e))
-        record_rpc_request(
-            method=request.method.value,
-            streaming=False,
-            duration_s=time.perf_counter() - start,
-            error_code=error.code,
-            error_type=type(e).__name__,
-        )
-        return AgentRPCResponse(id=request.id, error=error.model_dump(), result=None)
+        except ValidationError as e:
+            logger.error(f"Validation error in RPC request: {e}", exc_info=True)
+            error = JSONRPCError(code=-32602, message=f"Invalid parameters: {e}")
+            rpc_call.fail(error.code, e)
+            return AgentRPCResponse(
+                id=request.id, error=error.model_dump(), result=None
+            )
+        except Exception as e:
+            logger.error(f"Error handling JSON-RPC request: {e}", exc_info=True)
+            error = JSONRPCError(code=-32603, message=str(e))
+            rpc_call.fail(error.code, e)
+            return AgentRPCResponse(
+                id=request.id, error=error.model_dump(), result=None
+            )
 
 
 async def _handle_streaming_rpc(
@@ -632,66 +620,60 @@ async def _handle_streaming_rpc(
     """Handle streaming JSON-RPC requests."""
 
     async def rpc_response_generator():
-        start = time.perf_counter()
-        error_type: str | None = None
-        result_entity_async_iterator = None
-        try:
-            result_entity_async_iterator = await agents_acp_use_case.handle_rpc_request(
-                agent_id=agent_id,
-                agent_name=agent_name,
-                method=request.method,
-                params=request.params,
-                request_headers=request_headers,
-            )
-
-            if not isinstance(result_entity_async_iterator, AsyncIterator):
-                raise ValueError(
-                    f"Expected AsyncIterator, got {type(result_entity_async_iterator)}"
+        with rpc_request_timing(request.method.value, streaming=True) as rpc_call:
+            result_entity_async_iterator = None
+            try:
+                result_entity_async_iterator = (
+                    await agents_acp_use_case.handle_rpc_request(
+                        agent_id=agent_id,
+                        agent_name=agent_name,
+                        method=request.method,
+                        params=request.params,
+                        request_headers=request_headers,
+                    )
                 )
 
-            # At this point we know it's an AsyncIterator[TaskMessage]
-            async for task_message_update_entity in result_entity_async_iterator:
-                logger.debug(
-                    f"Streaming message chunk type: {type(task_message_update_entity).__name__}"
-                )
-                rpc_response = AgentRPCResponse.model_validate(
-                    {
-                        "id": request.id,
-                        "result": task_message_update_entity.model_dump(),
-                        "error": None,
-                    }
-                )
-                # Yield JSON bytes with newline for NDJSON format
-                yield rpc_response.model_dump_json().encode() + b"\n"
+                if not isinstance(result_entity_async_iterator, AsyncIterator):
+                    raise ValueError(
+                        f"Expected AsyncIterator, got {type(result_entity_async_iterator)}"
+                    )
 
-        except Exception as e:
-            logger.error(f"Error in streaming RPC response: {e}", exc_info=True)
-            error_type = type(e).__name__
-            # Yield error response
-            error_response = AgentRPCResponse(
-                id=request.id,
-                result=None,
-                error=JSONRPCError(code=-32603, message=str(e)).model_dump(),
-            )
-            yield error_response.model_dump_json().encode() + b"\n"
-        finally:
-            record_rpc_request(
-                method=request.method.value,
-                streaming=True,
-                duration_s=time.perf_counter() - start,
-                error_code=None if error_type is None else -32603,
-                error_type=error_type,
-            )
-            # CRITICAL: Ensure the async iterator is properly closed
-            # This ensures HTTP connections are released back to the pool
-            if result_entity_async_iterator is not None and hasattr(
-                result_entity_async_iterator, "aclose"
-            ):
-                try:
-                    await result_entity_async_iterator.aclose()
-                    logger.debug("Closed streaming iterator properly")
-                except Exception as e:
-                    logger.warning(f"Error closing streaming iterator: {e}")
+                # At this point we know it's an AsyncIterator[TaskMessage]
+                async for task_message_update_entity in result_entity_async_iterator:
+                    logger.debug(
+                        f"Streaming message chunk type: {type(task_message_update_entity).__name__}"
+                    )
+                    rpc_response = AgentRPCResponse.model_validate(
+                        {
+                            "id": request.id,
+                            "result": task_message_update_entity.model_dump(),
+                            "error": None,
+                        }
+                    )
+                    # Yield JSON bytes with newline for NDJSON format
+                    yield rpc_response.model_dump_json().encode() + b"\n"
+
+            except Exception as e:
+                logger.error(f"Error in streaming RPC response: {e}", exc_info=True)
+                rpc_call.fail(-32603, e)
+                # Yield error response
+                error_response = AgentRPCResponse(
+                    id=request.id,
+                    result=None,
+                    error=JSONRPCError(code=-32603, message=str(e)).model_dump(),
+                )
+                yield error_response.model_dump_json().encode() + b"\n"
+            finally:
+                # CRITICAL: Ensure the async iterator is properly closed
+                # This ensures HTTP connections are released back to the pool
+                if result_entity_async_iterator is not None and hasattr(
+                    result_entity_async_iterator, "aclose"
+                ):
+                    try:
+                        await result_entity_async_iterator.aclose()
+                        logger.debug("Closed streaming iterator properly")
+                    except Exception as e:
+                        logger.warning(f"Error closing streaming iterator: {e}")
 
     return StreamingResponse(
         rpc_response_generator(),

--- a/agentex/src/api/routes/agents.py
+++ b/agentex/src/api/routes/agents.py
@@ -1,4 +1,5 @@
 import secrets
+import time
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -43,6 +44,10 @@ from src.utils.authorization_shortcuts import (
     DAuthorizedResourceIds,
 )
 from src.utils.logging import make_logger
+from src.utils.rpc_metrics import (
+    RPC_STATUS_OK,
+    record_rpc_request,
+)
 from src.utils.task_authorization import check_task_or_collapse_to_404
 
 logger = make_logger(__name__)
@@ -549,6 +554,7 @@ async def _handle_sync_rpc(
     request_headers: dict[str, str] | None = None,
 ) -> AgentRPCResponse:
     """Handle synchronous JSON-RPC requests."""
+    start = time.perf_counter()
     try:
         result_entity = await agents_acp_use_case.handle_rpc_request(
             agent_id=agent_id,
@@ -580,6 +586,11 @@ async def _handle_sync_rpc(
         # else:
         #     raise ValueError(f"Unsupported method: {request.method}")
         # logger.info(f"AgentRPCResponse Result: {result}")
+        record_rpc_request(
+            method=request.method.value,
+            streaming=False,
+            duration_s=time.perf_counter() - start,
+        )
         return AgentRPCResponse.model_validate(
             {
                 "id": request.id,
@@ -591,10 +602,24 @@ async def _handle_sync_rpc(
     except ValidationError as e:
         logger.error(f"Validation error in RPC request: {e}", exc_info=True)
         error = JSONRPCError(code=-32602, message=f"Invalid parameters: {e}")
+        record_rpc_request(
+            method=request.method.value,
+            streaming=False,
+            duration_s=time.perf_counter() - start,
+            status_code=str(error.code),
+            error_type=type(e).__name__,
+        )
         return AgentRPCResponse(id=request.id, error=error.model_dump(), result=None)
     except Exception as e:
         logger.error(f"Error handling JSON-RPC request: {e}", exc_info=True)
         error = JSONRPCError(code=-32603, message=str(e))
+        record_rpc_request(
+            method=request.method.value,
+            streaming=False,
+            duration_s=time.perf_counter() - start,
+            status_code=str(error.code),
+            error_type=type(e).__name__,
+        )
         return AgentRPCResponse(id=request.id, error=error.model_dump(), result=None)
 
 
@@ -608,6 +633,8 @@ async def _handle_streaming_rpc(
     """Handle streaming JSON-RPC requests."""
 
     async def rpc_response_generator():
+        start = time.perf_counter()
+        error_type: str | None = None
         result_entity_async_iterator = None
         try:
             result_entity_async_iterator = await agents_acp_use_case.handle_rpc_request(
@@ -640,6 +667,7 @@ async def _handle_streaming_rpc(
 
         except Exception as e:
             logger.error(f"Error in streaming RPC response: {e}", exc_info=True)
+            error_type = type(e).__name__
             # Yield error response
             error_response = AgentRPCResponse(
                 id=request.id,
@@ -648,6 +676,13 @@ async def _handle_streaming_rpc(
             )
             yield error_response.model_dump_json().encode() + b"\n"
         finally:
+            record_rpc_request(
+                method=request.method.value,
+                streaming=True,
+                duration_s=time.perf_counter() - start,
+                status_code=RPC_STATUS_OK if error_type is None else "-32603",
+                error_type=error_type,
+            )
             # CRITICAL: Ensure the async iterator is properly closed
             # This ensures HTTP connections are released back to the pool
             if result_entity_async_iterator is not None and hasattr(

--- a/agentex/src/config/dependencies.py
+++ b/agentex/src/config/dependencies.py
@@ -19,7 +19,10 @@ from temporalio.client import Client as TemporalClient
 
 from src.config.environment_variables import Environment, EnvironmentVariables
 from src.utils.database import async_db_engine_creator
-from src.utils.db_metrics import PostgresMetricsCollector
+from src.utils.db_metrics import (
+    InstrumentedAsyncAdaptedQueuePool,
+    PostgresMetricsCollector,
+)
 from src.utils.logging import make_logger
 
 logger = make_logger(__name__)
@@ -97,6 +100,7 @@ class GlobalDependencies(metaclass=Singleton):
                 self.environment_variables.DATABASE_URL,
             ),
             echo=echo_db_engine,
+            poolclass=InstrumentedAsyncAdaptedQueuePool,  # emits pool wait_time/pending_requests/timeouts
             pool_size=async_db_pool_size,
             max_overflow=20,  # Allow 20 additional connections beyond pool_size when needed
             pool_pre_ping=True,
@@ -109,6 +113,7 @@ class GlobalDependencies(metaclass=Singleton):
                 self.environment_variables.DATABASE_URL,
             ),
             echo=echo_db_engine,
+            poolclass=InstrumentedAsyncAdaptedQueuePool,  # emits pool wait_time/pending_requests/timeouts
             pool_size=middleware_db_pool_size,
             max_overflow=10,  # Allow 10 additional connections for middleware
             pool_pre_ping=True,
@@ -188,6 +193,7 @@ class GlobalDependencies(metaclass=Singleton):
                 "postgresql+asyncpg://",
                 async_creator=async_db_engine_creator(read_only_db_url),
                 echo=echo_db_engine,
+                poolclass=InstrumentedAsyncAdaptedQueuePool,  # emits pool wait_time/pending_requests/timeouts
                 pool_size=async_db_pool_size,
                 max_overflow=20,
                 pool_pre_ping=True,

--- a/agentex/src/utils/db_metrics.py
+++ b/agentex/src/utils/db_metrics.py
@@ -19,6 +19,8 @@ from urllib.parse import urlparse
 from datadog import statsd
 from sqlalchemy import event
 from sqlalchemy.engine import ExecutionContext
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.pool import AsyncAdaptedQueuePool
 
 from src.utils.logging import make_logger
 from src.utils.otel_metrics import get_meter
@@ -38,6 +40,28 @@ _SLOW_QUERY_THRESHOLD = float(os.environ.get("POSTGRES_SLOW_QUERY_THRESHOLD", "0
 
 # StatsD is only enabled if DD_AGENT_HOST is configured
 _STATSD_ENABLED = bool(os.environ.get("DD_AGENT_HOST"))
+
+# Bucket boundaries (seconds) for the connection-acquisition wait histogram.
+# The SDK's default boundaries are millisecond-magnitude integers [0, 5, 10, ...]
+# that assume a millisecond unit; against a seconds-unit metric almost every
+# pool wait (µs–ms normally, up to the ~30s pool_timeout under saturation) falls
+# in the first bucket and quantiles are meaningless. These span instant-to-
+# timeout so p95/p99 stay usable.
+_POOL_WAIT_BUCKET_BOUNDARIES_S = (
+    0.001,
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+)
 
 
 def _format_statsd_tags(attributes: dict) -> list[str]:
@@ -68,6 +92,84 @@ def _parse_db_url(url: str) -> tuple[str, int, str]:
     port = parsed.port or 5432
     db_name = parsed.path.lstrip("/") if parsed.path else "postgres"
     return host, port, db_name
+
+
+class _PoolWaitInstruments:
+    """OTel instruments + attributes for connection-acquisition metrics.
+
+    Held on the pool instance so ``connect()`` can emit without looking back
+    through the collector. A ``None`` slot on the pool means OTel is not
+    configured and the override degrades to a straight passthrough.
+    """
+
+    __slots__ = ("wait_time", "pending_requests", "timeouts", "attributes")
+
+    def __init__(self, wait_time, pending_requests, timeouts, attributes):
+        self.wait_time = wait_time
+        self.pending_requests = pending_requests
+        self.timeouts = timeouts
+        self.attributes = attributes
+
+
+class InstrumentedAsyncAdaptedQueuePool(AsyncAdaptedQueuePool):
+    """Async connection pool that measures connection acquisition.
+
+    Sources the three OTel DB connection-pool metrics that the checkout/checkin
+    events in ``PostgresPoolMetrics`` cannot: by the time ``checkout`` fires the
+    wait is already over, SQLAlchemy exposes no "started waiting" event, and a
+    pool timeout raises before any connection is handed out.
+
+    ``Pool.connect()`` is the single, non-recursive entry point for obtaining a
+    connection (``connect() -> _ConnectionFairy._checkout() -> _do_get()``) and
+    runs inside the acquiring greenlet, so wall-clock timing around it captures
+    the real wait — including time blocked on a saturated pool. Overriding
+    ``_do_get`` directly would double-count, because ``QueuePool._do_get``
+    recurses on itself on the overflow-retry path.
+
+    Emits (OTel-only; no StatsD dual-emit, these are new series with no Datadog
+    consumer yet):
+      * ``db.client.connection.wait_time``        — time to obtain a connection
+      * ``db.client.connection.pending_requests`` — requests waiting right now
+      * ``db.client.connection.timeouts``         — pool acquisition timeouts
+
+    The pool is constructed inside ``create_async_engine`` before the collector
+    has meters, so instruments are attached post-construction; until then, and
+    whenever OTel is disabled, ``connect()`` is a plain passthrough.
+    """
+
+    # None => passthrough (OTel disabled, or instruments not yet attached).
+    _wait_instruments: _PoolWaitInstruments | None = None
+
+    def attach_wait_instruments(self, instruments: _PoolWaitInstruments) -> None:
+        self._wait_instruments = instruments
+
+    def recreate(self) -> InstrumentedAsyncAdaptedQueuePool:
+        # dispose()/reset recreates the pool object; carry instrumentation
+        # forward so metrics don't silently go dark after a pool recreate.
+        new_pool = super().recreate()
+        new_pool._wait_instruments = self._wait_instruments
+        return new_pool
+
+    def connect(self):
+        instruments = self._wait_instruments
+        if instruments is None:
+            return super().connect()
+
+        attributes = instruments.attributes
+        instruments.pending_requests.add(1, attributes)
+        start = time.monotonic()
+        try:
+            connection = super().connect()
+        except SQLAlchemyTimeoutError:
+            instruments.timeouts.add(1, attributes)
+            raise
+        finally:
+            instruments.pending_requests.add(-1, attributes)
+
+        # Only reached on success: a timed-out (or otherwise failed) acquisition
+        # obtained no connection, so it must not land in the wait_time histogram.
+        instruments.wait_time.record(time.monotonic() - start, attributes)
+        return connection
 
 
 class PostgresPoolMetrics:
@@ -150,6 +252,52 @@ class PostgresPoolMetrics:
             description="Time a connection was checked out",
             unit="s",
         )
+
+        # Connection-acquisition metrics (OTel DB semconv). Sourced from the
+        # InstrumentedAsyncAdaptedQueuePool.connect() seam rather than pool
+        # events, which can't see the wait, the current waiters, or a timeout.
+        self._connection_wait_time: Histogram = meter.create_histogram(
+            name="db.client.connection.wait_time",
+            description="The time it took to obtain an open connection from the pool",
+            unit="s",
+            explicit_bucket_boundaries_advisory=_POOL_WAIT_BUCKET_BOUNDARIES_S,
+        )
+
+        self._connection_pending_requests: UpDownCounter = meter.create_up_down_counter(
+            name="db.client.connection.pending_requests",
+            description="The number of current pending requests for an open connection",
+            unit="{request}",
+        )
+
+        self._connection_timeouts: Counter = meter.create_counter(
+            name="db.client.connection.timeouts",
+            description=(
+                "The number of connection timeouts that have occurred trying to "
+                "obtain a connection from the pool"
+            ),
+            unit="{timeout}",
+        )
+
+        # Hand the instruments to the pool so its connect() override can emit.
+        # Only InstrumentedAsyncAdaptedQueuePool carries the hook; a differently
+        # configured engine (e.g. NullPool in tests) is left as a passthrough.
+        pool = self.engine.sync_engine.pool
+        if isinstance(pool, InstrumentedAsyncAdaptedQueuePool):
+            pool.attach_wait_instruments(
+                _PoolWaitInstruments(
+                    wait_time=self._connection_wait_time,
+                    pending_requests=self._connection_pending_requests,
+                    timeouts=self._connection_timeouts,
+                    attributes=self.base_attributes,
+                )
+            )
+        else:
+            logger.warning(
+                "Pool for %s is %s, not InstrumentedAsyncAdaptedQueuePool; "
+                "wait_time/pending_requests/timeouts will not be emitted",
+                pool_name,
+                type(pool).__name__,
+            )
 
         # Track last reported values for delta calculation
         self._last_idle = 0

--- a/agentex/src/utils/db_metrics.py
+++ b/agentex/src/utils/db_metrics.py
@@ -102,12 +102,13 @@ class _PoolWaitInstruments:
     configured and the override degrades to a straight passthrough.
     """
 
-    __slots__ = ("wait_time", "pending_requests", "timeouts", "attributes")
+    __slots__ = ("wait_time", "pending_requests", "timeouts", "failures", "attributes")
 
-    def __init__(self, wait_time, pending_requests, timeouts, attributes):
+    def __init__(self, wait_time, pending_requests, timeouts, failures, attributes):
         self.wait_time = wait_time
         self.pending_requests = pending_requests
         self.timeouts = timeouts
+        self.failures = failures
         self.attributes = attributes
 
 
@@ -131,6 +132,8 @@ class InstrumentedAsyncAdaptedQueuePool(AsyncAdaptedQueuePool):
       * ``db.client.connection.wait_time``        — time to obtain a connection
       * ``db.client.connection.pending_requests`` — requests waiting right now
       * ``db.client.connection.timeouts``         — pool acquisition timeouts
+      * ``db.client.connection.failures_total``   — non-timeout acquisition
+        failures (DB refusing connections, network errors), by ``error.type``
 
     The pool is constructed inside ``create_async_engine`` before the collector
     has meters, so instruments are attached post-construction; until then, and
@@ -162,6 +165,15 @@ class InstrumentedAsyncAdaptedQueuePool(AsyncAdaptedQueuePool):
             connection = super().connect()
         except SQLAlchemyTimeoutError:
             instruments.timeouts.add(1, attributes)
+            raise
+        except Exception as exc:
+            # Non-timeout acquisition failure (DB at max_connections, network
+            # drop while establishing, auth error). Without this branch the
+            # attempt vanishes from metrics: no wait_time sample (nothing was
+            # acquired) and no timeout.
+            instruments.failures.add(
+                1, {**attributes, "error.type": type(exc).__name__}
+            )
             raise
         finally:
             instruments.pending_requests.add(-1, attributes)
@@ -278,6 +290,17 @@ class PostgresPoolMetrics:
             unit="{timeout}",
         )
 
+        # Custom extension (semconv only covers timeouts): acquisitions that
+        # failed for any other reason, tagged with error.type.
+        self._connection_failures: Counter = meter.create_counter(
+            name="db.client.connection.failures_total",
+            description=(
+                "Connection acquisitions that failed for a reason other than a "
+                "pool timeout (DB refusing connections, network errors)"
+            ),
+            unit="{failure}",
+        )
+
         # Hand the instruments to the pool so its connect() override can emit.
         # Only InstrumentedAsyncAdaptedQueuePool carries the hook; a differently
         # configured engine (e.g. NullPool in tests) is left as a passthrough.
@@ -288,6 +311,7 @@ class PostgresPoolMetrics:
                     wait_time=self._connection_wait_time,
                     pending_requests=self._connection_pending_requests,
                     timeouts=self._connection_timeouts,
+                    failures=self._connection_failures,
                     attributes=self.base_attributes,
                 )
             )

--- a/agentex/src/utils/rpc_metrics.py
+++ b/agentex/src/utils/rpc_metrics.py
@@ -32,12 +32,17 @@ semconv; names may still evolve upstream.)
 
 from __future__ import annotations
 
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from src.utils.logging import make_logger
 from src.utils.otel_metrics import get_meter
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from opentelemetry.metrics import Counter, Histogram
 
 logger = make_logger(__name__)
@@ -196,3 +201,55 @@ def record_rpc_request(
         logger.info("Agent RPC completed", extra=completion_fields)
     except Exception:
         logger.debug("Failed to emit agentex.rpc metrics", exc_info=True)
+
+
+@dataclass
+class RpcCallOutcome:
+    """Mutable outcome a handler fills in inside ``rpc_request_timing``.
+
+    ``error_code`` set => the call returned a ``JSONRPCError`` frame (counted in
+    ``agentex.rpc.errors``). ``error_type`` alone => the call terminated
+    abnormally without delivering an error frame (e.g. client disconnect
+    mid-stream) — visible on the duration/request series but not an RPC error.
+    """
+
+    error_code: int | None = None
+    error_type: str | None = None
+
+    def fail(self, code: int, exc: BaseException) -> None:
+        """Mark the call as failed with a JSON-RPC error code."""
+        self.error_code = code
+        self.error_type = type(exc).__name__
+
+
+@contextmanager
+def rpc_request_timing(method: str, streaming: bool) -> Iterator[RpcCallOutcome]:
+    """
+    Time one RPC call and record it exactly once on exit.
+
+    The handler classifies failures it converts into ``JSONRPCError`` responses
+    via ``outcome.fail(code, exc)``; timing, the single ``record_rpc_request``
+    call, and abnormal-exit classification live here.
+
+    An exception escaping the body (including ``GeneratorExit`` /
+    ``CancelledError`` when a streaming client disconnects mid-response) is
+    recorded with ``error.type`` but no ``error_code`` — no error frame was
+    delivered, so it must not count as a JSON-RPC error, but it must not read
+    as a clean success either — then re-raised.
+    """
+    outcome = RpcCallOutcome()
+    start = time.perf_counter()
+    try:
+        yield outcome
+    except BaseException as e:
+        if outcome.error_type is None:
+            outcome.error_type = type(e).__name__
+        raise
+    finally:
+        record_rpc_request(
+            method=method,
+            streaming=streaming,
+            duration_s=time.perf_counter() - start,
+            error_code=outcome.error_code,
+            error_type=outcome.error_type,
+        )

--- a/agentex/src/utils/rpc_metrics.py
+++ b/agentex/src/utils/rpc_metrics.py
@@ -15,6 +15,17 @@ excluded from metric attributes; they belong on spans and logs only.
 JSON-RPC status note: RPC-level failures return HTTP 200 with a ``JSONRPCError``
 in the body, so ``rpc.response.status_code`` carries the JSON-RPC error code
 (e.g. ``-32603``), not the HTTP status. Success is recorded as ``ok``.
+
+``task/create`` doubles as the workflow-level entry point for an agent
+invocation, so it additionally emits ``gen_ai.workflow.duration`` labeled with
+the OTel GenAI operation name (``invoke_workflow``) — workflow-level duration
+stays directly queryable instead of being inferable only from RPC duration.
+The GenAI semconv pairs ``gen_ai.workflow.duration`` with ``invoke_workflow``;
+``invoke_agent`` is reserved for ``gen_ai.invoke_agent.duration``, which the
+agent loop itself will emit — keeping the two operation names distinct means a
+query on either name never mixes gateway workflow duration with in-pod agent
+invocation duration. (These metrics are Development stability in the GenAI
+semconv; names may still evolve upstream.)
 """
 
 from __future__ import annotations
@@ -33,6 +44,14 @@ RPC_SYSTEM = "jsonrpc"
 
 # JSON-RPC status for a successful call (there is no success code in the spec).
 RPC_STATUS_OK = "ok"
+
+# Methods that mark the workflow-level entry point of an agent invocation, and
+# the OTel GenAI operation name each one is recorded under. Only these methods
+# emit ``gen_ai.workflow.duration``; the value must stay a bounded set of
+# semconv-style operation names, never a per-request identifier.
+WORKFLOW_OPERATION_BY_METHOD = {
+    "task/create": "invoke_workflow",
+}
 
 # Bucket boundaries (seconds) for the request-duration histogram: the OTel HTTP
 # semconv boundaries extended upward, because streaming responses are timed
@@ -61,12 +80,14 @@ _DURATION_BUCKET_BOUNDARIES_S = (
 _duration_histogram: Histogram | None = None
 _request_counter: Counter | None = None
 _error_counter: Counter | None = None
+_workflow_duration_histogram: Histogram | None = None
 _instruments_initialized = False
 
 
 def _ensure_instruments() -> None:
     """Create OTel instruments on first use. No-op if OTel is not configured."""
     global _duration_histogram, _request_counter, _error_counter
+    global _workflow_duration_histogram
     global _instruments_initialized
 
     if _instruments_initialized:
@@ -94,6 +115,16 @@ def _ensure_instruments() -> None:
         name="agentex.rpc.errors",
         description="Agent JSON-RPC requests that returned a JSONRPCError",
         unit="{error}",
+    )
+    _workflow_duration_histogram = meter.create_histogram(
+        name="gen_ai.workflow.duration",
+        description=(
+            "Duration of the workflow-level agent invocation entry point, "
+            "tagged with the GenAI operation name (e.g. invoke_workflow for "
+            "task/create)"
+        ),
+        unit="s",
+        explicit_bucket_boundaries_advisory=_DURATION_BUCKET_BOUNDARIES_S,
     )
 
 
@@ -137,6 +168,15 @@ def record_rpc_request(
             _request_counter.add(1, attributes)
         if _error_counter is not None and status_code != RPC_STATUS_OK:
             _error_counter.add(1, attributes)
+
+        workflow_operation = WORKFLOW_OPERATION_BY_METHOD.get(method)
+        if workflow_operation is not None and _workflow_duration_histogram is not None:
+            workflow_attributes: dict[str, str] = {
+                "gen_ai.operation.name": workflow_operation,
+            }
+            if error_type is not None:
+                workflow_attributes["error.type"] = error_type
+            _workflow_duration_histogram.record(duration_s, workflow_attributes)
 
         # One structured completion line per RPC, carrying the terminal fields
         # the observability contract requires on logs (status, error.type,

--- a/agentex/src/utils/rpc_metrics.py
+++ b/agentex/src/utils/rpc_metrics.py
@@ -1,0 +1,155 @@
+"""
+Metrics for the agent JSON-RPC endpoint (``/agents/*/rpc``).
+
+Recorded through the OpenTelemetry SDK when an OTLP endpoint is configured
+(``OTEL_EXPORTER_OTLP_ENDPOINT``); when it isn't, every function here is a
+cheap no-op. Unlike ``src/utils/db_metrics.py`` / ``src/utils/cache_metrics.py``
+there is no StatsD dual-emit: these series are new, so nothing on the Datadog
+side consumes them — OTel-only until a consumer appears.
+
+Metric attributes follow the OTel RPC semantic conventions (``rpc.system.name``,
+``rpc.method``, ``rpc.response.status_code``, ``error.type``) plus ``streaming``.
+High-cardinality identifiers (task id, agent id, request id) are deliberately
+excluded from metric attributes; they belong on spans and logs only.
+
+JSON-RPC status note: RPC-level failures return HTTP 200 with a ``JSONRPCError``
+in the body, so ``rpc.response.status_code`` carries the JSON-RPC error code
+(e.g. ``-32603``), not the HTTP status. Success is recorded as ``ok``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.utils.logging import make_logger
+from src.utils.otel_metrics import get_meter
+
+if TYPE_CHECKING:
+    from opentelemetry.metrics import Counter, Histogram
+
+logger = make_logger(__name__)
+
+RPC_SYSTEM = "jsonrpc"
+
+# JSON-RPC status for a successful call (there is no success code in the spec).
+RPC_STATUS_OK = "ok"
+
+# Bucket boundaries (seconds) for the request-duration histogram: the OTel HTTP
+# semconv boundaries extended upward, because streaming responses are timed
+# dispatch-to-final-byte and regularly run minutes. Without this advisory the
+# SDK falls back to millisecond-scale default boundaries [0, 5, 10, 25, ...]
+# and every sub-5-second observation lands in a single bucket.
+_DURATION_BUCKET_BOUNDARIES_S = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+    60.0,
+    120.0,
+    300.0,
+)
+
+# Lazily-created OTel instruments (created once, on first use).
+_duration_histogram: Histogram | None = None
+_request_counter: Counter | None = None
+_error_counter: Counter | None = None
+_instruments_initialized = False
+
+
+def _ensure_instruments() -> None:
+    """Create OTel instruments on first use. No-op if OTel is not configured."""
+    global _duration_histogram, _request_counter, _error_counter
+    global _instruments_initialized
+
+    if _instruments_initialized:
+        return
+    _instruments_initialized = True
+
+    meter = get_meter("agentex.rpc")
+    if meter is None:
+        # OTel not configured; nothing to emit to. Instruments stay None and
+        # record_rpc_request degrades to just the completion log line.
+        return
+
+    _duration_histogram = meter.create_histogram(
+        name="agentex.rpc.request.duration",
+        description="Duration of agent JSON-RPC requests, from dispatch to final byte",
+        unit="s",
+        explicit_bucket_boundaries_advisory=_DURATION_BUCKET_BOUNDARIES_S,
+    )
+    _request_counter = meter.create_counter(
+        name="agentex.rpc.requests",
+        description="Agent JSON-RPC requests, tagged by method, status, and streaming",
+        unit="{request}",
+    )
+    _error_counter = meter.create_counter(
+        name="agentex.rpc.errors",
+        description="Agent JSON-RPC requests that returned a JSONRPCError",
+        unit="{error}",
+    )
+
+
+def record_rpc_request(
+    method: str,
+    streaming: bool,
+    duration_s: float,
+    status_code: str = RPC_STATUS_OK,
+    error_type: str | None = None,
+) -> None:
+    """
+    Record one completed JSON-RPC request (successful or failed).
+
+    Args:
+        method: JSON-RPC method (e.g. "task/create", "message/send").
+        streaming: Whether the response was streamed (NDJSON) or a single body.
+        duration_s: Seconds from dispatch to completion. For streaming
+            responses this covers the whole stream, not just the handler return.
+        status_code: ``RPC_STATUS_OK`` or the JSON-RPC error code as a string
+            (e.g. "-32602").
+        error_type: Exception class name for failures; omitted on success.
+
+    Never raises: emission failures (an OTel SDK fault) are swallowed so
+    instrumentation can never disrupt the RPC path.
+    """
+    try:
+        _ensure_instruments()
+
+        attributes: dict[str, str | bool] = {
+            "rpc.system.name": RPC_SYSTEM,
+            "rpc.method": method,
+            "rpc.response.status_code": status_code,
+            "streaming": streaming,
+        }
+        if error_type is not None:
+            attributes["error.type"] = error_type
+
+        if _duration_histogram is not None:
+            _duration_histogram.record(duration_s, attributes)
+        if _request_counter is not None:
+            _request_counter.add(1, attributes)
+        if _error_counter is not None and status_code != RPC_STATUS_OK:
+            _error_counter.add(1, attributes)
+
+        # One structured completion line per RPC, carrying the terminal fields
+        # the observability contract requires on logs (status, error.type,
+        # duration_ms). rpc.method / agent.* / task.id ride along via the
+        # per-request log-fields context (see add_log_fields).
+        completion_fields: dict[str, str | bool | float] = {
+            "rpc.method": method,
+            "status": status_code,
+            "streaming": streaming,
+            "duration_ms": round(duration_s * 1000.0, 3),
+        }
+        if error_type is not None:
+            completion_fields["error.type"] = error_type
+        logger.info("Agent RPC completed", extra=completion_fields)
+    except Exception:
+        logger.debug("Failed to emit agentex.rpc metrics", exc_info=True)

--- a/agentex/src/utils/rpc_metrics.py
+++ b/agentex/src/utils/rpc_metrics.py
@@ -7,14 +7,16 @@ cheap no-op. Unlike ``src/utils/db_metrics.py`` / ``src/utils/cache_metrics.py``
 there is no StatsD dual-emit: these series are new, so nothing on the Datadog
 side consumes them — OTel-only until a consumer appears.
 
-Metric attributes follow the OTel RPC semantic conventions (``rpc.system.name``,
-``rpc.method``, ``rpc.response.status_code``, ``error.type``) plus ``streaming``.
+Metric attributes follow the OTel RPC semantic conventions (``rpc.system``,
+``rpc.method``, ``rpc.jsonrpc.error_code``, ``error.type``) plus ``streaming``.
 High-cardinality identifiers (task id, agent id, request id) are deliberately
 excluded from metric attributes; they belong on spans and logs only.
 
 JSON-RPC status note: RPC-level failures return HTTP 200 with a ``JSONRPCError``
-in the body, so ``rpc.response.status_code`` carries the JSON-RPC error code
-(e.g. ``-32603``), not the HTTP status. Success is recorded as ``ok``.
+in the body, so failures carry ``rpc.jsonrpc.error_code`` (the JSON-RPC error
+code, e.g. ``-32603``) rather than an HTTP status. Per the RPC semconv the
+attribute is only set when the call failed; success omits it, and error rate is
+read from the dedicated ``agentex.rpc.errors`` counter.
 
 ``task/create`` doubles as the workflow-level entry point for an agent
 invocation, so it additionally emits ``gen_ai.workflow.duration`` labeled with
@@ -41,9 +43,6 @@ if TYPE_CHECKING:
 logger = make_logger(__name__)
 
 RPC_SYSTEM = "jsonrpc"
-
-# JSON-RPC status for a successful call (there is no success code in the spec).
-RPC_STATUS_OK = "ok"
 
 # Methods that mark the workflow-level entry point of an agent invocation, and
 # the OTel GenAI operation name each one is recorded under. Only these methods
@@ -132,7 +131,7 @@ def record_rpc_request(
     method: str,
     streaming: bool,
     duration_s: float,
-    status_code: str = RPC_STATUS_OK,
+    error_code: int | None = None,
     error_type: str | None = None,
 ) -> None:
     """
@@ -143,8 +142,9 @@ def record_rpc_request(
         streaming: Whether the response was streamed (NDJSON) or a single body.
         duration_s: Seconds from dispatch to completion. For streaming
             responses this covers the whole stream, not just the handler return.
-        status_code: ``RPC_STATUS_OK`` or the JSON-RPC error code as a string
-            (e.g. "-32602").
+        error_code: JSON-RPC error code (e.g. -32602) when the call failed;
+            ``None`` on success. Sets the ``rpc.jsonrpc.error_code`` attribute
+            and drives the error counter.
         error_type: Exception class name for failures; omitted on success.
 
     Never raises: emission failures (an OTel SDK fault) are swallowed so
@@ -153,12 +153,15 @@ def record_rpc_request(
     try:
         _ensure_instruments()
 
-        attributes: dict[str, str | bool] = {
-            "rpc.system.name": RPC_SYSTEM,
+        failed = error_code is not None
+        attributes: dict[str, str | bool | int] = {
+            "rpc.system": RPC_SYSTEM,
             "rpc.method": method,
-            "rpc.response.status_code": status_code,
             "streaming": streaming,
         }
+        # rpc.jsonrpc.error_code is set only on failure, per the RPC semconv.
+        if error_code is not None:
+            attributes["rpc.jsonrpc.error_code"] = error_code
         if error_type is not None:
             attributes["error.type"] = error_type
 
@@ -166,7 +169,7 @@ def record_rpc_request(
             _duration_histogram.record(duration_s, attributes)
         if _request_counter is not None:
             _request_counter.add(1, attributes)
-        if _error_counter is not None and status_code != RPC_STATUS_OK:
+        if _error_counter is not None and failed:
             _error_counter.add(1, attributes)
 
         workflow_operation = WORKFLOW_OPERATION_BY_METHOD.get(method)
@@ -184,7 +187,7 @@ def record_rpc_request(
         # per-request log-fields context (see add_log_fields).
         completion_fields: dict[str, str | bool | float] = {
             "rpc.method": method,
-            "status": status_code,
+            "status": "ok" if error_code is None else str(error_code),
             "streaming": streaming,
             "duration_ms": round(duration_s * 1000.0, 3),
         }

--- a/agentex/tests/unit/utils/test_db_metrics.py
+++ b/agentex/tests/unit/utils/test_db_metrics.py
@@ -1,0 +1,155 @@
+"""Tests for the InstrumentedAsyncAdaptedQueuePool connection-acquisition metrics.
+
+These three series (wait_time / pending_requests / timeouts) can't be sourced
+from SQLAlchemy's checkout/checkin events, so they're emitted from a connect()
+override. The contract under test:
+
+  * unattached (OTel disabled) -> connect() is a pure passthrough,
+  * success -> pending +1 then -1, wait_time recorded once, no timeout,
+  * pool timeout -> timeout counted, pending balanced, wait_time NOT recorded,
+    and the original error still propagates,
+  * recreate() carries the instruments forward so metrics survive a dispose.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.pool import AsyncAdaptedQueuePool
+from src.utils import db_metrics
+from src.utils.db_metrics import (
+    InstrumentedAsyncAdaptedQueuePool,
+    _PoolWaitInstruments,
+)
+
+
+def _make_pool() -> InstrumentedAsyncAdaptedQueuePool:
+    # A creator that is never invoked: super().connect() is patched in every
+    # test that exercises acquisition, so no real DBAPI connection is made.
+    return InstrumentedAsyncAdaptedQueuePool(lambda: None, pool_size=1, max_overflow=0)
+
+
+def _mock_instruments() -> tuple[_PoolWaitInstruments, dict]:
+    attributes = {"db.client.connection.pool.name": "main"}
+    instruments = _PoolWaitInstruments(
+        wait_time=MagicMock(),
+        pending_requests=MagicMock(),
+        timeouts=MagicMock(),
+        attributes=attributes,
+    )
+    return instruments, attributes
+
+
+@pytest.mark.unit
+def test_connect_is_passthrough_when_no_instruments_attached():
+    pool = _make_pool()
+    sentinel = object()
+    with patch.object(
+        AsyncAdaptedQueuePool, "connect", return_value=sentinel
+    ) as super_connect:
+        assert pool.connect() is sentinel
+    super_connect.assert_called_once()
+
+
+@pytest.mark.unit
+def test_connect_success_records_wait_time_and_balances_pending():
+    pool = _make_pool()
+    instruments, attributes = _mock_instruments()
+    pool.attach_wait_instruments(instruments)
+
+    sentinel = object()
+    with patch.object(AsyncAdaptedQueuePool, "connect", return_value=sentinel):
+        assert pool.connect() is sentinel
+
+    # Joined the queue, then left it — net zero.
+    assert instruments.pending_requests.add.call_args_list == [
+        call(1, attributes),
+        call(-1, attributes),
+    ]
+    instruments.wait_time.record.assert_called_once()
+    recorded_value, recorded_attrs = instruments.wait_time.record.call_args.args
+    assert recorded_value >= 0
+    assert recorded_attrs is attributes
+    instruments.timeouts.add.assert_not_called()
+
+
+@pytest.mark.unit
+def test_connect_timeout_counts_timeout_and_skips_wait_time():
+    pool = _make_pool()
+    instruments, attributes = _mock_instruments()
+    pool.attach_wait_instruments(instruments)
+
+    boom = SQLAlchemyTimeoutError("QueuePool limit reached")
+    with patch.object(AsyncAdaptedQueuePool, "connect", side_effect=boom):
+        with pytest.raises(SQLAlchemyTimeoutError):
+            pool.connect()
+
+    instruments.timeouts.add.assert_called_once_with(1, attributes)
+    # A timed-out acquisition obtained no connection, so no wait_time sample.
+    instruments.wait_time.record.assert_not_called()
+    # pending is still balanced even though acquisition failed.
+    assert instruments.pending_requests.add.call_args_list == [
+        call(1, attributes),
+        call(-1, attributes),
+    ]
+
+
+@pytest.mark.unit
+def test_connect_non_timeout_error_balances_pending_without_counting_timeout():
+    pool = _make_pool()
+    instruments, attributes = _mock_instruments()
+    pool.attach_wait_instruments(instruments)
+
+    with patch.object(
+        AsyncAdaptedQueuePool, "connect", side_effect=RuntimeError("driver blew up")
+    ):
+        with pytest.raises(RuntimeError):
+            pool.connect()
+
+    instruments.timeouts.add.assert_not_called()
+    instruments.wait_time.record.assert_not_called()
+    assert instruments.pending_requests.add.call_args_list == [
+        call(1, attributes),
+        call(-1, attributes),
+    ]
+
+
+@pytest.mark.unit
+def test_recreate_carries_instruments_forward():
+    pool = _make_pool()
+    instruments, _ = _mock_instruments()
+    pool.attach_wait_instruments(instruments)
+
+    new_pool = pool.recreate()
+    assert isinstance(new_pool, InstrumentedAsyncAdaptedQueuePool)
+    assert new_pool._wait_instruments is instruments
+
+
+@pytest.mark.unit
+def test_register_engine_attaches_instruments_to_pool():
+    # End-to-end wiring: PostgresPoolMetrics should hand its instruments to an
+    # InstrumentedAsyncAdaptedQueuePool when OTel is enabled.
+    pool = _make_pool()
+    fake_engine = MagicMock()
+    fake_engine.sync_engine.pool = pool
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch.object(db_metrics, "get_meter", return_value=MagicMock())
+        )
+        # Don't register real SQLAlchemy event listeners against the mock engine.
+        stack.enter_context(
+            patch.object(db_metrics.PostgresPoolMetrics, "_register_pool_events")
+        )
+        db_metrics.PostgresPoolMetrics(
+            engine=fake_engine,
+            pool_name="main",
+            db_url="postgresql://user:pass@localhost:5432/agentex",
+            environment="test",
+        )
+
+    assert pool._wait_instruments is not None
+    assert pool._wait_instruments.attributes["db.client.connection.pool.name"] == "main"

--- a/agentex/tests/unit/utils/test_db_metrics.py
+++ b/agentex/tests/unit/utils/test_db_metrics.py
@@ -1,13 +1,15 @@
 """Tests for the InstrumentedAsyncAdaptedQueuePool connection-acquisition metrics.
 
-These three series (wait_time / pending_requests / timeouts) can't be sourced
-from SQLAlchemy's checkout/checkin events, so they're emitted from a connect()
-override. The contract under test:
+These series (wait_time / pending_requests / timeouts / failures) can't be
+sourced from SQLAlchemy's checkout/checkin events, so they're emitted from a
+connect() override. The contract under test:
 
   * unattached (OTel disabled) -> connect() is a pure passthrough,
   * success -> pending +1 then -1, wait_time recorded once, no timeout,
   * pool timeout -> timeout counted, pending balanced, wait_time NOT recorded,
     and the original error still propagates,
+  * any other acquisition error -> failure counted with error.type, no timeout,
+    pending balanced, original error still propagates,
   * recreate() carries the instruments forward so metrics survive a dispose.
 """
 
@@ -38,6 +40,7 @@ def _mock_instruments() -> tuple[_PoolWaitInstruments, dict]:
         wait_time=MagicMock(),
         pending_requests=MagicMock(),
         timeouts=MagicMock(),
+        failures=MagicMock(),
         attributes=attributes,
     )
     return instruments, attributes
@@ -88,6 +91,7 @@ def test_connect_timeout_counts_timeout_and_skips_wait_time():
             pool.connect()
 
     instruments.timeouts.add.assert_called_once_with(1, attributes)
+    instruments.failures.add.assert_not_called()
     # A timed-out acquisition obtained no connection, so no wait_time sample.
     instruments.wait_time.record.assert_not_called()
     # pending is still balanced even though acquisition failed.
@@ -98,7 +102,7 @@ def test_connect_timeout_counts_timeout_and_skips_wait_time():
 
 
 @pytest.mark.unit
-def test_connect_non_timeout_error_balances_pending_without_counting_timeout():
+def test_connect_non_timeout_error_counts_failure_with_error_type():
     pool = _make_pool()
     instruments, attributes = _mock_instruments()
     pool.attach_wait_instruments(instruments)
@@ -109,7 +113,12 @@ def test_connect_non_timeout_error_balances_pending_without_counting_timeout():
         with pytest.raises(RuntimeError):
             pool.connect()
 
+    # Not a pool timeout — it lands in the catch-all failure counter, tagged
+    # with the exception type, so refused/dropped connections aren't invisible.
     instruments.timeouts.add.assert_not_called()
+    instruments.failures.add.assert_called_once_with(
+        1, {**attributes, "error.type": "RuntimeError"}
+    )
     instruments.wait_time.record.assert_not_called()
     assert instruments.pending_requests.add.call_args_list == [
         call(1, attributes),

--- a/agentex/tests/unit/utils/test_rpc_metrics.py
+++ b/agentex/tests/unit/utils/test_rpc_metrics.py
@@ -74,12 +74,12 @@ def test_otel_emission_names_and_attributes():
         )
 
     expected_attributes = {
-        "rpc.system.name": "jsonrpc",
+        "rpc.system": "jsonrpc",
         "rpc.method": "message/send",
-        "rpc.response.status_code": "ok",
         "streaming": True,
     }
-    # Duration is recorded in seconds on the OTel side.
+    # Duration is recorded in seconds on the OTel side. Success omits
+    # rpc.jsonrpc.error_code, per the RPC semconv.
     histogram.record.assert_called_once_with(2.0, expected_attributes)
     requests.add.assert_called_once_with(1, expected_attributes)
     errors.add.assert_not_called()
@@ -95,14 +95,14 @@ def test_error_counter_on_failure():
             method="message/send",
             streaming=False,
             duration_s=0.4,
-            status_code="-32603",
+            error_code=-32603,
             error_type="ValueError",
         )
 
     expected_attributes = {
-        "rpc.system.name": "jsonrpc",
+        "rpc.system": "jsonrpc",
         "rpc.method": "message/send",
-        "rpc.response.status_code": "-32603",
+        "rpc.jsonrpc.error_code": -32603,
         "streaming": False,
         "error.type": "ValueError",
     }
@@ -133,7 +133,7 @@ def test_otel_workflow_histogram_records_error_type_on_failure():
             method="task/create",
             streaming=False,
             duration_s=0.3,
-            status_code="-32603",
+            error_code=-32603,
             error_type="ValueError",
         )
 

--- a/agentex/tests/unit/utils/test_rpc_metrics.py
+++ b/agentex/tests/unit/utils/test_rpc_metrics.py
@@ -3,6 +3,8 @@
 Same operational contract as the other metric emitters: the unconfigured path
 must be a harmless no-op, emission failures must never propagate into the RPC
 path, and the configured path must record the expected names and attributes.
+Also covers the workflow-level GenAI histogram, which only workflow
+entry-point methods (task/create) may emit.
 """
 
 from __future__ import annotations
@@ -25,6 +27,7 @@ def _patched_instruments(stack: ExitStack, **overrides):
         "_duration_histogram": None,
         "_request_counter": None,
         "_error_counter": None,
+        "_workflow_duration_histogram": None,
     }
     state.update(overrides)
     for name, value in state.items():
@@ -105,3 +108,48 @@ def test_error_counter_on_failure():
     }
     requests.add.assert_called_once_with(1, expected_attributes)
     errors.add.assert_called_once_with(1, expected_attributes)
+
+
+@pytest.mark.unit
+def test_otel_workflow_histogram_for_task_create():
+    workflow_histogram = MagicMock()
+    with ExitStack() as stack:
+        _patched_instruments(stack, _workflow_duration_histogram=workflow_histogram)
+        rpc_metrics.record_rpc_request(
+            method="task/create", streaming=False, duration_s=0.5
+        )
+
+    workflow_histogram.record.assert_called_once_with(
+        0.5, {"gen_ai.operation.name": "invoke_workflow"}
+    )
+
+
+@pytest.mark.unit
+def test_otel_workflow_histogram_records_error_type_on_failure():
+    workflow_histogram = MagicMock()
+    with ExitStack() as stack:
+        _patched_instruments(stack, _workflow_duration_histogram=workflow_histogram)
+        rpc_metrics.record_rpc_request(
+            method="task/create",
+            streaming=False,
+            duration_s=0.3,
+            status_code="-32603",
+            error_type="ValueError",
+        )
+
+    workflow_histogram.record.assert_called_once_with(
+        0.3,
+        {"gen_ai.operation.name": "invoke_workflow", "error.type": "ValueError"},
+    )
+
+
+@pytest.mark.unit
+def test_otel_workflow_histogram_not_recorded_for_non_workflow_method():
+    workflow_histogram = MagicMock()
+    with ExitStack() as stack:
+        _patched_instruments(stack, _workflow_duration_histogram=workflow_histogram)
+        rpc_metrics.record_rpc_request(
+            method="message/send", streaming=True, duration_s=0.1
+        )
+
+    workflow_histogram.record.assert_not_called()

--- a/agentex/tests/unit/utils/test_rpc_metrics.py
+++ b/agentex/tests/unit/utils/test_rpc_metrics.py
@@ -153,3 +153,82 @@ def test_otel_workflow_histogram_not_recorded_for_non_workflow_method():
         )
 
     workflow_histogram.record.assert_not_called()
+
+
+@pytest.mark.unit
+def test_timing_success_records_exactly_once_with_no_error():
+    with patch.object(rpc_metrics, "record_rpc_request") as record:
+        with rpc_metrics.rpc_request_timing("task/create", streaming=False):
+            pass
+
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["method"] == "task/create"
+    assert kwargs["streaming"] is False
+    assert kwargs["error_code"] is None
+    assert kwargs["error_type"] is None
+    assert kwargs["duration_s"] >= 0
+
+
+@pytest.mark.unit
+def test_timing_handler_classified_failure_records_exactly_once():
+    # The double-count regression: a handler that converts an exception into a
+    # JSONRPCError response (and returns normally) must produce ONE record
+    # carrying the error code — not one success and one failure.
+    with patch.object(rpc_metrics, "record_rpc_request") as record:
+        with rpc_metrics.rpc_request_timing("task/create", streaming=False) as rpc_call:
+            rpc_call.fail(-32602, ValueError("bad params"))
+
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["error_code"] == -32602
+    assert kwargs["error_type"] == "ValueError"
+
+
+@pytest.mark.unit
+def test_timing_escaping_exception_sets_error_type_and_reraises():
+    with patch.object(rpc_metrics, "record_rpc_request") as record:
+        with pytest.raises(RuntimeError):
+            with rpc_metrics.rpc_request_timing("message/send", streaming=False):
+                raise RuntimeError("handler blew up unclassified")
+
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["error_code"] is None
+    assert kwargs["error_type"] == "RuntimeError"
+
+
+@pytest.mark.unit
+def test_timing_client_disconnect_is_not_a_success_and_not_an_rpc_error():
+    # GeneratorExit is what a streaming generator sees when the client
+    # disconnects mid-response: no error frame was delivered (error_code stays
+    # None, so agentex.rpc.errors is untouched), but error.type must mark the
+    # call so truncated streams don't read as clean successes.
+    with patch.object(rpc_metrics, "record_rpc_request") as record:
+        with pytest.raises(GeneratorExit):
+            with rpc_metrics.rpc_request_timing("message/send", streaming=True):
+                raise GeneratorExit()
+
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["error_code"] is None
+    assert kwargs["error_type"] == "GeneratorExit"
+
+
+@pytest.mark.unit
+def test_timing_keeps_handler_classification_when_error_frame_delivery_dies():
+    # A handler classifies a failure, then the yield of the error frame itself
+    # dies (client already gone). The classified code must win — still exactly
+    # one record.
+    with patch.object(rpc_metrics, "record_rpc_request") as record:
+        with pytest.raises(GeneratorExit):
+            with rpc_metrics.rpc_request_timing(
+                "message/send", streaming=True
+            ) as rpc_call:
+                rpc_call.fail(-32603, ValueError("upstream error"))
+                raise GeneratorExit()
+
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["error_code"] == -32603
+    assert kwargs["error_type"] == "ValueError"

--- a/agentex/tests/unit/utils/test_rpc_metrics.py
+++ b/agentex/tests/unit/utils/test_rpc_metrics.py
@@ -1,0 +1,107 @@
+"""Tests for the agent RPC metrics emitter.
+
+Same operational contract as the other metric emitters: the unconfigured path
+must be a harmless no-op, emission failures must never propagate into the RPC
+path, and the configured path must record the expected names and attributes.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+from src.utils import rpc_metrics
+
+
+def _patched_instruments(stack: ExitStack, **overrides):
+    """Patch module state so record_rpc_request runs against controlled instruments.
+
+    Defaults to everything disabled (OTel unconfigured); pass instrument mocks
+    to enable a path.
+    """
+    state = {
+        "_instruments_initialized": True,
+        "_duration_histogram": None,
+        "_request_counter": None,
+        "_error_counter": None,
+    }
+    state.update(overrides)
+    for name, value in state.items():
+        stack.enter_context(patch.object(rpc_metrics, name, value))
+
+
+@pytest.mark.unit
+def test_record_rpc_request_is_noop_when_unconfigured():
+    # With no OTLP endpoint configured, the call must be harmless.
+    with ExitStack() as stack:
+        _patched_instruments(stack)
+        rpc_metrics.record_rpc_request(
+            method="message/send", streaming=True, duration_s=1.5
+        )
+
+
+@pytest.mark.unit
+def test_record_rpc_request_swallows_emission_errors():
+    # A failing backend must never propagate into the RPC path.
+    with ExitStack() as stack:
+        histogram = MagicMock()
+        histogram.record.side_effect = RuntimeError("SDK in a bad state")
+        _patched_instruments(stack, _duration_histogram=histogram)
+
+        rpc_metrics.record_rpc_request(
+            method="task/create", streaming=False, duration_s=0.2
+        )
+
+
+@pytest.mark.unit
+def test_otel_emission_names_and_attributes():
+    with ExitStack() as stack:
+        histogram = MagicMock()
+        requests = MagicMock()
+        errors = MagicMock()
+        _patched_instruments(
+            stack,
+            _duration_histogram=histogram,
+            _request_counter=requests,
+            _error_counter=errors,
+        )
+        rpc_metrics.record_rpc_request(
+            method="message/send", streaming=True, duration_s=2.0
+        )
+
+    expected_attributes = {
+        "rpc.system.name": "jsonrpc",
+        "rpc.method": "message/send",
+        "rpc.response.status_code": "ok",
+        "streaming": True,
+    }
+    # Duration is recorded in seconds on the OTel side.
+    histogram.record.assert_called_once_with(2.0, expected_attributes)
+    requests.add.assert_called_once_with(1, expected_attributes)
+    errors.add.assert_not_called()
+
+
+@pytest.mark.unit
+def test_error_counter_on_failure():
+    with ExitStack() as stack:
+        requests = MagicMock()
+        errors = MagicMock()
+        _patched_instruments(stack, _request_counter=requests, _error_counter=errors)
+        rpc_metrics.record_rpc_request(
+            method="message/send",
+            streaming=False,
+            duration_s=0.4,
+            status_code="-32603",
+            error_type="ValueError",
+        )
+
+    expected_attributes = {
+        "rpc.system.name": "jsonrpc",
+        "rpc.method": "message/send",
+        "rpc.response.status_code": "-32603",
+        "streaming": False,
+        "error.type": "ValueError",
+    }
+    requests.add.assert_called_once_with(1, expected_attributes)
+    errors.add.assert_called_once_with(1, expected_attributes)


### PR DESCRIPTION
## Summary

Brings the agent JSON-RPC endpoint (`POST /agents/{id}/rpc` — `task/create` / `message/send` / `event/send`) up to the metrics observability contract, and adds high-signal Postgres connection-pool saturation metrics. Everything here is OTel-only (no StatsD dual-emit — these are new series with no existing consumer), and a cheap no-op when no OTLP endpoint is configured.

### RPC RED metrics (`agentex.rpc.*`)
- `agentex.rpc.request.duration` (timed dispatch → final byte, so streaming responses are covered end-to-end), `agentex.rpc.requests`, `agentex.rpc.errors`.
- Attributes follow the OTel RPC semantic conventions: `rpc.system`, `rpc.method`, `rpc.jsonrpc.error_code`, `error.type`, `streaming`. No high-cardinality identifiers (no task/agent/request ids). JSON-RPC failures return HTTP 200, so the error code rides on `rpc.jsonrpc.error_code` (set only on failure), not an HTTP status.
- Never-raise emission; a single terminal emit per request covering the whole stream.

### Workflow-level GenAI metric
- `gen_ai.workflow.duration` for `task/create`, labeled `gen_ai.operation.name=invoke_workflow`, so workflow-level duration is directly queryable instead of only inferable from RPC duration. `invoke_agent` stays reserved for the agent loop's own duration, so the two operation names never mix gateway and in-pod durations.

### DB connection-pool metrics (OTel DB semconv)
- `db.client.connection.wait_time`, `db.client.connection.pending_requests`, `db.client.connection.timeouts` — the pre-outage early-warning signals for pool exhaustion.
- Sourced from an `InstrumentedAsyncAdaptedQueuePool` that wraps `Pool.connect()` (the single, non-recursive acquisition entry point, run inside the acquiring greenlet). The existing checkout/checkin listeners can't produce these: by the time `checkout` fires the wait is over, there's no waiter count, and a pool timeout raises before any connection is handed out.
- `wait_time` uses explicit second-scale histogram buckets so quantiles stay usable (the SDK default boundaries assume a millisecond unit).

## Testing
- Unit tests in `tests/unit/utils/test_rpc_metrics.py` and `test_db_metrics.py`: unconfigured no-op, never-raise on backend faults, metric name/attribute assertions, and the pool success / timeout / non-timeout-error paths. All green; `ruff` clean.

## Notes / follow-ups
- Requires an OTLP endpoint configured on the pods to export.
- HTTP auto-instrumentation (route-templated `http_server_request_duration_seconds`) lands on a separate branch.
- Dashboard/Mimir verification and matrix backfill to follow once the target environment is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds OTel-only RED metrics for the agent JSON-RPC endpoint (`agentex.rpc.*`), a GenAI workflow-duration histogram for `task/create`, and Postgres connection-pool acquisition metrics (`db.client.connection.wait_time/pending_requests/timeouts/failures`) sourced from a new `InstrumentedAsyncAdaptedQueuePool` subclass. It also removes the `namespace: agentex` from the local OTel collector's Prometheus exporter to fix a double-prefix bug that would have appeared for new `agentex.*`-prefixed instrument names.

- **RPC metrics**: A synchronous `@contextmanager` (`rpc_request_timing`) wraps both sync and streaming handlers; a `RpcCallOutcome` dataclass lets handlers classify JSON-RPC error codes, with `BaseException` catching client disconnects (e.g., `GeneratorExit`) separately from structured RPC errors. Never-raise contract is enforced throughout.
- **DB pool metrics**: `InstrumentedAsyncAdaptedQueuePool.connect()` is the correct interception seam (checkout/checkin events can\u2019t see the wait or a timeout), instruments are attached post-construction and carried across `recreate()`, and the `wait_time` histogram uses explicit second-scale buckets to keep quantiles usable.
- **Collector config**: Removing `namespace: agentex` aligns local PromQL with the production Mimir pipeline but renames existing `agentex_db_*` local series to `db_*`; teams with local Grafana dashboards querying the old prefixed names will need to update their queries.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are additive instrumentation with a never-raise emission contract and no mutations to the core RPC execution path.

The RPC and DB pool metric additions are purely observational. The rpc_request_timing contextmanager correctly handles BaseException including GeneratorExit, the pool override degrades to a passthrough when OTel is unconfigured, and recreate() carries instrumentation forward. Unit tests cover the no-op path, never-raise contract, double-count regression, and the streaming GeneratorExit scenario.

**Files Needing Attention:** No files require special attention. The otel-collector-config.yaml namespace removal warrants a local dashboard audit if Prometheus queries exist against the old agentex_db_*-prefixed series.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/utils/rpc_metrics.py | New module: RPC RED metrics and workflow-duration histogram with correct OTel semconv, never-raise emission, and single-record-per-request guarantee via contextmanager. |
| agentex/src/utils/db_metrics.py | Adds InstrumentedAsyncAdaptedQueuePool and three new OTel connection-acquisition metrics; pending_requests increment occurs outside the try block, so an OTel SDK raise there leaves the counter unbalanced without a compensating decrement. |
| agentex/src/api/routes/agents.py | Wraps sync and streaming RPC handlers with rpc_request_timing; streaming handler correctly carries instrumentation across yields and GeneratorExit. |
| agentex/src/config/dependencies.py | Adds poolclass=InstrumentedAsyncAdaptedQueuePool to all three engine constructors; straightforward wiring change. |
| agentex/otel/otel-collector-config.yaml | Removes namespace: agentex from Prometheus exporter to prevent double-prefixing for agentex.* metrics; renames existing local db.* metric series as a side effect. |
| agentex/tests/unit/utils/test_rpc_metrics.py | Comprehensive unit tests covering no-op, never-raise, attribute correctness, double-count regression, GeneratorExit, and handler-classification precedence. |
| agentex/tests/unit/utils/test_db_metrics.py | Unit tests for the pool instrumentation covering passthrough, success, timeout, non-timeout error, recreate propagation, and end-to-end wiring. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant agents_py as agents.py
    participant rpc_timing as rpc_request_timing
    participant use_case as agents_acp_use_case
    participant otel as OTel SDK

    Client->>agents_py: "POST /agents/{id}/rpc"
    agents_py->>rpc_timing: __enter__ (start timer)
    rpc_timing-->>agents_py: RpcCallOutcome

    alt Sync request
        agents_py->>use_case: handle_rpc_request()
        use_case-->>agents_py: result_entity
        agents_py->>rpc_timing: __exit__ (normal)
        rpc_timing->>otel: record duration/requests
        agents_py-->>Client: AgentRPCResponse (200)
    else Streaming request
        agents_py->>use_case: handle_rpc_request()
        use_case-->>agents_py: AsyncIterator
        loop Each chunk
            agents_py-->>Client: NDJSON chunk (yield)
        end
        alt Stream error
            agents_py->>rpc_timing: rpc_call.fail(-32603, e)
            agents_py-->>Client: error frame (yield)
        end
        agents_py->>rpc_timing: __exit__ (GeneratorExit or normal)
        rpc_timing->>otel: record duration/requests/errors
    end

    Note over agents_py,otel: task/create also emits gen_ai.workflow.duration
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into stephen-wang/rp..."](https://github.com/scaleapi/scale-agentex/commit/0e754eb70851c19e26c7e3458596a3bcb9d8db7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48001757)</sub>

<!-- /greptile_comment -->