### PR TITLE
feat(task-messages): add optional agent_path to TaskMessage

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -6605,6 +6605,18 @@ components:
           type: string
           title: Task Id
           description: ID of the task this message belongs to
+        agent_path:
+          anyOf:
+          - type: string
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Agent Path
+          description: 'Identifier of the agent that emitted this message: a single
+            agent id, or a root-to-emitter path (e.g. ["researcher", "subagent-abc"])
+            when nested agents share one task stream. Lets consumers attribute and
+            group streamed events by agent.'
         content:
           $ref: '#/components/schemas/TaskMessageContent'
           description: The content of the message. This content is not OpenAI compatible.

--- a/agentex/src/api/schemas/task_messages.py
+++ b/agentex/src/api/schemas/task_messages.py
@@ -217,6 +217,15 @@ class TaskMessage(BaseModel):
 
     id: str | None = Field(None, description="The task message's unique id")
     task_id: str = Field(..., description="ID of the task this message belongs to")
+    agent_path: str | list[str] | None = Field(
+        None,
+        description=(
+            "Identifier of the agent that emitted this message: a single agent id, "
+            'or a root-to-emitter path (e.g. ["researcher", "subagent-abc"]) when '
+            "nested agents share one task stream. Lets consumers attribute and group "
+            "streamed events by agent."
+        ),
+    )
     content: TaskMessageContent = Field(
         ...,
         description="The content of the message. This content is not OpenAI compatible. These are messages that are meant to be displayed to the user.",


### PR DESCRIPTION
## What
Add an optional `agent_path` field to the `TaskMessage` API schema (`agentex/src/api/schemas/task_messages.py`) and regenerate `openapi.yaml`.

`agent_path` is `str | list[str] | None`: a single agent id, or a root-to-emitter path (for example, `["researcher", "subagent-abc"]`) for nested agents that share one task stream.

## Why
Streamed task-message events currently carry only a `task_id`, so when multiple agents emit into a single task stream their events cannot be attributed to the emitting agent. Stream events already reference the message via `parent_task_message: TaskMessage`, so `TaskMessage` is the correct OpenAPI surface to carry the source. Consumers can then group and filter streamed events by agent.

## Scope
- API schema plus regenerated `openapi.yaml` only.
- Additive and backward-compatible (optional, defaults to `null`).
- Stream-only: no `TaskMessageEntity`, storage, or migration change.

## Paired SDK PR and merge order
This is the root of a two-PR change; the generated Python SDK consumes this spec:
1. **Merge this PR first.** On merge, the automated Stainless flow uploads the spec and opens/commits codegen to `scale-agentex-python` `next`, adding `agent_path` to the generated `TaskMessage`.
2. Then **scaleapi/scale-agentex-python#474**, the SDK-side runtime that stamps `agent_path` onto the in-memory envelope before emitting `start`/`delta`/`full`/`done`, is rebased to drop its temporary manual patch and rely on the regenerated field.

## Verification
`make gen-openapi` regenerated the spec; the pre-commit "Regenerate AgentEx OpenAPI spec" hook passed (spec in sync), and ruff and ruff-format passed. Diff is the new field only (+21, no deletions).

Generated with [Claude Code](https://claude.com/claude-code)