### PR TITLE
feat(states): add TaskStateORM and task_states table migration

### DIFF
--- a/agentex/database/migrations/alembic/versions/2026_08_03_1500_add_task_states_771e95623724.py
+++ b/agentex/database/migrations/alembic/versions/2026_08_03_1500_add_task_states_771e95623724.py
@@ -47,13 +47,11 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        # Cascade is a dormant safety net: no current flow hard-deletes task
-        # rows (API deletes are soft; retention deletes states explicitly and
-        # keeps the task row).
-        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="CASCADE"),
-        # No cascade on agent_id: agents are never hard-deleted today, and
-        # silently dropping an agent's states if that changed would be the
-        # wrong default.
+        # Both FKs are bare (no ON DELETE action), deliberately: MongoDB has no
+        # cascades, so state deletion is application-driven on both backends.
+        # The FK alone prevents orphaned rows; a future hard-delete flow must
+        # remove states through the repository or fail loudly here.
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
         sa.ForeignKeyConstraint(["agent_id"], ["agents.id"]),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/agentex/database/migrations/alembic/versions/2026_08_03_1500_add_task_states_771e95623724.py
+++ b/agentex/database/migrations/alembic/versions/2026_08_03_1500_add_task_states_771e95623724.py
@@ -48,9 +48,12 @@ def upgrade() -> None:
             nullable=False,
         ),
         # Both FKs are bare (no ON DELETE action), deliberately: MongoDB has no
-        # cascades, so state deletion is application-driven on both backends.
-        # The FK alone prevents orphaned rows; a future hard-delete flow must
-        # remove states through the repository or fail loudly here.
+        # cascades, so state deletion is application-driven on both backends,
+        # and the FK alone prevents orphaned rows. This matches the sibling
+        # child tables of tasks (task_agents, events), whose bare FKs already
+        # reject the existing DELETE /tasks path for any task with children;
+        # task_states behaves identically rather than cascading on one backend
+        # only.
         sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
         sa.ForeignKeyConstraint(["agent_id"], ["agents.id"]),
         sa.PrimaryKeyConstraint("id"),

--- a/agentex/database/migrations/alembic/versions/2026_08_03_1500_add_task_states_771e95623724.py
+++ b/agentex/database/migrations/alembic/versions/2026_08_03_1500_add_task_states_771e95623724.py
@@ -1,0 +1,72 @@
+"""add task_states
+
+Revision ID: 771e95623724
+Revises: a1b2c3d4e5f6
+Create Date: 2026-08-03 15:00:00.000000
+
+Creates the task_states table: the optional PostgreSQL backend for task state
+(selected per deployment via TASK_STATE_STORAGE_PHASE; MongoDB remains the
+default). Schema-only on a brand-new table, so creation is instant and holds
+no lock against live traffic; nothing reads or writes the table until the
+Postgres task-state repository lands.
+
+The (task_id, agent_id) index is deliberately absent: its shape is the open
+write-semantics decision (a unique constraint backing an atomic upsert, or a
+plain compound index mirroring MongoDB) and it ships with that decision.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "771e95623724"
+down_revision: str | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "task_states",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("task_id", sa.String(), nullable=False),
+        sa.Column("agent_id", sa.String(), nullable=False),
+        sa.Column("state", JSONB(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        # Cascade is a dormant safety net: no current flow hard-deletes task
+        # rows (API deletes are soft; retention deletes states explicitly and
+        # keeps the task row).
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"], ondelete="CASCADE"),
+        # No cascade on agent_id: agents are never hard-deleted today, and
+        # silently dropping an agent's states if that changed would be the
+        # wrong default.
+        sa.ForeignKeyConstraint(["agent_id"], ["agents.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # The index targets the table created in this same migration, so it holds
+    # no write-blocking lock against live traffic (the table has no rows yet).
+    op.create_index(
+        "ix_task_states_agent_id",
+        "task_states",
+        ["agent_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_task_states_agent_id", table_name="task_states")
+    op.drop_table("task_states")

--- a/agentex/src/adapters/orm.py
+++ b/agentex/src/adapters/orm.py
@@ -147,6 +147,45 @@ class AgentTaskTrackerORM(BaseORM):
     )
 
 
+class TaskStateORM(BaseORM):
+    """Task state on PostgreSQL: one row per (task, agent) pair.
+
+    Optional storage backend for task state (selected per deployment via
+    TASK_STATE_STORAGE_PHASE); MongoDB remains the default. Nothing reads or
+    writes this table until the Postgres task-state repository lands.
+    """
+
+    __tablename__ = "task_states"
+
+    id = Column(String, primary_key=True, default=orm_id)
+    # Cascade is a dormant safety net: no current flow hard-deletes task rows
+    # (API deletes are soft; retention deletes states explicitly and keeps the
+    # task row).
+    task_id = Column(String, ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False)
+    # No cascade: agents are never hard-deleted today, and if that changed,
+    # silently dropping an agent's states while its messages survive would be
+    # the wrong default.
+    agent_id = Column(String, ForeignKey("agents.id"), nullable=False)
+    state = Column(JSONB, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        # The (task_id, agent_id) index is deliberately absent: its shape is
+        # the open write-semantics decision (a unique constraint backing an
+        # atomic upsert, or a plain compound index mirroring MongoDB) and it
+        # ships with the repository that reads this table.
+        Index("ix_task_states_agent_id", "agent_id"),
+    )
+
+
 class SpanORM(BaseORM):
     __tablename__ = "spans"
     id = Column(String, primary_key=True, default=orm_id)  # Using UUIDs for IDs

--- a/agentex/src/adapters/orm.py
+++ b/agentex/src/adapters/orm.py
@@ -159,12 +159,18 @@ class TaskStateORM(BaseORM):
 
     id = Column(String, primary_key=True, default=orm_id)
     # Both FKs are bare (no ON DELETE action), deliberately: MongoDB has no
-    # cascades, so state deletion is application-driven on both backends. The
-    # FK alone prevents orphaned rows; a future hard-delete flow must remove
-    # states through the repository or fail loudly here.
+    # cascades, so state deletion is application-driven on both backends, and
+    # the FK alone prevents orphaned rows. This matches the sibling child
+    # tables of tasks (task_agents, events), whose bare FKs already reject the
+    # existing DELETE /tasks path for any task with children; task_states
+    # behaves identically rather than cascading on one backend only.
     task_id = Column(String, ForeignKey("tasks.id"), nullable=False)
     agent_id = Column(String, ForeignKey("agents.id"), nullable=False)
     state = Column(JSONB, nullable=False)
+    # NOT NULL with a server default: the repository must OMIT unset (None)
+    # timestamps when constructing rows. SQLAlchemy renders an explicitly
+    # assigned None as a literal NULL, which violates the constraint instead
+    # of falling back to the default (StateEntity defaults these to None).
     created_at = Column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/agentex/src/adapters/orm.py
+++ b/agentex/src/adapters/orm.py
@@ -158,13 +158,11 @@ class TaskStateORM(BaseORM):
     __tablename__ = "task_states"
 
     id = Column(String, primary_key=True, default=orm_id)
-    # Cascade is a dormant safety net: no current flow hard-deletes task rows
-    # (API deletes are soft; retention deletes states explicitly and keeps the
-    # task row).
-    task_id = Column(String, ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False)
-    # No cascade: agents are never hard-deleted today, and if that changed,
-    # silently dropping an agent's states while its messages survive would be
-    # the wrong default.
+    # Both FKs are bare (no ON DELETE action), deliberately: MongoDB has no
+    # cascades, so state deletion is application-driven on both backends. The
+    # FK alone prevents orphaned rows; a future hard-delete flow must remove
+    # states through the repository or fail loudly here.
+    task_id = Column(String, ForeignKey("tasks.id"), nullable=False)
     agent_id = Column(String, ForeignKey("agents.id"), nullable=False)
     state = Column(JSONB, nullable=False)
     created_at = Column(


### PR DESCRIPTION
## Summary

Second PR in the task-state storage series (follows #380). Adds `TaskStateORM` and a migration creating the `task_states` table: the PostgreSQL home for task state once the Postgres repository lands in the next PR.

The table is created empty and inert. Nothing reads or writes it until the repository PR wires the `postgres` phase, so deploying this changes no behavior. The migration is schema-only on a brand-new table (instant, no locks against live traffic) and `downgrade` cleanly drops it.

## Deliberately deferred (needs design sign-off)

Two decisions from the design review are still open, so this PR ships without them and stays in draft until they close:

1. **The `(task_id, agent_id)` index/constraint is absent.** Its shape is the open write-semantics decision: a unique constraint backing an atomic upsert, or a plain compound index mirroring MongoDB's non-unique one. It ships alongside the repository that implements whichever contract is chosen.
2. **FK delete behavior (proposed).** Both FKs are bare, no ON DELETE action, matching the repo convention. Rationale: MongoDB has no cascades, so state deletion is application-driven on both backends and a Postgres-only cascade would be a silent behavioral divergence; the FK alone prevents orphaned rows, and a future hard-delete flow should remove states through the repository or fail loudly on the constraint. This is Q5 in the TDD, deliberately left open for input; chime in there or here if you see a case for CASCADE.

## Verification

- Migration linter clean; ruff clean; full unit suite passes (the ORM materializes in the test fixtures' Postgres containers).
- Applied the full migration chain from scratch against a disposable Postgres 17 container: table shape verified column for column, `downgrade` removes it cleanly, re-upgrade succeeds.

## What's next

The final M1 PR: `TaskStatePostgresRepository` implementing the repository contract from #380, the selector's `postgres` branch going live, and the parity test suite running against both backends.
