### PR TITLE
fix(acp): forward allowlisted client headers on all ACP paths

### DIFF
--- a/agentex/src/domain/services/agent_acp_service.py
+++ b/agentex/src/domain/services/agent_acp_service.py
@@ -278,6 +278,10 @@ class AgentACPService(TaskMessageMixin):
         agent: AgentEntity,
         request_headers: dict[str, str] | None = None,
     ) -> dict[str, str]:
+        # Fall back to inbound request headers when callers don't pass them, so
+        # allowlisted client x-* headers are forwarded to the agent.
+        if request_headers is None:
+            request_headers = dict(self._request.headers)
         filtered_request_headers = filter_request_headers(request_headers)
         delegation_headers = self.get_delegation_headers(agent)
         auth_headers = await self.get_agent_auth_headers(agent)

--- a/agentex/tests/unit/services/test_agent_acp_service.py
+++ b/agentex/tests/unit/services/test_agent_acp_service.py
@@ -417,6 +417,61 @@ class TestAgentACPService:
         assert headers["x-request-id"] != "client-request-id"
         assert len(headers["x-request-id"]) > 0
 
+    async def test_get_headers_falls_back_to_inbound_request_headers(
+        self,
+        agent_acp_service,
+        mock_request,
+        sample_agent,
+    ):
+        """When request_headers is omitted, safe inbound x-* headers are forwarded."""
+        mock_request.state.principal_context = None
+        mock_request.state.agent_identity = None
+        mock_request.headers = {
+            "x-trace-id": "trace-789",
+            "x-user-id": "user-123",
+            "x-api-key": "must-not-forward",
+            "authorization": "Bearer must-not-forward",
+            "user-agent": "must-not-forward",
+        }
+
+        with patch.object(
+            agent_acp_service,
+            "get_agent_auth_headers",
+            new=AsyncMock(return_value={}),
+        ):
+            headers = await agent_acp_service.get_headers(sample_agent)
+
+        assert headers["x-trace-id"] == "trace-789"
+        assert headers["x-user-id"] == "user-123"
+        assert "x-api-key" not in headers
+        assert "authorization" not in headers
+        assert "user-agent" not in headers
+
+    async def test_get_headers_empty_request_headers_forwards_none(
+        self,
+        agent_acp_service,
+        mock_request,
+        sample_agent,
+    ):
+        """Passing an explicit empty dict forwards no client headers (no fallback)."""
+        mock_request.state.principal_context = None
+        mock_request.state.agent_identity = None
+        mock_request.headers = {"x-trace-id": "should-not-be-used"}
+
+        with patch.object(
+            agent_acp_service,
+            "get_agent_auth_headers",
+            new=AsyncMock(return_value={}),
+        ):
+            headers = await agent_acp_service.get_headers(
+                sample_agent,
+                request_headers={},
+            )
+
+        assert "x-trace-id" not in headers
+        # Only the server-generated x-request-id should remain.
+        assert set(headers.keys()) == {"x-request-id"}
+
     async def test_send_message_success_data(
         self,
         agent_acp_service,


### PR DESCRIPTION
## Summary
- `get_headers(agent)` is called from several ACP paths (`send_message_stream`, `create_task`, cancel/interrupt) without threading the inbound client headers.
- As a result `filter_request_headers(None)` returned `{}`, so no allowlisted client `x-*` headers ever reached the agent.
- Fall back to the inbound request headers when callers don't pass them, so the existing allowlist actually forwards them.

## Test plan
- [x] Trigger an ACP path that previously dropped headers (e.g. `send_message_stream`) and confirm allowlisted client `x-*` headers now reach the agent.
- [x] Confirm existing behavior is preserved when `request_headers` is explicitly passed.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where allowlisted `x-*` client headers were never forwarded to the agent on most ACP paths because `get_headers()` received `request_headers=None` and `filter_request_headers(None)` returned `{}`. The fix adds a four-line fallback that reads `self._request.headers` when no headers are explicitly passed, consistent with how `get_delegation_headers()` already reads the same source.

- `get_headers()` now falls back to `dict(self._request.headers)` when `request_headers is None`; the existing `BLOCKED_HEADERS` + `x-*`-allowlist filtering in `filter_request_headers()` is unchanged, so credentials (`authorization`, `x-api-key`, etc.) remain blocked.
- Callers that pass `request_headers={}` explicitly opt out of the fallback — the empty dict short-circuits `filter_request_headers` and no client headers are forwarded.
- Two new unit tests cover both the fallback path and the explicit-empty-dict opt-out, including assertions that blocked headers (`authorization`, `x-api-key`) are not forwarded.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is minimal and scoped to a single fallback in `get_headers()`; the security-sensitive filtering path (`filter_request_headers` + `BLOCKED_HEADERS`) is untouched.

The four-line fallback is consistent with how `get_delegation_headers()` already reads `self._request.headers`. Credential headers remain blocked by the existing allowlist. The two new tests directly exercise both the fallback and the opt-out paths with correct assertions on sensitive header names.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/services/agent_acp_service.py | Adds a 4-line fallback in `get_headers()` so inbound `x-*` client headers are forwarded when callers don't explicitly pass `request_headers`. Security filtering via `filter_request_headers` and `BLOCKED_HEADERS` is unchanged. |
| agentex/tests/unit/services/test_agent_acp_service.py | Adds two new unit tests covering the fallback path (omitted `request_headers` uses inbound headers) and the explicit empty-dict opt-out path. Both cover the security-critical header filtering cases. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ACPPath as ACP Path
    participant GetHeaders as get_headers
    participant FilterHeaders as filter_request_headers
    participant AgentPod as Agent Pod

    Client->>ACPPath: "HTTP request with x-* headers"
    ACPPath->>GetHeaders: get_headers(agent)

    alt Before fix
        GetHeaders->>FilterHeaders: filter_request_headers(None)
        FilterHeaders-->>GetHeaders: "{} empty dict"
    else After fix
        GetHeaders->>GetHeaders: "request_headers = dict(self._request.headers)"
        GetHeaders->>FilterHeaders: filter_request_headers(inbound headers)
        FilterHeaders-->>GetHeaders: "allowlisted x-* headers only"
    end

    GetHeaders-->>ACPPath: merged headers with delegation + auth + x-request-id
    ACPPath->>AgentPod: JSON-RPC with forwarded allowlisted headers
```
</details>

<sub>Reviews (5): Last reviewed commit: ["test(acp): cover get\_headers inbound-hea..."](https://github.com/scaleapi/scale-agentex/commit/bda8767edbdfcf8727b202474276596a4eb0de4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48298905)</sub>

<!-- /greptile_comment -->