### PR TITLE
feat(tasks): add task-stream lifecycle metrics

### DIFF
--- a/agentex/src/config/environment_variables.py
+++ b/agentex/src/config/environment_variables.py
@@ -55,6 +55,7 @@ class EnvVarKeys(str, Enum):
     HTTPX_POOL_TIMEOUT = "HTTPX_POOL_TIMEOUT"
     HTTPX_STREAMING_READ_TIMEOUT = "HTTPX_STREAMING_READ_TIMEOUT"
     SSE_KEEPALIVE_PING_INTERVAL = "SSE_KEEPALIVE_PING_INTERVAL"
+    SSE_STREAM_STALL_THRESHOLD_SECONDS = "SSE_STREAM_STALL_THRESHOLD_SECONDS"
     AGENTEX_SERVER_TASK_QUEUE = "AGENTEX_SERVER_TASK_QUEUE"
     ENABLE_HEALTH_CHECK_WORKFLOW = "ENABLE_HEALTH_CHECK_WORKFLOW"
     ENABLE_AGENT_RUN_SCHEDULES = "ENABLE_AGENT_RUN_SCHEDULES"
@@ -150,6 +151,10 @@ class EnvironmentVariables(BaseModel):
         300.0  # HTTPX streaming read timeout in seconds (5 minutes)
     )
     SSE_KEEPALIVE_PING_INTERVAL: int = 15  # SSE keepalive ping interval in seconds
+    # An open stream is counted as stalled once this many seconds pass with no
+    # data event pushed to the client. Kept above the keepalive interval so that
+    # keepalive pings (which are not data events) don't mask a real stall.
+    SSE_STREAM_STALL_THRESHOLD_SECONDS: int = 30
     AGENTEX_SERVER_TASK_QUEUE: str | None = None
     ENABLE_HEALTH_CHECK_WORKFLOW: bool = False
     # Gates the agent run schedules API. Off by default; enabled in development.
@@ -244,6 +249,9 @@ class EnvironmentVariables(BaseModel):
             ),
             SSE_KEEPALIVE_PING_INTERVAL=int(
                 os.environ.get(EnvVarKeys.SSE_KEEPALIVE_PING_INTERVAL, "15")
+            ),
+            SSE_STREAM_STALL_THRESHOLD_SECONDS=int(
+                os.environ.get(EnvVarKeys.SSE_STREAM_STALL_THRESHOLD_SECONDS, "30")
             ),
             AGENTEX_SERVER_TASK_QUEUE=os.environ.get(
                 EnvVarKeys.AGENTEX_SERVER_TASK_QUEUE

--- a/agentex/src/domain/use_cases/streams_use_case.py
+++ b/agentex/src/domain/use_cases/streams_use_case.py
@@ -108,15 +108,20 @@ class StreamsUseCase:
 
         stream_topic = get_task_event_stream_topic(task_id=task_id)
 
-        # A stream is "open" from here on. Pair this with exactly one
-        # record_stream_closed (in the finally below) so the active-stream gauge
-        # stays balanced even if setup — the tail snapshot or the first yield —
-        # raises. Placed after task resolution so a bad task_name never counts
+        # Capture the timing/outcome state the finally needs *before* marking the
+        # stream open, then flip ``opened`` as the first statement inside the try.
+        # This keeps record_stream_opened paired with exactly one
+        # record_stream_closed: the open lives inside the try, so any failure
+        # after it still routes through the finally and rebalances the active
+        # gauge — closing the narrow window that opening before the try left
+        # exposed. Placed after task resolution so a bad task_name never counts
         # as an opened stream.
-        record_stream_opened()
         stream_start_time = asyncio.get_running_loop().time()
         outcome: StreamOutcome = "completed"
+        opened = False
         try:
+            record_stream_opened()
+            opened = True
             # Snapshot the read cursor BEFORE yielding "connected". "connected"
             # is the client's cue to send its message, which makes the agent
             # start XADD-ing deltas. Snapshotting after the yield lets a
@@ -234,10 +239,13 @@ class StreamsUseCase:
             yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
         finally:
             logger.info(f"SSE stream for task {task_id} has ended")
-            record_stream_closed(
-                outcome,
-                asyncio.get_running_loop().time() - stream_start_time,
-            )
+            # Only close what we actually opened, so the active gauge is never
+            # decremented for a stream that never incremented it.
+            if opened:
+                record_stream_closed(
+                    outcome,
+                    asyncio.get_running_loop().time() - stream_start_time,
+                )
             await self.cleanup_stream(stream_topic)
 
 

--- a/agentex/src/domain/use_cases/streams_use_case.py
+++ b/agentex/src/domain/use_cases/streams_use_case.py
@@ -16,6 +16,12 @@ from src.domain.entities.task_stream_events import (
 )
 from src.domain.services.task_service import DAgentTaskService
 from src.utils.logging import make_logger
+from src.utils.stream_metrics import (
+    StreamOutcome,
+    record_stream_closed,
+    record_stream_opened,
+    record_stream_stall,
+)
 from src.utils.stream_topics import get_task_event_stream_topic
 
 logger = make_logger(__name__)
@@ -101,25 +107,48 @@ class StreamsUseCase:
             task_id = task.id
 
         stream_topic = get_task_event_stream_topic(task_id=task_id)
-        # Snapshot the read cursor BEFORE yielding "connected". "connected" is
-        # the client's cue to send its message, which makes the agent start
-        # XADD-ing deltas. Snapshotting after the yield lets a congested relay
-        # fall behind far enough that those deltas land before the snapshot and
-        # are never read. Snapshotting first resolves to "0-0" (stream is empty
-        # until the client sends), so we read from the beginning.
-        last_id = await self.stream_repository.get_stream_tail_id(stream_topic)
-        # Send initial connection data
-        yield f"data: {TaskStreamConnectedEventEntity(type='connected', taskId=task_id).model_dump_json()}\n\n"
-        last_message_time = asyncio.get_running_loop().time()
-        ping_interval = float(
-            self.environment_variables.SSE_KEEPALIVE_PING_INTERVAL
-        )  # Configurable keepalive ping interval
-        # Track consecutive read failures so we can back off and avoid a
-        # tight error loop. When the Redis pool is exhausted, every connected
-        # client's read fails on each cycle; without backoff this turns into a
-        # log-ingestion firehose (one failure per client per cycle, ~once/sec).
-        consecutive_errors = 0
+
+        # A stream is "open" from here on. Pair this with exactly one
+        # record_stream_closed (in the finally below) so the active-stream gauge
+        # stays balanced even if setup — the tail snapshot or the first yield —
+        # raises. Placed after task resolution so a bad task_name never counts
+        # as an opened stream.
+        record_stream_opened()
+        stream_start_time = asyncio.get_running_loop().time()
+        outcome: StreamOutcome = "completed"
         try:
+            # Snapshot the read cursor BEFORE yielding "connected". "connected"
+            # is the client's cue to send its message, which makes the agent
+            # start XADD-ing deltas. Snapshotting after the yield lets a
+            # congested relay fall behind far enough that those deltas land
+            # before the snapshot and are never read. Snapshotting first resolves
+            # to "0-0" (stream is empty until the client sends), so we read from
+            # the beginning.
+            last_id = await self.stream_repository.get_stream_tail_id(stream_topic)
+            # Send initial connection data
+            yield f"data: {TaskStreamConnectedEventEntity(type='connected', taskId=task_id).model_dump_json()}\n\n"
+            now = asyncio.get_running_loop().time()
+            # last_message_time drives the keepalive ping and is reset by pings;
+            # last_event_time tracks only real data pushes (a ping is not a data
+            # event) and drives stall detection, so a persistently quiet stream
+            # still trips the stall signal even while keepalive pings flow.
+            last_message_time = now
+            last_event_time = now
+            ping_interval = float(
+                self.environment_variables.SSE_KEEPALIVE_PING_INTERVAL
+            )  # Configurable keepalive ping interval
+            stall_threshold = float(
+                self.environment_variables.SSE_STREAM_STALL_THRESHOLD_SECONDS
+            )
+            # Whether the current quiet spell has already been counted, so one
+            # stall episode increments the counter once (measuring stall onsets)
+            # rather than once per idle cycle. Reset when a data event flows.
+            stalled = False
+            # Track consecutive read failures so we can back off and avoid a
+            # tight error loop. When the Redis pool is exhausted, every connected
+            # client's read fails on each cycle; without backoff this turns into a
+            # log-ingestion firehose (one failure per client per cycle, ~once/sec).
+            consecutive_errors = 0
             # Application-level control loop
             while True:
                 try:
@@ -135,7 +164,10 @@ class StreamsUseCase:
                         # Send the data to the client
                         data_str = f"data: {data.model_dump_json()}\n\n"
                         yield data_str
-                        last_message_time = asyncio.get_running_loop().time()
+                        now = asyncio.get_running_loop().time()
+                        last_message_time = now
+                        last_event_time = now
+                        stalled = False
                         await asyncio.sleep(0.02)
 
                     # A read cycle completed without raising — the stream is
@@ -146,6 +178,16 @@ class StreamsUseCase:
                     # to prevent tight loops and send keepalive ping if needed
                     if message_count == 0:
                         current_time = asyncio.get_running_loop().time()
+                        # No data event pushed for the stall window: count the
+                        # onset once. Keepalive pings deliberately do not reset
+                        # last_event_time, so a persistently quiet stream is
+                        # visible even though the connection stays alive.
+                        if (
+                            current_time - last_event_time >= stall_threshold
+                            and not stalled
+                        ):
+                            stalled = True
+                            record_stream_stall()
                         if current_time - last_message_time >= ping_interval:
                             yield ":ping\n\n"
                             last_message_time = current_time
@@ -182,15 +224,20 @@ class StreamsUseCase:
 
         except asyncio.CancelledError:
             # Just exit the generator on cancellation
+            outcome = "client_disconnect"
             logger.info(f"Client disconnected from SSE stream for task {task_id}")
-            pass
         except Exception as e:
+            outcome = "error"
             logger.error(
                 f"Fatal error in SSE stream for task {task_id}: {e}", exc_info=True
             )
             yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
         finally:
             logger.info(f"SSE stream for task {task_id} has ended")
+            record_stream_closed(
+                outcome,
+                asyncio.get_running_loop().time() - stream_start_time,
+            )
             await self.cleanup_stream(stream_topic)
 
 

--- a/agentex/src/utils/stream_metrics.py
+++ b/agentex/src/utils/stream_metrics.py
@@ -62,14 +62,6 @@ _active_updown: UpDownCounter | None = None
 _stall_counter: Counter | None = None
 _instruments_initialized = False
 
-# Process-local count of currently-open streams, used solely to emit the StatsD
-# ``active`` gauge as an absolute value. DogStatsD gauges are last-value-wins and
-# do not honor deltas (unlike Etsy StatsD); increment/decrement would instead
-# submit a COUNT — the rate of change — never the concurrency level. So the
-# StatsD path keeps the running total here and reports it via ``statsd.gauge``.
-# The OTel ``UpDownCounter`` expresses this natively and needs no bookkeeping.
-_active_stream_count = 0
-
 
 def _ensure_instruments() -> None:
     """Create the OTel instruments on first use. No-op if OTel is not configured."""
@@ -119,7 +111,6 @@ def record_stream_opened() -> None:
     Pair every call with exactly one ``record_stream_closed`` so the active gauge
     stays balanced. Never raises: see ``record_stream_closed``.
     """
-    global _active_stream_count
     try:
         _ensure_instruments()
 
@@ -130,9 +121,11 @@ def record_stream_opened() -> None:
 
         if _STATSD_ENABLED:
             statsd.increment("agentex.task_stream.opened")
-            # Report the concurrency level as an absolute gauge, not a delta.
-            _active_stream_count += 1
-            statsd.gauge("agentex.task_stream.active", _active_stream_count)
+            # No StatsD "active" gauge: concurrency is OTel-only. DogStatsD
+            # gauges are last-write-wins per flush, so N workers each emitting a
+            # process-local count would make the gauge flap between workers
+            # rather than sum to the true concurrency. The OTel UpDownCounter
+            # sums correctly across per-instance series at query time.
     except Exception:
         logger.debug("Failed to emit agentex.task_stream.opened metric", exc_info=True)
 
@@ -149,7 +142,6 @@ def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> Non
     Never raises: emission failures (e.g. a StatsD UDP socket error or an OTel
     SDK fault) are swallowed so instrumentation can never disrupt the SSE path.
     """
-    global _active_stream_count
     try:
         _ensure_instruments()
 
@@ -164,9 +156,8 @@ def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> Non
             statsd.increment("agentex.task_stream.closed", tags=[f"outcome:{outcome}"])
             # Datadog histograms conventionally take milliseconds for durations.
             statsd.histogram("agentex.task_stream.duration", duration_seconds * 1000)
-            # Report the concurrency level as an absolute gauge, not a delta.
-            _active_stream_count -= 1
-            statsd.gauge("agentex.task_stream.active", _active_stream_count)
+            # No StatsD "active" gauge — concurrency is OTel-only; a per-worker
+            # DogStatsD gauge would flap rather than sum (see record_stream_opened).
     except Exception:
         logger.debug("Failed to emit agentex.task_stream.closed metric", exc_info=True)
 

--- a/agentex/src/utils/stream_metrics.py
+++ b/agentex/src/utils/stream_metrics.py
@@ -1,0 +1,177 @@
+"""
+Metrics instrumentation for the task-event SSE stream lifecycle.
+
+Mirrors the dual-emit pattern in ``src/utils/cache_metrics.py``:
+
+- When an OTLP endpoint is configured (``OTEL_EXPORTER_OTLP_ENDPOINT``), the
+  instruments are recorded through the OpenTelemetry SDK.
+- When the Datadog Agent is reachable (``DD_AGENT_HOST``), the same events are
+  emitted as StatsD metrics.
+- When neither is configured, every function here is a cheap no-op.
+
+**Why this exists (see AGX1-616/AGX1-618):** HTTP request-level RED for
+``GET /tasks/{task_id}/stream`` is already covered by auto-instrumentation — the
+route records into ``http_server_request_duration_seconds`` at connection close.
+But a single SSE request produces exactly one duration sample, which says nothing
+about what happened *during* the stream's life: how many were concurrently open,
+whether a stream ended normally vs. by client disconnect vs. by error, or whether
+a stream went quiet (no events pushed) for a stretch. Those are the stream-
+lifecycle signals request-level instrumentation cannot express, and they are what
+this module adds.
+
+Instrument names are deliberately dotted (``agentex.task_stream.*``); the OTLP →
+Prometheus translation flattens dots to underscores, appends ``_total`` to
+monotonic counters, and appends the unit (``s`` → ``_seconds``) to the histogram,
+so the series land in Mimir as ``agentex_task_stream_opened_total``,
+``agentex_task_stream_closed_total``, ``agentex_task_stream_duration_seconds``,
+``agentex_task_stream_active`` and ``agentex_task_stream_stall_total``. These
+hand-instrumented series carry only bounded attributes (``outcome``) and no
+``http_route`` label — group by ``outcome``, not ``http_route``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Literal
+
+from datadog import statsd
+
+from src.utils.logging import make_logger
+from src.utils.otel_metrics import get_meter
+
+if TYPE_CHECKING:
+    from opentelemetry.metrics import Counter, Histogram, UpDownCounter
+
+logger = make_logger(__name__)
+
+# StatsD is only emitted if the Datadog Agent host is configured.
+_STATSD_ENABLED = bool(os.environ.get("DD_AGENT_HOST"))
+
+# How a stream ended. "completed" = the generator returned normally;
+# "client_disconnect" = the client went away (asyncio.CancelledError);
+# "error" = the stream loop raised a fatal, non-recoverable exception. HTTP
+# status 200 at connection close cannot tell these three apart, which is why the
+# distinction lives here as a bounded label rather than on the request metric.
+StreamOutcome = Literal["completed", "client_disconnect", "error"]
+
+# Lazily-created OTel instruments (created once, on first use).
+_opened_counter: Counter | None = None
+_closed_counter: Counter | None = None
+_duration_histogram: Histogram | None = None
+_active_updown: UpDownCounter | None = None
+_stall_counter: Counter | None = None
+_instruments_initialized = False
+
+
+def _ensure_instruments() -> None:
+    """Create the OTel instruments on first use. No-op if OTel is not configured."""
+    global _opened_counter, _closed_counter, _duration_histogram
+    global _active_updown, _stall_counter, _instruments_initialized
+
+    if _instruments_initialized:
+        return
+    _instruments_initialized = True
+
+    meter = get_meter("agentex.task_stream")
+    if meter is None:
+        # OTel not configured; OTel path stays disabled. StatsD may still emit.
+        return
+
+    _opened_counter = meter.create_counter(
+        name="agentex.task_stream.opened",
+        description="Task-event SSE streams opened",
+        unit="{stream}",
+    )
+    _closed_counter = meter.create_counter(
+        name="agentex.task_stream.closed",
+        description="Task-event SSE streams closed, tagged by outcome",
+        unit="{stream}",
+    )
+    _duration_histogram = meter.create_histogram(
+        name="agentex.task_stream.duration",
+        description="Task-event SSE stream lifetime",
+        unit="s",
+    )
+    _active_updown = meter.create_up_down_counter(
+        name="agentex.task_stream.active",
+        description="Currently open task-event SSE streams",
+        unit="{stream}",
+    )
+    _stall_counter = meter.create_counter(
+        name="agentex.task_stream.stall",
+        description="Task-event SSE streams that went idle (no event pushed) past the stall threshold",
+        unit="{stream}",
+    )
+
+
+def record_stream_opened() -> None:
+    """
+    Record a task-event stream opening: bumps the opened counter and the active gauge.
+
+    Pair every call with exactly one ``record_stream_closed`` so the active gauge
+    stays balanced. Never raises: see ``record_stream_closed``.
+    """
+    try:
+        _ensure_instruments()
+
+        if _opened_counter is not None:
+            _opened_counter.add(1)
+        if _active_updown is not None:
+            _active_updown.add(1)
+
+        if _STATSD_ENABLED:
+            statsd.increment("agentex.task_stream.opened")
+            statsd.increment("agentex.task_stream.active")
+    except Exception:
+        logger.debug("Failed to emit agentex.task_stream.opened metric", exc_info=True)
+
+
+def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> None:
+    """
+    Record a task-event stream closing: bumps the closed counter (tagged by
+    outcome), records the stream lifetime, and decrements the active gauge.
+
+    Args:
+        outcome: One of "completed", "client_disconnect", "error".
+        duration_seconds: How long the stream was open.
+
+    Never raises: emission failures (e.g. a StatsD UDP socket error or an OTel
+    SDK fault) are swallowed so instrumentation can never disrupt the SSE path.
+    """
+    try:
+        _ensure_instruments()
+
+        if _closed_counter is not None:
+            _closed_counter.add(1, {"outcome": outcome})
+        if _duration_histogram is not None:
+            _duration_histogram.record(duration_seconds)
+        if _active_updown is not None:
+            _active_updown.add(-1)
+
+        if _STATSD_ENABLED:
+            statsd.increment("agentex.task_stream.closed", tags=[f"outcome:{outcome}"])
+            # Datadog histograms conventionally take milliseconds for durations.
+            statsd.histogram("agentex.task_stream.duration", duration_seconds * 1000)
+            statsd.decrement("agentex.task_stream.active")
+    except Exception:
+        logger.debug("Failed to emit agentex.task_stream.closed metric", exc_info=True)
+
+
+def record_stream_stall() -> None:
+    """
+    Record that an open stream went idle — no event pushed to the client for
+    longer than the configured stall threshold. Emit once per stall episode
+    (the caller de-dupes) so the counter measures stall onsets, not idle cycles.
+
+    Never raises: see ``record_stream_closed``.
+    """
+    try:
+        _ensure_instruments()
+
+        if _stall_counter is not None:
+            _stall_counter.add(1)
+
+        if _STATSD_ENABLED:
+            statsd.increment("agentex.task_stream.stall")
+    except Exception:
+        logger.debug("Failed to emit agentex.task_stream.stall metric", exc_info=True)

--- a/agentex/src/utils/stream_metrics.py
+++ b/agentex/src/utils/stream_metrics.py
@@ -52,6 +52,27 @@ logger = make_logger(__name__)
 # distinction lives here as a bounded label rather than on the request metric.
 StreamOutcome = Literal["completed", "client_disconnect", "error"]
 
+# Bucket boundaries (seconds) for the stream-lifetime histogram, spanning 1s to
+# 4h. SSE streams are long-lived — seconds to hours — so without this advisory
+# the SDK falls back to its millisecond-scale default boundaries [0, 5, 10, 25,
+# ... 10000] and every stream shorter than 10s piles into one bucket while
+# anything past ~2.8h overflows to +Inf. See rpc_metrics.py / db_metrics.py for
+# the same pattern.
+_DURATION_BUCKET_BOUNDARIES_S = (
+    1.0,
+    5.0,
+    15.0,
+    30.0,
+    60.0,
+    120.0,
+    300.0,
+    600.0,
+    1800.0,
+    3600.0,
+    7200.0,
+    14400.0,
+)
+
 # Lazily-created OTel instruments (created once, on first use).
 _opened_counter: Counter | None = None
 _closed_counter: Counter | None = None
@@ -89,6 +110,7 @@ def _ensure_instruments() -> None:
         name="agentex.task_stream.duration",
         description="Task-event SSE stream lifetime",
         unit="s",
+        explicit_bucket_boundaries_advisory=_DURATION_BUCKET_BOUNDARIES_S,
     )
     _active_updown = meter.create_up_down_counter(
         name="agentex.task_stream.active",

--- a/agentex/src/utils/stream_metrics.py
+++ b/agentex/src/utils/stream_metrics.py
@@ -133,7 +133,8 @@ def record_stream_opened() -> None:
 def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> None:
     """
     Record a task-event stream closing: bumps the closed counter (tagged by
-    outcome), records the stream lifetime, and lowers the active gauge.
+    outcome), records the stream lifetime (also tagged by outcome), and lowers
+    the active gauge.
 
     Args:
         outcome: One of "completed", "client_disconnect", "error".
@@ -148,14 +149,18 @@ def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> Non
         if _closed_counter is not None:
             _closed_counter.add(1, {"outcome": outcome})
         if _duration_histogram is not None:
-            _duration_histogram.record(duration_seconds)
+            _duration_histogram.record(duration_seconds, {"outcome": outcome})
         if _active_updown is not None:
             _active_updown.add(-1)
 
         if _STATSD_ENABLED:
             statsd.increment("agentex.task_stream.closed", tags=[f"outcome:{outcome}"])
             # Datadog histograms conventionally take milliseconds for durations.
-            statsd.histogram("agentex.task_stream.duration", duration_seconds * 1000)
+            statsd.histogram(
+                "agentex.task_stream.duration",
+                duration_seconds * 1000,
+                tags=[f"outcome:{outcome}"],
+            )
             # No StatsD "active" gauge — concurrency is OTel-only; a per-worker
             # DogStatsD gauge would flap rather than sum (see record_stream_opened).
     except Exception:

--- a/agentex/src/utils/stream_metrics.py
+++ b/agentex/src/utils/stream_metrics.py
@@ -13,7 +13,7 @@ routes OTel to Datadog through the collector rather than emitting to the Datadog
 Agent directly — so a second, DogStatsD-native copy of every point would just be
 redundant.
 
-**Why this exists (see AGX1-616/AGX1-618):** HTTP request-level RED for
+**Why this exists:** HTTP request-level RED for
 ``GET /tasks/{task_id}/stream`` is already covered by auto-instrumentation — the
 route records into ``http_server_request_duration_seconds`` at connection close.
 But a single SSE request produces exactly one duration sample, which says nothing

--- a/agentex/src/utils/stream_metrics.py
+++ b/agentex/src/utils/stream_metrics.py
@@ -1,13 +1,17 @@
 """
 Metrics instrumentation for the task-event SSE stream lifecycle.
 
-Mirrors the dual-emit pattern in ``src/utils/cache_metrics.py``:
+Emission is OpenTelemetry-only:
 
 - When an OTLP endpoint is configured (``OTEL_EXPORTER_OTLP_ENDPOINT``), the
   instruments are recorded through the OpenTelemetry SDK.
-- When the Datadog Agent is reachable (``DD_AGENT_HOST``), the same events are
-  emitted as StatsD metrics.
-- When neither is configured, every function here is a cheap no-op.
+- When it is not configured, every function here is a cheap no-op.
+
+Unlike the older ``cache_metrics.py`` dual-emit path, there is no direct
+StatsD/DogStatsD emission here. These are new metrics, and the target state
+routes OTel to Datadog through the collector rather than emitting to the Datadog
+Agent directly — so a second, DogStatsD-native copy of every point would just be
+redundant.
 
 **Why this exists (see AGX1-616/AGX1-618):** HTTP request-level RED for
 ``GET /tasks/{task_id}/stream`` is already covered by auto-instrumentation — the
@@ -31,10 +35,7 @@ hand-instrumented series carry only bounded attributes (``outcome``) and no
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Literal
-
-from datadog import statsd
 
 from src.utils.logging import make_logger
 from src.utils.otel_metrics import get_meter
@@ -43,9 +44,6 @@ if TYPE_CHECKING:
     from opentelemetry.metrics import Counter, Histogram, UpDownCounter
 
 logger = make_logger(__name__)
-
-# StatsD is only emitted if the Datadog Agent host is configured.
-_STATSD_ENABLED = bool(os.environ.get("DD_AGENT_HOST"))
 
 # How a stream ended. "completed" = the generator returned normally;
 # "client_disconnect" = the client went away (asyncio.CancelledError);
@@ -74,7 +72,7 @@ def _ensure_instruments() -> None:
 
     meter = get_meter("agentex.task_stream")
     if meter is None:
-        # OTel not configured; OTel path stays disabled. StatsD may still emit.
+        # OTel not configured; every record_* call stays a no-op.
         return
 
     _opened_counter = meter.create_counter(
@@ -118,14 +116,6 @@ def record_stream_opened() -> None:
             _opened_counter.add(1)
         if _active_updown is not None:
             _active_updown.add(1)
-
-        if _STATSD_ENABLED:
-            statsd.increment("agentex.task_stream.opened")
-            # No StatsD "active" gauge: concurrency is OTel-only. DogStatsD
-            # gauges are last-write-wins per flush, so N workers each emitting a
-            # process-local count would make the gauge flap between workers
-            # rather than sum to the true concurrency. The OTel UpDownCounter
-            # sums correctly across per-instance series at query time.
     except Exception:
         logger.debug("Failed to emit agentex.task_stream.opened metric", exc_info=True)
 
@@ -140,8 +130,8 @@ def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> Non
         outcome: One of "completed", "client_disconnect", "error".
         duration_seconds: How long the stream was open.
 
-    Never raises: emission failures (e.g. a StatsD UDP socket error or an OTel
-    SDK fault) are swallowed so instrumentation can never disrupt the SSE path.
+    Never raises: emission failures (e.g. an OTel SDK fault) are swallowed so
+    instrumentation can never disrupt the SSE path.
     """
     try:
         _ensure_instruments()
@@ -152,17 +142,6 @@ def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> Non
             _duration_histogram.record(duration_seconds, {"outcome": outcome})
         if _active_updown is not None:
             _active_updown.add(-1)
-
-        if _STATSD_ENABLED:
-            statsd.increment("agentex.task_stream.closed", tags=[f"outcome:{outcome}"])
-            # Datadog histograms conventionally take milliseconds for durations.
-            statsd.histogram(
-                "agentex.task_stream.duration",
-                duration_seconds * 1000,
-                tags=[f"outcome:{outcome}"],
-            )
-            # No StatsD "active" gauge — concurrency is OTel-only; a per-worker
-            # DogStatsD gauge would flap rather than sum (see record_stream_opened).
     except Exception:
         logger.debug("Failed to emit agentex.task_stream.closed metric", exc_info=True)
 
@@ -180,8 +159,5 @@ def record_stream_stall() -> None:
 
         if _stall_counter is not None:
             _stall_counter.add(1)
-
-        if _STATSD_ENABLED:
-            statsd.increment("agentex.task_stream.stall")
     except Exception:
         logger.debug("Failed to emit agentex.task_stream.stall metric", exc_info=True)

--- a/agentex/src/utils/stream_metrics.py
+++ b/agentex/src/utils/stream_metrics.py
@@ -62,6 +62,14 @@ _active_updown: UpDownCounter | None = None
 _stall_counter: Counter | None = None
 _instruments_initialized = False
 
+# Process-local count of currently-open streams, used solely to emit the StatsD
+# ``active`` gauge as an absolute value. DogStatsD gauges are last-value-wins and
+# do not honor deltas (unlike Etsy StatsD); increment/decrement would instead
+# submit a COUNT — the rate of change — never the concurrency level. So the
+# StatsD path keeps the running total here and reports it via ``statsd.gauge``.
+# The OTel ``UpDownCounter`` expresses this natively and needs no bookkeeping.
+_active_stream_count = 0
+
 
 def _ensure_instruments() -> None:
     """Create the OTel instruments on first use. No-op if OTel is not configured."""
@@ -111,6 +119,7 @@ def record_stream_opened() -> None:
     Pair every call with exactly one ``record_stream_closed`` so the active gauge
     stays balanced. Never raises: see ``record_stream_closed``.
     """
+    global _active_stream_count
     try:
         _ensure_instruments()
 
@@ -121,7 +130,9 @@ def record_stream_opened() -> None:
 
         if _STATSD_ENABLED:
             statsd.increment("agentex.task_stream.opened")
-            statsd.increment("agentex.task_stream.active")
+            # Report the concurrency level as an absolute gauge, not a delta.
+            _active_stream_count += 1
+            statsd.gauge("agentex.task_stream.active", _active_stream_count)
     except Exception:
         logger.debug("Failed to emit agentex.task_stream.opened metric", exc_info=True)
 
@@ -129,7 +140,7 @@ def record_stream_opened() -> None:
 def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> None:
     """
     Record a task-event stream closing: bumps the closed counter (tagged by
-    outcome), records the stream lifetime, and decrements the active gauge.
+    outcome), records the stream lifetime, and lowers the active gauge.
 
     Args:
         outcome: One of "completed", "client_disconnect", "error".
@@ -138,6 +149,7 @@ def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> Non
     Never raises: emission failures (e.g. a StatsD UDP socket error or an OTel
     SDK fault) are swallowed so instrumentation can never disrupt the SSE path.
     """
+    global _active_stream_count
     try:
         _ensure_instruments()
 
@@ -152,7 +164,9 @@ def record_stream_closed(outcome: StreamOutcome, duration_seconds: float) -> Non
             statsd.increment("agentex.task_stream.closed", tags=[f"outcome:{outcome}"])
             # Datadog histograms conventionally take milliseconds for durations.
             statsd.histogram("agentex.task_stream.duration", duration_seconds * 1000)
-            statsd.decrement("agentex.task_stream.active")
+            # Report the concurrency level as an absolute gauge, not a delta.
+            _active_stream_count -= 1
+            statsd.gauge("agentex.task_stream.active", _active_stream_count)
     except Exception:
         logger.debug("Failed to emit agentex.task_stream.closed metric", exc_info=True)
 

--- a/agentex/tests/unit/utils/test_stream_metrics.py
+++ b/agentex/tests/unit/utils/test_stream_metrics.py
@@ -46,8 +46,8 @@ def test_record_functions_swallow_emission_errors():
         patch.object(stream_metrics, "statsd") as mock_statsd,
     ):
         mock_statsd.increment.side_effect = OSError("socket in a bad state")
-        mock_statsd.decrement.side_effect = OSError("socket in a bad state")
         mock_statsd.histogram.side_effect = OSError("socket in a bad state")
+        mock_statsd.gauge.side_effect = OSError("socket in a bad state")
 
         # None of these should raise despite the backend blowing up.
         stream_metrics.record_stream_opened()
@@ -62,13 +62,15 @@ def test_record_stream_opened_emits_statsd_when_enabled():
         patch.object(stream_metrics, "_instruments_initialized", True),
         patch.object(stream_metrics, "_opened_counter", None),
         patch.object(stream_metrics, "_active_updown", None),
+        patch.object(stream_metrics, "_active_stream_count", 0),
         patch.object(stream_metrics, "statsd") as mock_statsd,
     ):
         stream_metrics.record_stream_opened()
 
-    # Opening bumps both the opened counter and the active gauge.
-    mock_statsd.increment.assert_any_call("agentex.task_stream.opened")
-    mock_statsd.increment.assert_any_call("agentex.task_stream.active")
+    # Opening bumps the opened counter and reports the active concurrency level
+    # as an absolute gauge (DogStatsD gauges are last-value-wins, not deltas).
+    mock_statsd.increment.assert_called_once_with("agentex.task_stream.opened")
+    mock_statsd.gauge.assert_called_once_with("agentex.task_stream.active", 1)
 
 
 @pytest.mark.unit
@@ -79,6 +81,7 @@ def test_record_stream_closed_emits_statsd_when_enabled():
         patch.object(stream_metrics, "_closed_counter", None),
         patch.object(stream_metrics, "_duration_histogram", None),
         patch.object(stream_metrics, "_active_updown", None),
+        patch.object(stream_metrics, "_active_stream_count", 1),
         patch.object(stream_metrics, "statsd") as mock_statsd,
     ):
         stream_metrics.record_stream_closed("client_disconnect", 3.25)
@@ -91,8 +94,8 @@ def test_record_stream_closed_emits_statsd_when_enabled():
     mock_statsd.histogram.assert_called_once_with(
         "agentex.task_stream.duration", 3250.0
     )
-    # Closing decrements the active gauge.
-    mock_statsd.decrement.assert_called_once_with("agentex.task_stream.active")
+    # Closing lowers the active gauge to the new absolute level (1 -> 0).
+    mock_statsd.gauge.assert_called_once_with("agentex.task_stream.active", 0)
 
 
 @pytest.mark.unit

--- a/agentex/tests/unit/utils/test_stream_metrics.py
+++ b/agentex/tests/unit/utils/test_stream_metrics.py
@@ -87,9 +87,11 @@ def test_record_stream_closed_emits_statsd_when_enabled():
         "agentex.task_stream.closed",
         tags=["outcome:client_disconnect"],
     )
-    # Duration is reported to StatsD in milliseconds.
+    # Duration is reported to StatsD in milliseconds, tagged by outcome.
     mock_statsd.histogram.assert_called_once_with(
-        "agentex.task_stream.duration", 3250.0
+        "agentex.task_stream.duration",
+        3250.0,
+        tags=["outcome:client_disconnect"],
     )
     # Concurrency ("active") is OTel-only, so closing emits no StatsD gauge.
     mock_statsd.gauge.assert_not_called()
@@ -132,7 +134,7 @@ def test_closed_records_otel_instruments_with_outcome():
 
     assert opened.calls == [(1, None)]
     assert closed.calls == [(1, {"outcome": "error"})]
-    assert duration.calls == [(4.0, None)]
+    assert duration.calls == [(4.0, {"outcome": "error"})]
     # +1 on open, -1 on close nets to a balanced active gauge.
     assert active.calls == [(1, None), (-1, None)]
 

--- a/agentex/tests/unit/utils/test_stream_metrics.py
+++ b/agentex/tests/unit/utils/test_stream_metrics.py
@@ -1,0 +1,150 @@
+"""Tests for the task-stream lifecycle metrics emitter.
+
+Covers the two paths that matter operationally: the no-op path (neither OTel nor
+StatsD configured, which is the default in tests and local dev) must never
+raise, and the StatsD path must emit each metric with the expected name and
+tags. The SSE stream path must never be disrupted by an instrumentation fault,
+so emission errors must be swallowed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from src.utils import stream_metrics
+
+
+@pytest.mark.unit
+def test_record_functions_are_noop_when_unconfigured():
+    # With no OTLP endpoint and no DD_AGENT_HOST, every call must be harmless.
+    with (
+        patch.object(stream_metrics, "_STATSD_ENABLED", False),
+        patch.object(stream_metrics, "_opened_counter", None),
+        patch.object(stream_metrics, "_closed_counter", None),
+        patch.object(stream_metrics, "_duration_histogram", None),
+        patch.object(stream_metrics, "_active_updown", None),
+        patch.object(stream_metrics, "_stall_counter", None),
+        patch.object(stream_metrics, "_instruments_initialized", True),
+    ):
+        stream_metrics.record_stream_opened()
+        stream_metrics.record_stream_closed("completed", 1.5)
+        stream_metrics.record_stream_stall()
+
+
+@pytest.mark.unit
+def test_record_functions_swallow_emission_errors():
+    # A failing backend must never propagate to the caller (live SSE path).
+    with (
+        patch.object(stream_metrics, "_STATSD_ENABLED", True),
+        patch.object(stream_metrics, "_instruments_initialized", True),
+        patch.object(stream_metrics, "_opened_counter", None),
+        patch.object(stream_metrics, "_closed_counter", None),
+        patch.object(stream_metrics, "_duration_histogram", None),
+        patch.object(stream_metrics, "_active_updown", None),
+        patch.object(stream_metrics, "_stall_counter", None),
+        patch.object(stream_metrics, "statsd") as mock_statsd,
+    ):
+        mock_statsd.increment.side_effect = OSError("socket in a bad state")
+        mock_statsd.decrement.side_effect = OSError("socket in a bad state")
+        mock_statsd.histogram.side_effect = OSError("socket in a bad state")
+
+        # None of these should raise despite the backend blowing up.
+        stream_metrics.record_stream_opened()
+        stream_metrics.record_stream_closed("error", 2.0)
+        stream_metrics.record_stream_stall()
+
+
+@pytest.mark.unit
+def test_record_stream_opened_emits_statsd_when_enabled():
+    with (
+        patch.object(stream_metrics, "_STATSD_ENABLED", True),
+        patch.object(stream_metrics, "_instruments_initialized", True),
+        patch.object(stream_metrics, "_opened_counter", None),
+        patch.object(stream_metrics, "_active_updown", None),
+        patch.object(stream_metrics, "statsd") as mock_statsd,
+    ):
+        stream_metrics.record_stream_opened()
+
+    # Opening bumps both the opened counter and the active gauge.
+    mock_statsd.increment.assert_any_call("agentex.task_stream.opened")
+    mock_statsd.increment.assert_any_call("agentex.task_stream.active")
+
+
+@pytest.mark.unit
+def test_record_stream_closed_emits_statsd_when_enabled():
+    with (
+        patch.object(stream_metrics, "_STATSD_ENABLED", True),
+        patch.object(stream_metrics, "_instruments_initialized", True),
+        patch.object(stream_metrics, "_closed_counter", None),
+        patch.object(stream_metrics, "_duration_histogram", None),
+        patch.object(stream_metrics, "_active_updown", None),
+        patch.object(stream_metrics, "statsd") as mock_statsd,
+    ):
+        stream_metrics.record_stream_closed("client_disconnect", 3.25)
+
+    mock_statsd.increment.assert_called_once_with(
+        "agentex.task_stream.closed",
+        tags=["outcome:client_disconnect"],
+    )
+    # Duration is reported to StatsD in milliseconds.
+    mock_statsd.histogram.assert_called_once_with(
+        "agentex.task_stream.duration", 3250.0
+    )
+    # Closing decrements the active gauge.
+    mock_statsd.decrement.assert_called_once_with("agentex.task_stream.active")
+
+
+@pytest.mark.unit
+def test_record_stream_stall_emits_statsd_when_enabled():
+    with (
+        patch.object(stream_metrics, "_STATSD_ENABLED", True),
+        patch.object(stream_metrics, "_instruments_initialized", True),
+        patch.object(stream_metrics, "_stall_counter", None),
+        patch.object(stream_metrics, "statsd") as mock_statsd,
+    ):
+        stream_metrics.record_stream_stall()
+
+    mock_statsd.increment.assert_called_once_with("agentex.task_stream.stall")
+
+
+@pytest.mark.unit
+def test_closed_records_otel_instruments_with_outcome():
+    # The OTel path records the outcome as a bounded attribute (not an id).
+    opened, closed, duration, active, stall = (
+        _FakeInstrument(),
+        _FakeInstrument(),
+        _FakeInstrument(),
+        _FakeInstrument(),
+        _FakeInstrument(),
+    )
+    with (
+        patch.object(stream_metrics, "_STATSD_ENABLED", False),
+        patch.object(stream_metrics, "_instruments_initialized", True),
+        patch.object(stream_metrics, "_opened_counter", opened),
+        patch.object(stream_metrics, "_closed_counter", closed),
+        patch.object(stream_metrics, "_duration_histogram", duration),
+        patch.object(stream_metrics, "_active_updown", active),
+        patch.object(stream_metrics, "_stall_counter", stall),
+    ):
+        stream_metrics.record_stream_opened()
+        stream_metrics.record_stream_closed("error", 4.0)
+
+    assert opened.calls == [(1, None)]
+    assert closed.calls == [(1, {"outcome": "error"})]
+    assert duration.calls == [(4.0, None)]
+    # +1 on open, -1 on close nets to a balanced active gauge.
+    assert active.calls == [(1, None), (-1, None)]
+
+
+class _FakeInstrument:
+    """Records (value, attributes) for add()/record() so tests can assert on them."""
+
+    def __init__(self):
+        self.calls: list[tuple[float, dict | None]] = []
+
+    def add(self, value, attributes=None):
+        self.calls.append((value, attributes))
+
+    def record(self, value, attributes=None):
+        self.calls.append((value, attributes))

--- a/agentex/tests/unit/utils/test_stream_metrics.py
+++ b/agentex/tests/unit/utils/test_stream_metrics.py
@@ -1,10 +1,10 @@
 """Tests for the task-stream lifecycle metrics emitter.
 
-Covers the two paths that matter operationally: the no-op path (neither OTel nor
-StatsD configured, which is the default in tests and local dev) must never
-raise, and the StatsD path must emit each metric with the expected name and
-tags. The SSE stream path must never be disrupted by an instrumentation fault,
-so emission errors must be swallowed.
+Emission is OpenTelemetry-only. Two paths matter operationally: the no-op path
+(OTel not configured, which is the default in tests and local dev) must never
+raise, and the OTel path must record each instrument with the expected value and
+bounded attributes. The SSE stream path must never be disrupted by an
+instrumentation fault, so emission errors must be swallowed.
 """
 
 from __future__ import annotations
@@ -17,9 +17,8 @@ from src.utils import stream_metrics
 
 @pytest.mark.unit
 def test_record_functions_are_noop_when_unconfigured():
-    # With no OTLP endpoint and no DD_AGENT_HOST, every call must be harmless.
+    # With no OTLP endpoint the instruments stay None, so every call is harmless.
     with (
-        patch.object(stream_metrics, "_STATSD_ENABLED", False),
         patch.object(stream_metrics, "_opened_counter", None),
         patch.object(stream_metrics, "_closed_counter", None),
         patch.object(stream_metrics, "_duration_histogram", None),
@@ -34,80 +33,20 @@ def test_record_functions_are_noop_when_unconfigured():
 
 @pytest.mark.unit
 def test_record_functions_swallow_emission_errors():
-    # A failing backend must never propagate to the caller (live SSE path).
+    # A failing instrument must never propagate to the caller (live SSE path).
+    exploding = _ExplodingInstrument()
     with (
-        patch.object(stream_metrics, "_STATSD_ENABLED", True),
         patch.object(stream_metrics, "_instruments_initialized", True),
-        patch.object(stream_metrics, "_opened_counter", None),
-        patch.object(stream_metrics, "_closed_counter", None),
-        patch.object(stream_metrics, "_duration_histogram", None),
-        patch.object(stream_metrics, "_active_updown", None),
-        patch.object(stream_metrics, "_stall_counter", None),
-        patch.object(stream_metrics, "statsd") as mock_statsd,
+        patch.object(stream_metrics, "_opened_counter", exploding),
+        patch.object(stream_metrics, "_closed_counter", exploding),
+        patch.object(stream_metrics, "_duration_histogram", exploding),
+        patch.object(stream_metrics, "_active_updown", exploding),
+        patch.object(stream_metrics, "_stall_counter", exploding),
     ):
-        mock_statsd.increment.side_effect = OSError("socket in a bad state")
-        mock_statsd.histogram.side_effect = OSError("socket in a bad state")
-
-        # None of these should raise despite the backend blowing up.
+        # None of these should raise despite the instrument blowing up.
         stream_metrics.record_stream_opened()
         stream_metrics.record_stream_closed("error", 2.0)
         stream_metrics.record_stream_stall()
-
-
-@pytest.mark.unit
-def test_record_stream_opened_emits_statsd_when_enabled():
-    with (
-        patch.object(stream_metrics, "_STATSD_ENABLED", True),
-        patch.object(stream_metrics, "_instruments_initialized", True),
-        patch.object(stream_metrics, "_opened_counter", None),
-        patch.object(stream_metrics, "_active_updown", None),
-        patch.object(stream_metrics, "statsd") as mock_statsd,
-    ):
-        stream_metrics.record_stream_opened()
-
-    # Opening bumps the opened counter. Concurrency ("active") is deliberately
-    # OTel-only, so the StatsD path emits no gauge (see module rationale).
-    mock_statsd.increment.assert_called_once_with("agentex.task_stream.opened")
-    mock_statsd.gauge.assert_not_called()
-
-
-@pytest.mark.unit
-def test_record_stream_closed_emits_statsd_when_enabled():
-    with (
-        patch.object(stream_metrics, "_STATSD_ENABLED", True),
-        patch.object(stream_metrics, "_instruments_initialized", True),
-        patch.object(stream_metrics, "_closed_counter", None),
-        patch.object(stream_metrics, "_duration_histogram", None),
-        patch.object(stream_metrics, "_active_updown", None),
-        patch.object(stream_metrics, "statsd") as mock_statsd,
-    ):
-        stream_metrics.record_stream_closed("client_disconnect", 3.25)
-
-    mock_statsd.increment.assert_called_once_with(
-        "agentex.task_stream.closed",
-        tags=["outcome:client_disconnect"],
-    )
-    # Duration is reported to StatsD in milliseconds, tagged by outcome.
-    mock_statsd.histogram.assert_called_once_with(
-        "agentex.task_stream.duration",
-        3250.0,
-        tags=["outcome:client_disconnect"],
-    )
-    # Concurrency ("active") is OTel-only, so closing emits no StatsD gauge.
-    mock_statsd.gauge.assert_not_called()
-
-
-@pytest.mark.unit
-def test_record_stream_stall_emits_statsd_when_enabled():
-    with (
-        patch.object(stream_metrics, "_STATSD_ENABLED", True),
-        patch.object(stream_metrics, "_instruments_initialized", True),
-        patch.object(stream_metrics, "_stall_counter", None),
-        patch.object(stream_metrics, "statsd") as mock_statsd,
-    ):
-        stream_metrics.record_stream_stall()
-
-    mock_statsd.increment.assert_called_once_with("agentex.task_stream.stall")
 
 
 @pytest.mark.unit
@@ -121,7 +60,6 @@ def test_closed_records_otel_instruments_with_outcome():
         _FakeInstrument(),
     )
     with (
-        patch.object(stream_metrics, "_STATSD_ENABLED", False),
         patch.object(stream_metrics, "_instruments_initialized", True),
         patch.object(stream_metrics, "_opened_counter", opened),
         patch.object(stream_metrics, "_closed_counter", closed),
@@ -139,6 +77,18 @@ def test_closed_records_otel_instruments_with_outcome():
     assert active.calls == [(1, None), (-1, None)]
 
 
+@pytest.mark.unit
+def test_stall_records_otel_counter():
+    stall = _FakeInstrument()
+    with (
+        patch.object(stream_metrics, "_instruments_initialized", True),
+        patch.object(stream_metrics, "_stall_counter", stall),
+    ):
+        stream_metrics.record_stream_stall()
+
+    assert stall.calls == [(1, None)]
+
+
 class _FakeInstrument:
     """Records (value, attributes) for add()/record() so tests can assert on them."""
 
@@ -150,3 +100,13 @@ class _FakeInstrument:
 
     def record(self, value, attributes=None):
         self.calls.append((value, attributes))
+
+
+class _ExplodingInstrument:
+    """Raises on every emission to prove the record_* functions swallow faults."""
+
+    def add(self, value, attributes=None):
+        raise OSError("instrument in a bad state")
+
+    def record(self, value, attributes=None):
+        raise OSError("instrument in a bad state")

--- a/agentex/tests/unit/utils/test_stream_metrics.py
+++ b/agentex/tests/unit/utils/test_stream_metrics.py
@@ -47,7 +47,6 @@ def test_record_functions_swallow_emission_errors():
     ):
         mock_statsd.increment.side_effect = OSError("socket in a bad state")
         mock_statsd.histogram.side_effect = OSError("socket in a bad state")
-        mock_statsd.gauge.side_effect = OSError("socket in a bad state")
 
         # None of these should raise despite the backend blowing up.
         stream_metrics.record_stream_opened()
@@ -62,15 +61,14 @@ def test_record_stream_opened_emits_statsd_when_enabled():
         patch.object(stream_metrics, "_instruments_initialized", True),
         patch.object(stream_metrics, "_opened_counter", None),
         patch.object(stream_metrics, "_active_updown", None),
-        patch.object(stream_metrics, "_active_stream_count", 0),
         patch.object(stream_metrics, "statsd") as mock_statsd,
     ):
         stream_metrics.record_stream_opened()
 
-    # Opening bumps the opened counter and reports the active concurrency level
-    # as an absolute gauge (DogStatsD gauges are last-value-wins, not deltas).
+    # Opening bumps the opened counter. Concurrency ("active") is deliberately
+    # OTel-only, so the StatsD path emits no gauge (see module rationale).
     mock_statsd.increment.assert_called_once_with("agentex.task_stream.opened")
-    mock_statsd.gauge.assert_called_once_with("agentex.task_stream.active", 1)
+    mock_statsd.gauge.assert_not_called()
 
 
 @pytest.mark.unit
@@ -81,7 +79,6 @@ def test_record_stream_closed_emits_statsd_when_enabled():
         patch.object(stream_metrics, "_closed_counter", None),
         patch.object(stream_metrics, "_duration_histogram", None),
         patch.object(stream_metrics, "_active_updown", None),
-        patch.object(stream_metrics, "_active_stream_count", 1),
         patch.object(stream_metrics, "statsd") as mock_statsd,
     ):
         stream_metrics.record_stream_closed("client_disconnect", 3.25)
@@ -94,8 +91,8 @@ def test_record_stream_closed_emits_statsd_when_enabled():
     mock_statsd.histogram.assert_called_once_with(
         "agentex.task_stream.duration", 3250.0
     )
-    # Closing lowers the active gauge to the new absolute level (1 -> 0).
-    mock_statsd.gauge.assert_called_once_with("agentex.task_stream.active", 0)
+    # Concurrency ("active") is OTel-only, so closing emits no StatsD gauge.
+    mock_statsd.gauge.assert_not_called()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Adds stream-lifecycle instrumentation for the task-event SSE stream (`GET /tasks/{task_id}/stream`). HTTP request-level RED is already covered by auto-instrumentation — but a single long-lived SSE request emits exactly one duration sample at connection close, which says nothing about what happened *during* the stream's life. This fills that gap with five hand-instrumented series:

- `agentex_task_stream_opened_total` — streams opened
- `agentex_task_stream_closed_total{outcome}` — streams closed, tagged `completed` / `client_disconnect` / `error`
- `agentex_task_stream_duration_seconds` — stream lifetime histogram
- `agentex_task_stream_active` — currently-open streams (gauge)
- `agentex_task_stream_stall_total` — streams that went idle (no event pushed) past a configurable threshold

## Local Testing:
- make dev -> kicks off local OpenTelemetry collector fired an SSE stream against the endpoint:                                                                                                                                    
- ran fake tasks/{id}/stream API locally: curl -N http://localhost:5003/tasks/blah/stream
  - This returned the initial data: {"type":"connected","taskId":"blah"}, then :ping, then disconnected, and checcked the metrics via curl -s http://localhost:8889/metrics | grep agentex_task_stream, which printed out stuff that included all 5 custom metrics:
 
```
cynthia.wang@SCMJMH9C4MX2W agentex % curl -s localhost:8889/metrics | grep -E '^agentex_task_stream_'
agentex_task_stream_active{instance="agentex-api.unknown.21635",job="agentex-api"} 0 1785785023147
agentex_task_stream_closed_total{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect"} 1 1785785023147
agentex_task_stream_closed_total{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="1"} 0 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="5"} 0 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="15"} 0 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="30"} 0 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="60"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="120"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="300"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="600"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="1800"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="3600"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="7200"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="14400"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect",le="+Inf"} 1 1785785023147
agentex_task_stream_duration_seconds_sum{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect"} 39.602999999944586 1785785023147
agentex_task_stream_duration_seconds_count{instance="agentex-api.unknown.21635",job="agentex-api",outcome="client_disconnect"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="1"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="5"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="15"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="30"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="60"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="120"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="300"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="600"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="1800"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="3600"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="7200"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="14400"} 1 1785785023147
agentex_task_stream_duration_seconds_bucket{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error",le="+Inf"} 1 1785785023147
agentex_task_stream_duration_seconds_sum{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error"} 0.03399999998509884 1785785023147
agentex_task_stream_duration_seconds_count{instance="agentex-api.unknown.21635",job="agentex-api",outcome="error"} 1 1785785023147
agentex_task_stream_opened_total{instance="agentex-api.unknown.21635",job="agentex-api"} 2 1785785023147
agentex_task_stream_stall_total{instance="agentex-api.unknown.21635",job="agentex-api"} 1 1785785023147
cynthia.wang@SCMJMH9C4MX2W agentex % 


```                                                                                  
                                                                                                                                                                                                  

## Details

- New `src/utils/stream_metrics.py` mirrors the dual-emit pattern in `cache_metrics.py`: records through the OpenTelemetry SDK when an OTLP endpoint is configured, emits StatsD when the Datadog Agent host is set, and is a cheap no-op otherwise. Every emit path is wrapped so an instrumentation fault can never disrupt the live SSE path.
- Instruments carry only the bounded `outcome` label (no ids, no `http_route`), so cardinality stays flat.
- Open/close are paired via `try/finally` in `stream_task_events` so the active gauge stays balanced even if setup raises. Stall detection tracks last *data* event separately from keepalive pings, so a persistently quiet stream still trips the stall signal while the connection stays alive. One stall episode increments the counter once (onset), not once per idle cycle.
- New env var `SSE_STREAM_STALL_THRESHOLD_SECONDS` (default 30) controls the stall window.

## Test plan

- [x] `make test FILE=tests/unit/utils/test_stream_metrics.py` — no-op-when-unconfigured, error-swallowing, and StatsD/OTel emission assertions
- [ ] Confirm the five series land in Mimir with the expected flattened names once deployed to an OTLP-enabled environment
- [ ] Verify `outcome` distribution (`completed` / `client_disconnect` / `error`) on a real stream close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds five hand-instrumented OTel series that fill the observability gap left by auto-instrumented HTTP RED metrics on the long-lived `GET /tasks/{task_id}/stream` SSE endpoint. Each series is scoped to a bounded `outcome` attribute, so cardinality stays flat across any deployment scale.

- **`stream_metrics.py`**: New OTel-only module with lazily-created instruments, exception-swallowing emit functions, and clear separation from the older StatsD dual-emit path used by `cache_metrics.py`.
- **`streams_use_case.py`**: Instruments the generator using an `opened` flag inside a `try/finally` so the active gauge is always balanced; stall detection uses a separate `last_event_time` clock so keepalive pings don't mask real idle periods, and a `stalled` boolean ensures each stall episode increments the counter exactly once.
- **`environment_variables.py`**: Adds `SSE_STREAM_STALL_THRESHOLD_SECONDS` (default 30 s) with consistent enum key, model field, and `from_env` wiring.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — instrumentation is additive, all emit functions are exception-safe, and the active gauge is correctly balanced via the opened flag in try/finally.

All five metric series are wired correctly, the outcome attribute stays bounded to three values, the opened guard prevents double-decrementing the active gauge, and stall detection uses a separate clock so keepalive pings do not mask real idle periods. Unit tests cover the no-op, error-swallowing, and emit paths. No metric cardinality violations found.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/utils/stream_metrics.py | New OTel-only metrics module for SSE stream lifecycle; lazy instrument init, all emit paths swallow exceptions, bounded outcome attribute only — no cardinality issues. |
| agentex/src/domain/use_cases/streams_use_case.py | Adds stream-open/close instrumentation inside try/finally with opened flag to avoid over-decrementing the active gauge; correctly maps all four exit paths to the right StreamOutcome values. |
| agentex/src/config/environment_variables.py | Adds SSE_STREAM_STALL_THRESHOLD_SECONDS env var (default 30) alongside the existing keepalive interval; enum key, model field, and from_env construction are all consistent. |
| agentex/tests/unit/utils/test_stream_metrics.py | Unit tests cover the three key behaviours: no-op when unconfigured, exception-swallowing, and correct OTel instrument recording for open/close/stall paths. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant StreamsUseCase
    participant stream_metrics
    participant OTel

    Client->>StreamsUseCase: "GET /tasks/{id}/stream"
    Note over StreamsUseCase: stream_start_time = loop.time()
    StreamsUseCase->>stream_metrics: record_stream_opened()
    stream_metrics->>OTel: opened_counter +1, active_updown +1
    StreamsUseCase-->>Client: data connected
    loop Live polling
        StreamsUseCase->>StreamsUseCase: read_messages()
        alt Messages received
            StreamsUseCase-->>Client: data event
            Note over StreamsUseCase: last_event_time=now, stalled=False
        else Idle
            alt stall threshold exceeded
                StreamsUseCase->>stream_metrics: record_stream_stall()
                stream_metrics->>OTel: stall_counter +1
            end
            StreamsUseCase-->>Client: :ping
        end
    end
    alt Normal completion
        StreamsUseCase->>stream_metrics: record_stream_closed(completed, duration)
    else Client disconnect
        StreamsUseCase->>stream_metrics: record_stream_closed(client_disconnect, duration)
    else Error
        StreamsUseCase->>stream_metrics: record_stream_closed(error, duration)
    end
    stream_metrics->>OTel: closed_counter, duration_histogram, active_updown -1
```
</details>

<sub>Reviews (8): Last reviewed commit: ["fix(tasks): set seconds-scale buckets on..."](https://github.com/scaleapi/scale-agentex/commit/66273b018bf4ec9e48ce7d8e76ecc0fd2343d051) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48769476)</sub>

<!-- /greptile_comment -->