### PR TITLE
fix(agentex-ui): abort the upstream request when the BFF client disconnects

### DIFF
--- a/agentex-ui/app/api/agentex/[...path]/route.ts
+++ b/agentex-ui/app/api/agentex/[...path]/route.ts
@@ -34,14 +34,24 @@ async function proxy(
 
   const method = req.method.toUpperCase();
   const hasBody = method !== 'GET' && method !== 'HEAD';
-  const upstream = await fetch(target, {
-    method,
-    headers,
-    body: hasBody ? req.body : undefined,
-    redirect: 'manual',
-    // @ts-expect-error `duplex` is required to stream a request body (undici)
-    duplex: 'half',
-  });
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method,
+      headers,
+      body: hasBody ? req.body : undefined,
+      redirect: 'manual',
+      // A client disconnect must tear down the upstream request; undici otherwise holds it
+      // open and the upstream handler keeps running.
+      signal: req.signal,
+      // @ts-expect-error `duplex` is required to stream a request body (undici)
+      duplex: 'half',
+    });
+  } catch (error) {
+    // The disconnect above aborts `req.signal`, which rejects the fetch — not an upstream failure.
+    if (req.signal.aborted) return new Response(null, { status: 499 });
+    throw error;
+  }
 
   // Pass the upstream body through unbuffered so SSE / streaming responses work.
   const resHeaders = new Headers(upstream.headers);

--- a/agentex-ui/app/api/agentex/[...path]/route.ts
+++ b/agentex-ui/app/api/agentex/[...path]/route.ts
@@ -48,8 +48,10 @@ async function proxy(
       duplex: 'half',
     });
   } catch (error) {
-    // The disconnect above aborts `req.signal`, which rejects the fetch — not an upstream failure.
-    if (req.signal.aborted) return new Response(null, { status: 499 });
+    // The disconnect above rejects the fetch with the signal's abort reason itself, so identity —
+    // not `error.name` — separates it from a transport failure that coincides with a disconnect.
+    // Next's reason is a `ResponseAborted`, so an `AbortError` check would never fire.
+    if (error === req.signal.reason) return new Response(null, { status: 499 });
     throw error;
   }
 


### PR DESCRIPTION
## Problem

The `/api/agentex` catch-all BFF proxy streams SSE through unbuffered but passes no `signal` to `fetch`. When the browser goes away — closed tab, navigation, or the 300s Istio route timeout on the UI's `virtualService` — undici keeps the upstream request open. There is no timeout on the call either, so an orphan never expires, and the browser's `EventSource` then reconnects and opens a fresh one.

Each orphan leaves an `agentex` handler blocked in a Redis `XREAD`, pinning one connection from that pod's redis-py pool (`REDIS_MAX_CONNECTIONS`, default 200). They accumulate until the pools are exhausted, at which point `agentex` fails to serve new requests and only a restart recovers it.

Reported on Mayo Nonprod ([Slack thread](https://scaleapi.slack.com/archives/C05KKGVD2QP/p1785278044417629)). At saturation Redis showed 1,094 `connected_clients` with 943 `blocked_clients`, while each of the two `agentex-ui` pods held ~570 established sockets to the `agentex` ClusterIP and served one inbound client apiece. Restarting only `agentex-ui` dropped backend Redis connections from ~1,094 to 279 without touching `agentex`, confirming the UI as the holder. Introduced in 0f07dc7 (#350).

## Fix

Pass `req.signal`. App Router aborts it on client disconnect, which propagates through undici and destroys the upstream request — and makes the existing Istio route timeout an effective ceiling on upstream lifetime. A fixed timeout would be wrong here, since it would cut legitimate long-lived SSE streams.

The abort also rejects the in-flight `fetch`, so that case is answered with a 499 instead of propagating as a 500 — a departed client isn't an upstream failure. A genuine transport error still propagates exactly as before.

## Verification

Built this branch, pointed `AGENTEX_API_URL` at a connection-counting SSE upstream, opened 5 streaming clients and killed them:

| | upstream live while connected | 6s after clients killed |
| --- | --- | --- |
| current `main` shape | 5 | **5** ← leak |
| this branch | 5 | **0** |

No `ResponseAborted` stack traces in the server log, server healthy afterward.

The main risk of adding a signal is truncating a response that is still streaming after the handler returns, so that was checked explicitly on a production build:

- a 2 MB body streamed from upstream over ~2s arrived at exactly 2,048,011 bytes, 3/3 runs
- a 666,669-byte streamed `POST` with `duplex: 'half'` echoed back intact

`tsc --noEmit`, `eslint --max-warnings=0`, and `prettier --check` are clean.

## Follow-ups for the Agents team (not this PR)

Two `agentex` backend issues from the same thread remain open:

1. **`cleanup_stream` in the `finally` deletes a task-wide stream** ([`streams_use_case.py:194`](https://github.com/scaleapi/scale-agentex/blob/main/agentex/src/domain/use_cases/streams_use_case.py#L194)). The topic is keyed by task id alone, so it is shared by every viewer. Worth landing with or right after this PR: today that `finally` almost never runs *because* disconnects don't propagate, and this change makes it run on every tab close. If something looks like a regression from this PR, it is that.
2. **SSE subscriptions have no terminal condition.** A tab left open on a finished task still pins a pool connection indefinitely, polling `XREAD` every ~2.1s. The naive fix is unsafe: the client's retry loop (`custom-subscribe-task-state.tsx`, `while (!signal?.aborted)`) treats a clean server-side stream end as "reconnect immediately" — no backoff, no error-counter increment — so ending the stream server-side alone would produce a reconnect storm. Needs a coordinated client change.

Separately and unrelated to the leak: `AGENTEX_API_URL` falls back silently to `http://localhost:5003`, so a rename on either side yields a UI that can't reach the backend with no configuration error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a connection-pool exhaustion bug in the Next.js App Router BFF proxy: upstream `fetch` calls were made without a cancellation signal, so client disconnects (tab close, navigation, Istio route timeout) left orphaned requests alive, each pinning a Redis connection in the backend's pool until restart.

- Adds `signal: req.signal` to the upstream `fetch` so undici tears down the backend connection whenever the browser client disconnects or the Istio timeout fires.
- Wraps the `fetch` in a try/catch and returns HTTP 499 for abort-triggered errors, using identity comparison against `req.signal.reason` (rather than `error.name`) to correctly distinguish a client-disconnect abort from a genuine transport failure that coincides with a disconnect — validated against Next.js's `ResponseAborted` internal abort path.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — a one-file, focused fix that adds a cancellation signal and handles the resulting abort error correctly.

The change is minimal and well-reasoned: it adds `signal: req.signal` to the upstream fetch and uses identity comparison against `req.signal.reason` to discriminate a client-abort from a coincident transport failure. The PR author verified the behavior against a production Next.js 15 build, confirmed no stream truncation on 2 MB bodies, and the comment in the code accurately documents why `error.name` would be wrong here. No other code paths are affected.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex-ui/app/api/agentex/[...path]/route.ts | Adds `signal: req.signal` to upstream fetch and catches abort errors with identity comparison against `req.signal.reason`; logic is correct and well-commented. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant NextBFF as Next.js BFF (route.ts)
    participant Upstream as Agentex Backend
    participant Redis

    Browser->>NextBFF: SSE request
    NextBFF->>Upstream: "fetch(target, { signal: req.signal, ... })"
    Upstream->>Redis: XREAD (blocking)
    
    alt Client disconnects (tab close / Istio timeout)
        Browser--xNextBFF: disconnect
        Note over NextBFF: req.signal aborted (ResponseAborted reason)
        NextBFF->>Upstream: AbortSignal propagated → undici cancels request
        Upstream--xRedis: connection released
        NextBFF-->>Browser: 499 (client already gone)
    else Genuine upstream transport error
        Upstream--xNextBFF: TypeError (ECONNREFUSED etc.)
        Note over NextBFF: error !== req.signal.reason → rethrow
        NextBFF-->>Browser: 500
    else Normal SSE stream
        Redis-->>Upstream: stream events
        Upstream-->>NextBFF: streamed response body
        NextBFF-->>Browser: unbuffered SSE
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into erichwoo/bff-ab..."](https://github.com/scaleapi/scale-agentex/commit/dd5971c0b435c4d8ad89bcc94b0ec0653bdab111) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48166959)</sub>

<!-- /greptile_comment -->