### PR TITLE
fix(observability): isolate SSE stream spans and continue ingress traceparent

### DIFF
--- a/agentex/src/api/routes/tasks.py
+++ b/agentex/src/api/routes/tasks.py
@@ -1,7 +1,7 @@
 import json
 from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 
 from src.adapters.temporal.adapter_temporal import DTemporalAdapter
@@ -345,13 +345,18 @@ async def timeout_task(
 async def stream_task_events(
     task_id: DAuthorizedId(AgentexResourceType.task, AuthorizedOperationType.read),
     stream_use_case: DStreamsUseCase,
+    request: Request,
 ) -> StreamingResponse:
     """
     Streams task events using Server-Sent Events (SSE).
     """
 
     return StreamingResponse(
-        stream_use_case.stream_task_events(task_id=task_id),
+        # Pass request headers so the stream span continues an inbound W3C
+        # traceparent (ingress edge) instead of starting an unrelated trace.
+        stream_use_case.stream_task_events(
+            task_id=task_id, carrier=dict(request.headers)
+        ),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
@@ -369,13 +374,18 @@ async def stream_task_events(
 async def stream_task_events_by_name(
     task_name: DAuthorizedName(AgentexResourceType.task, AuthorizedOperationType.read),
     stream_use_case: DStreamsUseCase,
+    request: Request,
 ) -> StreamingResponse:
     """
     Streams task events using Server-Sent Events (SSE) by task name.
     """
 
     return StreamingResponse(
-        stream_use_case.stream_task_events(task_name=task_name),
+        # Pass request headers so the stream span continues an inbound W3C
+        # traceparent (ingress edge) instead of starting an unrelated trace.
+        stream_use_case.stream_task_events(
+            task_name=task_name, carrier=dict(request.headers)
+        ),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/agentex/src/domain/use_cases/streams_use_case.py
+++ b/agentex/src/domain/use_cases/streams_use_case.py
@@ -1,8 +1,14 @@
 import asyncio
-from collections.abc import AsyncIterator
+import sys
+from collections.abc import AsyncIterator, Mapping
 from typing import Annotated
 
 from fastapi import Depends
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.propagate import extract
+from opentelemetry.trace import SpanKind, Status, StatusCode
 from pydantic import ValidationError
 
 from src.adapters.crud_store.exceptions import ItemDoesNotExist
@@ -22,6 +28,11 @@ from src.utils.logging import make_logger
 from src.utils.stream_topics import get_task_event_stream_topic
 
 logger = make_logger(__name__)
+
+# ProxyTracer: resolves to the process TracerProvider lazily at span-creation
+# time, so this is safe to bind at import even when tracing is configured later
+# (and a no-op when no provider is installed).
+_TRACER = trace.get_tracer("agentex.task_stream")
 
 
 class StreamsUseCase:
@@ -90,151 +101,238 @@ class StreamsUseCase:
         self,
         task_id: str | None = None,
         task_name: str | None = None,
+        carrier: Mapping[str, str] | None = None,
     ) -> AsyncIterator[str]:
         """
         Async generator for streaming task message updates as SSE data strings.
         Sends keepalive pings to maintain long-lived connections.
+
+        Each call runs under its own OpenTelemetry span whose parent is taken
+        *only* from the inbound W3C ``traceparent`` (``carrier``) or, absent one,
+        a fresh root — never the ambient context. The SSE body is pumped by the
+        ASGI server long after the request handler returned, so the ambient
+        context can still carry a previous request's span; inheriting it made a
+        stream's logs and child spans resolve to an unrelated, long-lived trace
+        (cross-request context bleed). Anchoring to an isolated context and
+        attaching it for the stream's lifetime keeps every stream self-contained.
         """
-        task_id = task_id
-        if not task_id:
-            if not task_name:
-                raise ValueError("Either task_id or task_name must be provided")
+        # Parent the stream span on the ingress traceparent alone. The empty
+        # ``Context()`` base is the isolation: ``extract`` otherwise falls back to
+        # the current (possibly stale) context, which is exactly the bleed. With
+        # no inbound traceparent this yields a fresh root; with one, a child.
+        parent_context = extract(dict(carrier) if carrier else {}, context=Context())
+        span = _TRACER.start_span(
+            "stream task events",
+            context=parent_context,
+            kind=SpanKind.SERVER,
+        )
+        # Attach the span as current for the stream's lifetime so log lines
+        # correlate to this trace (fixing the "otelTraceID resolves to an
+        # unrelated trace" symptom) and any downstream spans nest under it.
+        context_token = otel_context.attach(
+            trace.set_span_in_context(span, parent_context)
+        )
 
-            task = await self.task_service.get_task(name=task_name)
-            task_id = task.id
+        # Lifecycle outcome, finalized on the span in ``finally``. Defaults assume
+        # a clean server-side end; each termination path narrows the reason.
+        stream_outcome = "completed"
+        disconnect_reason = "completed"
+        first_event_recorded = False
 
-        stream_topic = get_task_event_stream_topic(task_id=task_id)
-        # Cursor before status read: catches a racing terminal event.
-        last_id = await self.stream_repository.get_stream_tail_id(stream_topic)
-        task = await self.task_service.get_task(id=task_id)
-        # Send initial connection data
-        yield f"data: {TaskStreamConnectedEventEntity(type='connected', taskId=task_id).model_dump_json()}\n\n"
-        # Already terminal: replay buffered events and end (late connect).
-        if task.status in TERMINAL_TASK_STATUSES:
-            async for _id, data in self.read_messages(topic=stream_topic, last_id="0"):
-                yield f"data: {data.model_dump_json()}\n\n"
-                await asyncio.sleep(0.02)
-            logger.info(
-                f"Ending SSE stream for task {task_id}: already terminal at connect"
-            )
-            return
+        def _record_first_event() -> None:
+            # Time-to-first-event marker: the first real task event delivered
+            # (the synthetic "connected" frame and keepalive pings don't count).
+            nonlocal first_event_recorded
+            if not first_event_recorded:
+                first_event_recorded = True
+                span.add_event("first-event")
 
-        last_message_time = asyncio.get_running_loop().time()
-        ping_interval = float(
-            self.environment_variables.SSE_KEEPALIVE_PING_INTERVAL
-        )  # Configurable keepalive ping interval
-        # Track consecutive read failures so we can back off and avoid a
-        # tight error loop. When the Redis pool is exhausted, every connected
-        # client's read fails on each cycle; without backoff this turns into a
-        # log-ingestion firehose (one failure per client per cycle, ~once/sec).
-        consecutive_errors = 0
-        last_status_check = last_message_time
+        span.add_event("open")
         try:
-            # Application-level control loop
-            while True:
-                try:
-                    # Authoritative status recheck on an interval. Runs at the
-                    # TOP of every iteration — even after a read failure/backoff —
-                    # so a terminal task ends even if its event publish was lost
-                    # or Redis reads keep erroring.
-                    current_time = asyncio.get_running_loop().time()
-                    if current_time - last_status_check >= ping_interval:
-                        last_status_check = current_time
-                        try:
-                            task = await self.task_service.get_task(id=task_id)
-                        except ItemDoesNotExist:
-                            # Row permanently gone (e.g. retention) — end, don't retry.
-                            logger.info(
-                                f"Ending SSE stream for task {task_id}: "
-                                "task no longer exists"
-                            )
-                            return
-                        if task.status in TERMINAL_TASK_STATUSES:
-                            logger.info(
-                                f"Ending SSE stream for task {task_id}: "
-                                "terminal on status recheck"
-                            )
-                            return
+            if not task_id:
+                if not task_name:
+                    raise ValueError("Either task_id or task_name must be provided")
 
-                    # Process yielded messages one by one
-                    message_generator = self.read_messages(
-                        topic=stream_topic, last_id=last_id
-                    )
-                    message_count = 0
-                    async for new_id, data in message_generator:
-                        # Update the last_id for the next iteration
-                        last_id = new_id
-                        message_count += 1
-                        # Send the data to the client
-                        data_str = f"data: {data.model_dump_json()}\n\n"
-                        yield data_str
-                        last_message_time = asyncio.get_running_loop().time()
-                        # Terminal event is the last one — end here.
-                        if (
-                            isinstance(data, TaskStreamTaskUpdatedEventEntity)
-                            and data.task is not None
-                            and data.task.status in TERMINAL_TASK_STATUSES
-                        ):
-                            logger.info(
-                                f"Ending SSE stream for task {task_id}: received "
-                                "a terminal task_updated event"
-                            )
-                            return
-                        await asyncio.sleep(0.02)
+                task = await self.task_service.get_task(name=task_name)
+                task_id = task.id
+            span.set_attribute("task.id", task_id)
 
-                    # A read cycle completed without raising — the stream is
-                    # healthy again, so reset the backoff/error counter.
-                    consecutive_errors = 0
+            stream_topic = get_task_event_stream_topic(task_id=task_id)
+            # Cursor before status read: catches a racing terminal event.
+            last_id = await self.stream_repository.get_stream_tail_id(stream_topic)
+            task = await self.task_service.get_task(id=task_id)
+            # Send initial connection data
+            yield f"data: {TaskStreamConnectedEventEntity(type='connected', taskId=task_id).model_dump_json()}\n\n"
+            # Already terminal: replay buffered events and end (late connect).
+            if task.status in TERMINAL_TASK_STATUSES:
+                async for _id, data in self.read_messages(
+                    topic=stream_topic, last_id="0"
+                ):
+                    _record_first_event()
+                    yield f"data: {data.model_dump_json()}\n\n"
+                    await asyncio.sleep(0.02)
+                disconnect_reason = "already_terminal"
+                logger.info(
+                    f"Ending SSE stream for task {task_id}: already terminal at connect"
+                )
+                return
 
-                    # Idle: send keepalive ping so proxies don't reap us. Use a
-                    # fresh timestamp — the read above blocks up to timeout_ms, so
-                    # the loop-top current_time would be stale for ping timing.
-                    if message_count == 0:
-                        now = asyncio.get_running_loop().time()
-                        if now - last_message_time >= ping_interval:
-                            yield ":ping\n\n"
-                            last_message_time = now
-                        await asyncio.sleep(0.1)
-                    else:
-                        # Small pause between batches
-                        await asyncio.sleep(0.02)
-                except asyncio.CancelledError:
-                    # Client disconnected, exit the loop
-                    logger.info(
-                        f"Client disconnected from SSE stream for task {task_id}"
-                    )
-                    raise
-                except Exception as e:
-                    consecutive_errors += 1
-                    # Always log the full traceback — nothing is swallowed.
-                    # Volume is controlled two ways instead of by dropping
-                    # diagnostics: structured JSON logging keeps each traceback
-                    # to a single log entry (see utils.logging), and the
-                    # exponential backoff below caps how often a sustained
-                    # failure can repeat. The failure counter gives context on
-                    # how long a stream has been erroring.
-                    logger.error(
-                        f"Error processing events for task {task_id} "
-                        f"(failure #{consecutive_errors}): {e}",
-                        exc_info=True,
-                    )
-                    yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
-                    # Exponential backoff (capped) so a sustained failure (e.g.
-                    # Redis pool exhaustion) doesn't spin a tight per-client
-                    # loop hammering Redis and flooding logs.
-                    backoff = min(2.0 ** min(consecutive_errors - 1, 5), 30.0)
-                    await asyncio.sleep(backoff)
+            last_message_time = asyncio.get_running_loop().time()
+            ping_interval = float(
+                self.environment_variables.SSE_KEEPALIVE_PING_INTERVAL
+            )  # Configurable keepalive ping interval
+            # Track consecutive read failures so we can back off and avoid a
+            # tight error loop. When the Redis pool is exhausted, every connected
+            # client's read fails on each cycle; without backoff this turns into a
+            # log-ingestion firehose (one failure per client per cycle, ~once/sec).
+            consecutive_errors = 0
+            last_status_check = last_message_time
+            try:
+                # Application-level control loop
+                while True:
+                    try:
+                        # Authoritative status recheck on an interval. Runs at the
+                        # TOP of every iteration — even after a read failure/backoff
+                        # — so a terminal task ends even if its event publish was
+                        # lost or Redis reads keep erroring.
+                        current_time = asyncio.get_running_loop().time()
+                        if current_time - last_status_check >= ping_interval:
+                            last_status_check = current_time
+                            try:
+                                task = await self.task_service.get_task(id=task_id)
+                            except ItemDoesNotExist:
+                                # Row permanently gone (e.g. retention) — end.
+                                stream_outcome = "task_gone"
+                                disconnect_reason = "task_deleted"
+                                logger.info(
+                                    f"Ending SSE stream for task {task_id}: "
+                                    "task no longer exists"
+                                )
+                                return
+                            if task.status in TERMINAL_TASK_STATUSES:
+                                disconnect_reason = "terminal_status"
+                                logger.info(
+                                    f"Ending SSE stream for task {task_id}: "
+                                    "terminal on status recheck"
+                                )
+                                return
 
-        except asyncio.CancelledError:
-            # Just exit the generator on cancellation
-            logger.info(f"Client disconnected from SSE stream for task {task_id}")
-            pass
-        except Exception as e:
-            logger.error(
-                f"Fatal error in SSE stream for task {task_id}: {e}", exc_info=True
-            )
-            yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
+                        # Process yielded messages one by one
+                        message_generator = self.read_messages(
+                            topic=stream_topic, last_id=last_id
+                        )
+                        message_count = 0
+                        async for new_id, data in message_generator:
+                            # Update the last_id for the next iteration
+                            last_id = new_id
+                            message_count += 1
+                            _record_first_event()
+                            # Send the data to the client
+                            data_str = f"data: {data.model_dump_json()}\n\n"
+                            yield data_str
+                            last_message_time = asyncio.get_running_loop().time()
+                            # Terminal event is the last one — end here.
+                            if (
+                                isinstance(data, TaskStreamTaskUpdatedEventEntity)
+                                and data.task is not None
+                                and data.task.status in TERMINAL_TASK_STATUSES
+                            ):
+                                disconnect_reason = "terminal_event"
+                                logger.info(
+                                    f"Ending SSE stream for task {task_id}: received "
+                                    "a terminal task_updated event"
+                                )
+                                return
+                            await asyncio.sleep(0.02)
+
+                        # A read cycle completed without raising — the stream is
+                        # healthy again, so reset the backoff/error counter.
+                        consecutive_errors = 0
+
+                        # Idle: send keepalive ping so proxies don't reap us. Use a
+                        # fresh timestamp — the read above blocks up to timeout_ms,
+                        # so the loop-top current_time would be stale for ping timing.
+                        if message_count == 0:
+                            now = asyncio.get_running_loop().time()
+                            if now - last_message_time >= ping_interval:
+                                yield ":ping\n\n"
+                                last_message_time = now
+                            await asyncio.sleep(0.1)
+                        else:
+                            # Small pause between batches
+                            await asyncio.sleep(0.02)
+                    except asyncio.CancelledError:
+                        # Client disconnected, exit the loop
+                        stream_outcome = "client_disconnect"
+                        disconnect_reason = "client_disconnect"
+                        logger.info(
+                            f"Client disconnected from SSE stream for task {task_id}"
+                        )
+                        raise
+                    except Exception as e:
+                        consecutive_errors += 1
+                        # Always log the full traceback — nothing is swallowed.
+                        # Volume is controlled two ways instead of by dropping
+                        # diagnostics: structured JSON logging keeps each traceback
+                        # to a single log entry (see utils.logging), and the
+                        # exponential backoff below caps how often a sustained
+                        # failure can repeat. The failure counter gives context on
+                        # how long a stream has been erroring.
+                        logger.error(
+                            f"Error processing events for task {task_id} "
+                            f"(failure #{consecutive_errors}): {e}",
+                            exc_info=True,
+                        )
+                        yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
+                        # Exponential backoff (capped) so a sustained failure (e.g.
+                        # Redis pool exhaustion) doesn't spin a tight per-client
+                        # loop hammering Redis and flooding logs.
+                        backoff = min(2.0 ** min(consecutive_errors - 1, 5), 30.0)
+                        await asyncio.sleep(backoff)
+
+            except asyncio.CancelledError:
+                # Just exit the generator on cancellation
+                stream_outcome = "client_disconnect"
+                disconnect_reason = "client_disconnect"
+                logger.info(f"Client disconnected from SSE stream for task {task_id}")
+                pass
+            except Exception as e:
+                stream_outcome = "error"
+                disconnect_reason = type(e).__name__
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                logger.error(
+                    f"Fatal error in SSE stream for task {task_id}: {e}", exc_info=True
+                )
+                yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
         finally:
+            # Classify an outcome that no handler already set from the exception
+            # still in flight. Two uncaught cases reach here: Starlette aborting
+            # the body with GeneratorExit on client disconnect, and an exception
+            # from the pre-loop setup (task resolution, initial reads) — neither
+            # passes through the loop's handlers, so without this they'd be
+            # mislabeled "completed".
+            in_flight = sys.exc_info()[1]
+            if in_flight is not None and stream_outcome == "completed":
+                if isinstance(in_flight, GeneratorExit | asyncio.CancelledError):
+                    stream_outcome = "client_disconnect"
+                    disconnect_reason = "client_disconnect"
+                else:
+                    stream_outcome = "error"
+                    disconnect_reason = type(in_flight).__name__
+                    span.record_exception(in_flight)
+                    span.set_status(Status(StatusCode.ERROR, str(in_flight)))
+            span.set_attribute("stream.outcome", stream_outcome)
+            span.set_attribute("disconnect.reason", disconnect_reason)
+            span.add_event(
+                "close",
+                {
+                    "stream.outcome": stream_outcome,
+                    "disconnect.reason": disconnect_reason,
+                },
+            )
+            span.end()
+            otel_context.detach(context_token)
             # Don't delete the shared topic; the TTL reclaims it.
             logger.info(f"SSE stream for task {task_id} has ended")
 

--- a/agentex/src/domain/use_cases/streams_use_case.py
+++ b/agentex/src/domain/use_cases/streams_use_case.py
@@ -187,131 +187,129 @@ class StreamsUseCase:
             # log-ingestion firehose (one failure per client per cycle, ~once/sec).
             consecutive_errors = 0
             last_status_check = last_message_time
-            try:
-                # Application-level control loop
-                while True:
-                    try:
-                        # Authoritative status recheck on an interval. Runs at the
-                        # TOP of every iteration — even after a read failure/backoff
-                        # — so a terminal task ends even if its event publish was
-                        # lost or Redis reads keep erroring.
-                        current_time = asyncio.get_running_loop().time()
-                        if current_time - last_status_check >= ping_interval:
-                            last_status_check = current_time
-                            try:
-                                task = await self.task_service.get_task(id=task_id)
-                            except ItemDoesNotExist:
-                                # Row permanently gone (e.g. retention) — end.
-                                stream_outcome = "task_gone"
-                                disconnect_reason = "task_deleted"
-                                logger.info(
-                                    f"Ending SSE stream for task {task_id}: "
-                                    "task no longer exists"
-                                )
-                                return
-                            if task.status in TERMINAL_TASK_STATUSES:
-                                disconnect_reason = "terminal_status"
-                                logger.info(
-                                    f"Ending SSE stream for task {task_id}: "
-                                    "terminal on status recheck"
-                                )
-                                return
+            # Application-level control loop
+            while True:
+                try:
+                    # Authoritative status recheck on an interval. Runs at the
+                    # TOP of every iteration — even after a read failure/backoff
+                    # — so a terminal task ends even if its event publish was
+                    # lost or Redis reads keep erroring.
+                    current_time = asyncio.get_running_loop().time()
+                    if current_time - last_status_check >= ping_interval:
+                        last_status_check = current_time
+                        try:
+                            task = await self.task_service.get_task(id=task_id)
+                        except ItemDoesNotExist:
+                            # Row permanently gone (e.g. retention) — end.
+                            stream_outcome = "task_gone"
+                            disconnect_reason = "task_deleted"
+                            logger.info(
+                                f"Ending SSE stream for task {task_id}: "
+                                "task no longer exists"
+                            )
+                            return
+                        if task.status in TERMINAL_TASK_STATUSES:
+                            disconnect_reason = "terminal_status"
+                            logger.info(
+                                f"Ending SSE stream for task {task_id}: "
+                                "terminal on status recheck"
+                            )
+                            return
 
-                        # Process yielded messages one by one
-                        message_generator = self.read_messages(
-                            topic=stream_topic, last_id=last_id
-                        )
-                        message_count = 0
-                        async for new_id, data in message_generator:
-                            # Update the last_id for the next iteration
-                            last_id = new_id
-                            message_count += 1
-                            _record_first_event()
-                            # Send the data to the client
-                            data_str = f"data: {data.model_dump_json()}\n\n"
-                            yield data_str
-                            last_message_time = asyncio.get_running_loop().time()
-                            # Terminal event is the last one — end here.
-                            if (
-                                isinstance(data, TaskStreamTaskUpdatedEventEntity)
-                                and data.task is not None
-                                and data.task.status in TERMINAL_TASK_STATUSES
-                            ):
-                                disconnect_reason = "terminal_event"
-                                logger.info(
-                                    f"Ending SSE stream for task {task_id}: received "
-                                    "a terminal task_updated event"
-                                )
-                                return
-                            await asyncio.sleep(0.02)
+                    # Process yielded messages one by one
+                    message_generator = self.read_messages(
+                        topic=stream_topic, last_id=last_id
+                    )
+                    message_count = 0
+                    async for new_id, data in message_generator:
+                        # Update the last_id for the next iteration
+                        last_id = new_id
+                        message_count += 1
+                        _record_first_event()
+                        # Send the data to the client
+                        data_str = f"data: {data.model_dump_json()}\n\n"
+                        yield data_str
+                        last_message_time = asyncio.get_running_loop().time()
+                        # Terminal event is the last one — end here.
+                        if (
+                            isinstance(data, TaskStreamTaskUpdatedEventEntity)
+                            and data.task is not None
+                            and data.task.status in TERMINAL_TASK_STATUSES
+                        ):
+                            disconnect_reason = "terminal_event"
+                            logger.info(
+                                f"Ending SSE stream for task {task_id}: received "
+                                "a terminal task_updated event"
+                            )
+                            return
+                        await asyncio.sleep(0.02)
 
-                        # A read cycle completed without raising — the stream is
-                        # healthy again, so reset the backoff/error counter.
-                        consecutive_errors = 0
+                    # A read cycle completed without raising — the stream is
+                    # healthy again, so reset the backoff/error counter.
+                    consecutive_errors = 0
 
-                        # Idle: send keepalive ping so proxies don't reap us. Use a
-                        # fresh timestamp — the read above blocks up to timeout_ms,
-                        # so the loop-top current_time would be stale for ping timing.
-                        if message_count == 0:
-                            now = asyncio.get_running_loop().time()
-                            if now - last_message_time >= ping_interval:
-                                yield ":ping\n\n"
-                                last_message_time = now
-                            await asyncio.sleep(0.1)
-                        else:
-                            # Small pause between batches
-                            await asyncio.sleep(0.02)
-                    except asyncio.CancelledError:
-                        # Client disconnected, exit the loop
-                        stream_outcome = "client_disconnect"
-                        disconnect_reason = "client_disconnect"
-                        logger.info(
-                            f"Client disconnected from SSE stream for task {task_id}"
-                        )
-                        raise
-                    except Exception as e:
-                        consecutive_errors += 1
-                        # Always log the full traceback — nothing is swallowed.
-                        # Volume is controlled two ways instead of by dropping
-                        # diagnostics: structured JSON logging keeps each traceback
-                        # to a single log entry (see utils.logging), and the
-                        # exponential backoff below caps how often a sustained
-                        # failure can repeat. The failure counter gives context on
-                        # how long a stream has been erroring.
-                        logger.error(
-                            f"Error processing events for task {task_id} "
-                            f"(failure #{consecutive_errors}): {e}",
-                            exc_info=True,
-                        )
-                        yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
-                        # Exponential backoff (capped) so a sustained failure (e.g.
-                        # Redis pool exhaustion) doesn't spin a tight per-client
-                        # loop hammering Redis and flooding logs.
-                        backoff = min(2.0 ** min(consecutive_errors - 1, 5), 30.0)
-                        await asyncio.sleep(backoff)
+                    # Idle: send keepalive ping so proxies don't reap us. Use a
+                    # fresh timestamp — the read above blocks up to timeout_ms,
+                    # so the loop-top current_time would be stale for ping timing.
+                    if message_count == 0:
+                        now = asyncio.get_running_loop().time()
+                        if now - last_message_time >= ping_interval:
+                            yield ":ping\n\n"
+                            last_message_time = now
+                        await asyncio.sleep(0.1)
+                    else:
+                        # Small pause between batches
+                        await asyncio.sleep(0.02)
+                except asyncio.CancelledError:
+                    # Client disconnected, exit the loop
+                    stream_outcome = "client_disconnect"
+                    disconnect_reason = "client_disconnect"
+                    logger.info(
+                        f"Client disconnected from SSE stream for task {task_id}"
+                    )
+                    raise
+                except Exception as e:
+                    consecutive_errors += 1
+                    # Always log the full traceback — nothing is swallowed.
+                    # Volume is controlled two ways instead of by dropping
+                    # diagnostics: structured JSON logging keeps each traceback
+                    # to a single log entry (see utils.logging), and the
+                    # exponential backoff below caps how often a sustained
+                    # failure can repeat. The failure counter gives context on
+                    # how long a stream has been erroring.
+                    logger.error(
+                        f"Error processing events for task {task_id} "
+                        f"(failure #{consecutive_errors}): {e}",
+                        exc_info=True,
+                    )
+                    yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
+                    # Exponential backoff (capped) so a sustained failure (e.g.
+                    # Redis pool exhaustion) doesn't spin a tight per-client
+                    # loop hammering Redis and flooding logs.
+                    backoff = min(2.0 ** min(consecutive_errors - 1, 5), 30.0)
+                    await asyncio.sleep(backoff)
 
-            except asyncio.CancelledError:
-                # Just exit the generator on cancellation
-                stream_outcome = "client_disconnect"
-                disconnect_reason = "client_disconnect"
-                logger.info(f"Client disconnected from SSE stream for task {task_id}")
-                pass
-            except Exception as e:
-                stream_outcome = "error"
-                disconnect_reason = type(e).__name__
-                span.record_exception(e)
-                span.set_status(Status(StatusCode.ERROR, str(e)))
-                logger.error(
-                    f"Fatal error in SSE stream for task {task_id}: {e}", exc_info=True
-                )
-                yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
+        except asyncio.CancelledError:
+            # Just exit the generator on cancellation
+            stream_outcome = "client_disconnect"
+            disconnect_reason = "client_disconnect"
+            logger.info(f"Client disconnected from SSE stream for task {task_id}")
+            pass
+        except Exception as e:
+            stream_outcome = "error"
+            disconnect_reason = type(e).__name__
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            logger.error(
+                f"Fatal error in SSE stream for task {task_id}: {e}", exc_info=True
+            )
+            yield f"data: {TaskStreamErrorEventEntity(type='error', message=str(e)).model_dump_json()}\n\n"
         finally:
-            # Classify an outcome that no handler already set from the exception
-            # still in flight. Two uncaught cases reach here: Starlette aborting
-            # the body with GeneratorExit on client disconnect, and an exception
-            # from the pre-loop setup (task resolution, initial reads) — neither
-            # passes through the loop's handlers, so without this they'd be
-            # mislabeled "completed".
+            # Safety net for an exception that bypassed the except clauses above
+            # and is still in flight — chiefly Starlette aborting the SSE body
+            # with GeneratorExit on client disconnect, which is a BaseException
+            # that `except Exception` doesn't see. Only reclassify when no
+            # handler already set an outcome.
             in_flight = sys.exc_info()[1]
             if in_flight is not None and stream_outcome == "completed":
                 if isinstance(in_flight, GeneratorExit | asyncio.CancelledError):

--- a/agentex/tests/unit/use_cases/test_streams_use_case_tracing.py
+++ b/agentex/tests/unit/use_cases/test_streams_use_case_tracing.py
@@ -204,3 +204,29 @@ class TestStreamTracing:
         # No stream span should be lingering as the current span.
         current = trace.get_current_span()
         assert current.get_span_context().trace_id == 0  # INVALID → nothing attached
+
+    async def test_setup_failure_emits_error_frame_and_marks_span(self, span_exporter):
+        # A failure during setup (here, the initial task lookup) must produce the
+        # established SSE error frame rather than escaping the generator — which
+        # would surface to the client as a broken stream — and the span must be
+        # marked errored.
+        class _BoomTaskService:
+            async def get_task(self, id=None, name=None):
+                raise RuntimeError("boom")
+
+        uc = StreamsUseCase(
+            stream_repository=_FakeStreamRepository(),
+            task_service=_BoomTaskService(),
+            environment_variables=SimpleNamespace(SSE_KEEPALIVE_PING_INTERVAL=15),
+        )
+        frames = [chunk async for chunk in uc.stream_task_events(task_id="task-123")]
+
+        # The generator completed normally, yielding a parseable SSE error frame.
+        assert frames, "expected an SSE error frame, got nothing"
+        assert frames[-1].startswith("data: ")
+        assert '"type":"error"' in frames[-1]
+        assert "boom" in frames[-1]
+
+        span = _only_stream_span(span_exporter)
+        assert span.attributes["stream.outcome"] == "error"
+        assert span.attributes["disconnect.reason"] == "RuntimeError"

--- a/agentex/tests/unit/use_cases/test_streams_use_case_tracing.py
+++ b/agentex/tests/unit/use_cases/test_streams_use_case_tracing.py
@@ -1,0 +1,206 @@
+"""Tracing tests for the SSE task-event stream.
+
+These lock in the AGX1-617 fixes:
+
+1. Each stream runs under its own span, isolated from the ambient OTel context —
+   a stream must never nest under a leftover span from an unrelated request
+   (the cross-request "context bleed" that made a /stream log's trace resolve to
+   a multi-hour, thousands-of-spans trace).
+2. When the caller supplies a W3C ``traceparent`` (ingress edge), the stream
+   span continues that trace as a child rather than starting a new root.
+3. The span carries the ``open`` / ``first-event`` / ``close`` lifecycle events
+   and the ``task.id`` / ``stream.outcome`` / ``disconnect.reason`` attributes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+
+import pytest
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from src.domain.entities.tasks import TaskStatus
+from src.domain.use_cases import streams_use_case as streams_module
+from src.domain.use_cases.streams_use_case import StreamsUseCase
+
+# A well-formed W3C traceparent (version-traceid-spanid-flags), sampled.
+_INBOUND_TRACE_ID = 0x4BF92F3577B34DA6A3CE929D0E0E4736
+_INBOUND_PARENT_SPAN_ID = 0x00F067AA0BA902B7
+_INBOUND_TRACEPARENT = f"00-{_INBOUND_TRACE_ID:032x}-{_INBOUND_PARENT_SPAN_ID:016x}-01"
+
+_SPAN_NAME = "stream task events"
+
+
+class _FakeStreamRepository:
+    """Minimal stream repo: a fixed tail id and a fixed buffered replay."""
+
+    def __init__(self, buffered: list[tuple[str, dict]] | None = None):
+        self._buffered = buffered or []
+
+    async def get_stream_tail_id(self, topic: str) -> str:
+        return "0-0"
+
+    async def read_messages(
+        self, topic: str, last_id: str, timeout_ms: int = 2000, count: int = 10
+    ) -> AsyncIterator[tuple[str, dict]]:
+        for message_id, obj in self._buffered:
+            yield message_id, obj
+
+
+class _FakeTaskService:
+    """Returns a single task for both id and name lookups."""
+
+    def __init__(self, task: SimpleNamespace):
+        self._task = task
+
+    async def get_task(self, id=None, name=None) -> SimpleNamespace:
+        return self._task
+
+
+def _make_use_case(
+    *,
+    status: TaskStatus,
+    buffered: list[tuple[str, dict]] | None = None,
+    task_id: str = "task-123",
+) -> StreamsUseCase:
+    task = SimpleNamespace(id=task_id, status=status)
+    return StreamsUseCase(
+        stream_repository=_FakeStreamRepository(buffered),
+        task_service=_FakeTaskService(task),
+        environment_variables=SimpleNamespace(SSE_KEEPALIVE_PING_INTERVAL=15),
+    )
+
+
+@pytest.fixture
+def span_exporter(monkeypatch) -> InMemorySpanExporter:
+    """Route the module's tracer to an in-memory exporter for assertions."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(streams_module, "_TRACER", provider.get_tracer("test"))
+    # Stash the provider so tests can mint a "stale" ambient span from it.
+    exporter._test_provider = provider  # type: ignore[attr-defined]
+    return exporter
+
+
+def _only_stream_span(exporter: InMemorySpanExporter):
+    spans = [s for s in exporter.get_finished_spans() if s.name == _SPAN_NAME]
+    assert len(spans) == 1, f"expected exactly one stream span, got {len(spans)}"
+    return spans[0]
+
+
+async def _drain(gen) -> None:
+    async for _ in gen:
+        pass
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestStreamTracing:
+    async def test_stream_span_is_isolated_root_when_no_traceparent(
+        self, span_exporter
+    ):
+        # A stale span is active in the ambient context, mimicking a previous
+        # request whose context leaked. The stream must NOT nest under it.
+        provider = span_exporter._test_provider  # type: ignore[attr-defined]
+        stale = provider.get_tracer("stale").start_span("POST /unrelated")
+        token = otel_context.attach(trace.set_span_in_context(stale))
+        try:
+            uc = _make_use_case(status=TaskStatus.COMPLETED)
+            await _drain(uc.stream_task_events(task_id="task-123"))
+        finally:
+            otel_context.detach(token)
+            stale.end()
+
+        span = _only_stream_span(span_exporter)
+        # No parent → a brand-new root, on a different trace than the stale span.
+        assert span.parent is None
+        assert span.context.trace_id != stale.get_span_context().trace_id
+
+    async def test_stream_span_continues_inbound_traceparent(self, span_exporter):
+        uc = _make_use_case(status=TaskStatus.COMPLETED)
+        await _drain(
+            uc.stream_task_events(
+                task_id="task-123",
+                carrier={"traceparent": _INBOUND_TRACEPARENT},
+            )
+        )
+
+        span = _only_stream_span(span_exporter)
+        # Same trace as the caller, parented on the caller's span id.
+        assert span.context.trace_id == _INBOUND_TRACE_ID
+        assert span.parent is not None
+        assert span.parent.span_id == _INBOUND_PARENT_SPAN_ID
+
+    async def test_inbound_traceparent_wins_over_ambient_context(self, span_exporter):
+        # Even with a (stale) ambient span active, the ingress traceparent — not
+        # the ambient context — must decide the parent.
+        provider = span_exporter._test_provider  # type: ignore[attr-defined]
+        stale = provider.get_tracer("stale").start_span("POST /unrelated")
+        token = otel_context.attach(trace.set_span_in_context(stale))
+        try:
+            uc = _make_use_case(status=TaskStatus.COMPLETED)
+            await _drain(
+                uc.stream_task_events(
+                    task_id="task-123",
+                    carrier={"traceparent": _INBOUND_TRACEPARENT},
+                )
+            )
+        finally:
+            otel_context.detach(token)
+            stale.end()
+
+        span = _only_stream_span(span_exporter)
+        assert span.context.trace_id == _INBOUND_TRACE_ID
+        assert span.context.trace_id != stale.get_span_context().trace_id
+
+    async def test_lifecycle_events_and_attributes_on_clean_end(self, span_exporter):
+        # Already-terminal task replays one buffered event, then ends cleanly.
+        buffered = [("1-0", {"type": "error", "message": "buffered"})]
+        uc = _make_use_case(status=TaskStatus.COMPLETED, buffered=buffered)
+        await _drain(uc.stream_task_events(task_id="task-123"))
+
+        span = _only_stream_span(span_exporter)
+        event_names = [e.name for e in span.events]
+        assert event_names == ["open", "first-event", "close"]
+        assert span.attributes["task.id"] == "task-123"
+        assert span.attributes["stream.outcome"] == "completed"
+        assert span.attributes["disconnect.reason"] == "already_terminal"
+
+    async def test_first_event_absent_when_no_events_delivered(self, span_exporter):
+        # Terminal-at-connect with nothing buffered: open/close only.
+        uc = _make_use_case(status=TaskStatus.COMPLETED)
+        await _drain(uc.stream_task_events(task_id="task-123"))
+
+        span = _only_stream_span(span_exporter)
+        assert [e.name for e in span.events] == ["open", "close"]
+
+    async def test_client_disconnect_is_recorded_on_aclose(self, span_exporter):
+        # Non-terminal task: the generator suspends at the "connected" yield.
+        # Closing it (as Starlette does on client disconnect) raises GeneratorExit
+        # into the generator, which must be classified as a client disconnect.
+        uc = _make_use_case(status=TaskStatus.RUNNING)
+        gen = uc.stream_task_events(task_id="task-123")
+        first = await gen.__anext__()
+        assert "connected" in first
+        await gen.aclose()
+
+        span = _only_stream_span(span_exporter)
+        assert span.attributes["stream.outcome"] == "client_disconnect"
+        assert span.attributes["disconnect.reason"] == "client_disconnect"
+
+    async def test_span_ends_exactly_once_and_detaches_context(self, span_exporter):
+        # After the stream ends, the ambient context must be clean (the attached
+        # stream context was detached), so a later span is a fresh root.
+        uc = _make_use_case(status=TaskStatus.COMPLETED)
+        await _drain(uc.stream_task_events(task_id="task-123"))
+
+        # No stream span should be lingering as the current span.
+        current = trace.get_current_span()
+        assert current.get_span_context().trace_id == 0  # INVALID → nothing attached

--- a/agentex/tests/unit/use_cases/test_streams_use_case_tracing.py
+++ b/agentex/tests/unit/use_cases/test_streams_use_case_tracing.py
@@ -1,6 +1,6 @@
 """Tracing tests for the SSE task-event stream.
 
-These lock in the AGX1-617 fixes:
+These lock in the SSE trace context bleed fixes:
 
 1. Each stream runs under its own span, isolated from the ambient OTel context —
    a stream must never nest under a leftover span from an unrelated request
@@ -203,6 +203,9 @@ class TestStreamTracing:
         # stream context was detached), so a later span is a fresh root.
         uc = _make_use_case(status=TaskStatus.COMPLETED)
         await _drain(uc.stream_task_events(task_id="task-123"))
+
+        # Exactly one stream span was finished (ended once, not zero or twice).
+        _only_stream_span(span_exporter)
 
         # No stream span should be lingering as the current span.
         current = trace.get_current_span()


### PR DESCRIPTION
## Summary

The SSE task-event stream reused the ambient OpenTelemetry context across requests. Because the SSE body is pumped by the ASGI server long after the request handler returns, the ambient context could still carry a previous request's span — so a stream's logs (`otelTraceID`) and any child spans resolved to an unrelated, long-lived trace (cross-request context bleed).

This change makes each stream self-contained:

- **Isolated per-stream span.** Every `stream_task_events` call runs under its own span, parented **only** on the inbound W3C `traceparent` (via `extract(carrier, context=Context())`) or a fresh root when absent — never the ambient context. The empty `Context()` base is the isolation mechanism.
- **Ingress traceparent continuation.** The stream routes now pass request headers, so when a caller supplies a `traceparent` the stream span continues that trace as a child instead of starting a new root.
- **Lifecycle span.** The span carries `open` / `first-event` / `close` events and `task.id` / `stream.outcome` / `disconnect.reason` attributes, and stays attached for the generator's lifetime so log lines correlate to the correct trace. A `finally` block classifies the in-flight exception (`GeneratorExit` / `CancelledError` → client disconnect) so the ASGI disconnect path isn't mislabeled `completed`.

Existing SSE behavior (keepalive pings, backoff, terminal detection, shared-topic non-deletion) is unchanged.

## Testing
Local trace validation                                                                                                                                                                                     - Exercised the real stream_task_events code against a local OpenTelemetry collector to confirm the per-stream span is emitted with the right lineage and lifecycle.

What was run                                                        
 - Added a temporary traces pipeline to the local collector config (otlp receiver → batch → debug exporter) so spans sent to :4317 print to the collector's stdout.                    
- Ran a throwaway host-side script that installs a TracerProvider + OTLP exporter (the local app process installs none), then calls stream_task_events twice through it: once with no inbound traceparent, once with a fixed W3C traceparent. Both invocations use a fake repo/task, so no Redis/Postgres needed.                                                           
- Read the spans back with docker logs agentex-otel-collector.      
- Both artifacts are local-only and are not part of this change.                                                                                                                        
- output                                                                                                                                                              

```
cynthia.wang@SCMJMH9C4MX2W agentex % docker logs --since 40s agentex-otel-collector 2>&1 | tail -80
     -> server.address: Str(agentex-postgres)
     -> server.port: Int(5432)
     -> db.namespace: Str(agentex)
     -> deployment.environment: Str(development)
StartTimestamp: 2026-08-04 00:00:46.032029327 +0000 UTC
Timestamp: 2026-08-04 18:46:13.005977041 +0000 UTC
Value: 30
	{"kind": "exporter", "data_type": "metrics", "name": "debug"}
2026-08-04T18:46:29.476Z	info	TracesExporter	{"kind": "exporter", "data_type": "traces", "name": "debug", "resource spans": 1, "spans": 2}
2026-08-04T18:46:29.476Z	info	ResourceSpans #0
Resource SchemaURL: 
Resource attributes:
     -> telemetry.sdk.language: Str(python)
     -> telemetry.sdk.name: Str(opentelemetry)
     -> telemetry.sdk.version: Str(1.39.1)
     -> service.name: Str(unknown_service)
ScopeSpans #0
ScopeSpans SchemaURL: 
InstrumentationScope agentex.task_stream 
Span #0
    Trace ID       : a8570b702f8e9bf556ae9312ef52d5b4
    Parent ID      : 
    ID             : 2f61e8c10d846335
    Name           : stream task events
    Kind           : Server
    Start time     : 2026-08-04 18:46:20.65019 +0000 UTC
    End time       : 2026-08-04 18:46:20.671546 +0000 UTC
    Status code    : Unset
    Status message : 
Attributes:
     -> task.id: Str(task-123)
     -> stream.outcome: Str(completed)
     -> disconnect.reason: Str(already_terminal)
Events:
SpanEvent #0
     -> Name: open
     -> Timestamp: 2026-08-04 18:46:20.650199 +0000 UTC
     -> DroppedAttributesCount: 0
SpanEvent #1
     -> Name: first-event
     -> Timestamp: 2026-08-04 18:46:20.650381 +0000 UTC
     -> DroppedAttributesCount: 0
SpanEvent #2
     -> Name: close
     -> Timestamp: 2026-08-04 18:46:20.671544 +0000 UTC
     -> DroppedAttributesCount: 0
     -> Attributes::
          -> stream.outcome: Str(completed)
          -> disconnect.reason: Str(already_terminal)
Span #1
    Trace ID       : 4bf92f3577b34da6a3ce929d0e0e4736
    Parent ID      : 00f067aa0ba902b7
    ID             : ead43fd6edc6c9ba
    Name           : stream task events
    Kind           : Server
    Start time     : 2026-08-04 18:46:20.671629 +0000 UTC
    End time       : 2026-08-04 18:46:20.692803 +0000 UTC
    Status code    : Unset
    Status message : 
Attributes:
     -> task.id: Str(task-123)
     -> stream.outcome: Str(completed)
     -> disconnect.reason: Str(already_terminal)
Events:
SpanEvent #0
     -> Name: open
     -> Timestamp: 2026-08-04 18:46:20.671633 +0000 UTC
     -> DroppedAttributesCount: 0
SpanEvent #1
     -> Name: first-event
     -> Timestamp: 2026-08-04 18:46:20.671649 +0000 UTC
     -> DroppedAttributesCount: 0
SpanEvent #2
     -> Name: close
     -> Timestamp: 2026-08-04 18:46:20.692801 +0000 UTC
     -> DroppedAttributesCount: 0
     -> Attributes::
          -> stream.outcome: Str(completed)
          -> disconnect.reason: Str(already_terminal)
	{"kind": "exporter", "data_type": "traces", "name": "debug"}
cynthia.wang@SCMJMH9C4MX2W agentex % 
```

What it shows — two stream task events spans (Kind: Server):                                                                                                                          
- Span 0 (no traceparent) — empty Parent ID and its own Trace ID: a fresh root, confirming the fallback when no inbound context is present.                                          
- Span 1 (with traceparent) — Trace ID equals the inbound trace and Parent ID equals the inbound span id, with a new span id of its own: the stream continues the caller's trace as a child rather than starting a new one.                                                                                                                                                
  - Both carry the lifecycle events open → first-event → close and the attributes task.id, stream.outcome, disconnect.reason, verifying the per-stream span shape.
                                                                                                                                                                                        
The context-isolation behavior (a stream must not inherit a leftover ambient span from an unrelated request) can't be reproduced by this out-of-process harness and is covered by the 
  unit tests in tests/unit/use_cases/test_streams_use_case_tracing.py.  

## Changes

- `src/domain/use_cases/streams_use_case.py` — module tracer + span lifecycle around the stream generator; `carrier` param.
- `src/api/routes/tasks.py` — both stream routes inject `Request` and pass `carrier=dict(request.headers)`.
- `tests/unit/use_cases/test_streams_use_case_tracing.py` (new) — 7 tests covering isolation-from-ambient, traceparent continuation, ingress-wins-over-ambient, lifecycle event order/attributes, and clean context detach.

## Test plan

- [x] New tracing unit tests pass (7 passed)
- [x] Full unit suite passes (433 passed) — no regression
- [x] Ruff lint + format clean (pre-commit hooks pass)
- [ ] Integration suite (`test_task_stream.py`) — could not run locally (testcontainers/Docker env issue); calls are signature-compatible with the new `carrier=None` default
- [ ] E2E in a collector: confirm a `/stream` trace is a self-contained root without a `traceparent` header, and a child of the caller when one is supplied

> Note: real SDK clients won't inject `traceparent` until the SDK-side ingress injection lands; until then the continuation half is verified with an explicit `traceparent` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR isolates each SSE task-event stream in its own OpenTelemetry span and continues valid inbound W3C trace context.
- Passes request headers from both task stream routes into the stream use case.
- Adds stream lifecycle events, outcome attributes, exception recording, and context cleanup.
- Moves task and stream setup into the SSE error-handling boundary.
- Adds unit coverage for context isolation, parent continuation, lifecycle metadata, disconnect handling, cleanup, and setup failures.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported setup failures are now handled inside the stream recovery boundary and produce an SSE error frame, with no blocking failure remaining.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/streams_use_case.py | Introduces isolated per-stream tracing and lifecycle telemetry while moving the previously reported setup operations inside the SSE error-frame handler. |
| agentex/src/api/routes/tasks.py | Passes inbound request headers from both SSE routes to the stream use case for W3C trace-context continuation. |
| agentex/tests/unit/use_cases/test_streams_use_case_tracing.py | Covers trace isolation and continuation, lifecycle attributes, generator closure, context detachment, and setup-failure recovery. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Route as Task stream route
    participant Stream as StreamsUseCase
    participant OTel as OpenTelemetry
    participant Repo as Task/stream repositories

    Client->>Route: "GET /tasks/.../stream<br/>optional traceparent"
    Route->>Stream: "stream_task_events(carrier=headers)"
    Stream->>OTel: Extract using isolated Context
    Stream->>OTel: Start and attach per-stream span
    Stream->>Repo: Resolve task and stream cursor
    alt Setup succeeds
        Stream-->>Client: connected and event frames
    else Setup fails
        Stream->>OTel: Record exception and error status
        Stream-->>Client: SSE error frame
    end
    Stream->>OTel: Add close metadata, end span, detach context
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into cynthiawang/agx..."](https://github.com/scaleapi/scale-agentex/commit/5a044a75c70f2e040bb5e97e23f168229e50c3c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49237640)</sub>

<!-- /greptile_comment -->