### PR TITLE
feat(agentex): support SYNC agents in the Slack gateway

### DIFF
--- a/agentex/src/domain/use_cases/slack_gateway_use_case.py
+++ b/agentex/src/domain/use_cases/slack_gateway_use_case.py
@@ -103,6 +103,14 @@ _MESSAGE_PAGE = 200  # per-poll page size when collecting the reply
 # ``event_id`` via Redis with a short TTL so a retry can't start a duplicate turn.
 _EVENT_DEDUP_TTL_SECONDS = int(os.getenv("SLACK_EVENT_DEDUP_TTL", "600"))
 
+# A create-race (two concurrent first turns for one thread) makes the loser's
+# get-or-create raise DuplicateItemError. Retrying re-runs get-or-create; the backoff
+# lets a lagging read replica catch up so the retry sees the winner's task instead of
+# racing the create against the primary again. A single retry can still miss under
+# replica lag, so retry a bounded number of times before surfacing the failure.
+_CREATE_RACE_ATTEMPTS = max(1, int(os.getenv("SLACK_CREATE_RACE_ATTEMPTS", "4")))
+_CREATE_RACE_BACKOFF_S = float(os.getenv("SLACK_CREATE_RACE_BACKOFF_S", "0.25"))
+
 # The ``@agent <selector>`` token drives resolution (see ``_resolve_target``): the
 # selector is tried as an SGP agent_config NAME (-> golden-agent + that config), then as a
 # registered agentex agent name (-> route to that runtime); if neither matches (or there's
@@ -442,6 +450,46 @@ class SlackGatewayUseCase:
             )
         return None
 
+    async def _message_send_with_race_retry(self, acp, params, agent_id):
+        """Send a SYNC agent's ``message/send`` (which get-or-creates the thread task and
+        returns the reply), retrying the whole call on the create-race.
+
+        Two concurrent first messages for the same thread both miss the get-or-create
+        lookup and race the insert on the globally-unique task name; the loser raises
+        ``DuplicateItemError``. Retrying re-runs get-or-create — but the lookup reads the
+        (possibly-lagging) read replica, so a single retry can still miss the winner's
+        task and race the create again. Loop with a short backoff so replication catches
+        up; give up only after ``_CREATE_RACE_ATTEMPTS`` (persistent lag → surfaced to
+        the caller). Each raising attempt fails on the insert before appending anything,
+        so retries never duplicate the turn's message."""
+        last: DuplicateItemError | None = None
+        for attempt in range(_CREATE_RACE_ATTEMPTS):
+            try:
+                return await acp.handle_rpc_request(
+                    method=AgentRPCMethod.MESSAGE_SEND, params=params, agent_id=agent_id
+                )
+            except DuplicateItemError as exc:
+                last = exc
+                if attempt < _CREATE_RACE_ATTEMPTS - 1:
+                    await asyncio.sleep(_CREATE_RACE_BACKOFF_S)
+        raise last  # exhausted retries — let _run_turn surface the failure
+
+    async def _resolve_task_after_race(self, task_service, task_name: str):
+        """Resolve the winner's task by name after an async-path create-race
+        (DuplicateItemError). The lookup reads the (possibly-lagging) read replica, so
+        retry on ItemDoesNotExist with a short backoff until replication catches up —
+        the task exists on the primary, the replica just hasn't seen it yet. Give up
+        after ``_CREATE_RACE_ATTEMPTS`` (persistent lag → surfaced to the caller)."""
+        last: ItemDoesNotExist | None = None
+        for attempt in range(_CREATE_RACE_ATTEMPTS):
+            try:
+                return await task_service.get_task(name=task_name)
+            except ItemDoesNotExist as exc:
+                last = exc
+                if attempt < _CREATE_RACE_ATTEMPTS - 1:
+                    await asyncio.sleep(_CREATE_RACE_BACKOFF_S)
+        raise last
+
     async def _dispatch(
         self,
         target: Target,
@@ -496,14 +544,7 @@ class SlackGatewayUseCase:
                 task_params=create_params,
                 stream=False,
             )
-            try:
-                replies = await acp.handle_rpc_request(
-                    method=AgentRPCMethod.MESSAGE_SEND, params=send, agent_id=agent.id
-                )
-            except DuplicateItemError:
-                replies = await acp.handle_rpc_request(
-                    method=AgentRPCMethod.MESSAGE_SEND, params=send, agent_id=agent.id
-                )
+            replies = await self._message_send_with_race_retry(acp, send, agent.id)
             return _agent_text(replies or [])
 
         # ASYNC / AGENTIC: TASK_CREATE only on the first turn, then event/send + poll.
@@ -530,9 +571,10 @@ class SlackGatewayUseCase:
             except DuplicateItemError:
                 # A concurrent first event for the same thread won the create race
                 # (task_name is globally unique, and the DB insert fails before any
-                # workflow starts). Fall back to the task it created and just send this
-                # turn's event, exactly as a follow-up would.
-                task = await acp.task_service.get_task(name=task_name)
+                # workflow starts). Resolve the winner's task and just send this turn's
+                # event, as a follow-up would. Retry the lookup: it reads the (possibly
+                # lagging) replica, which may not have the just-created task yet.
+                task = await self._resolve_task_after_race(acp.task_service, task_name)
 
         # Snapshot existing messages so we can isolate THIS turn's reply.
         seen = await self._seen_message_ids(acp.task_message_service, task.id)

--- a/agentex/src/domain/use_cases/slack_gateway_use_case.py
+++ b/agentex/src/domain/use_cases/slack_gateway_use_case.py
@@ -50,11 +50,12 @@ from src.config.dependencies import (
     database_async_read_write_session_maker,
 )
 from src.domain.entities.agent_api_keys import AgentAPIKeyType
-from src.domain.entities.agents import AgentStatus
+from src.domain.entities.agents import ACPType, AgentStatus
 from src.domain.entities.agents_rpc import (
     AgentRPCMethod,
     CreateTaskRequestEntity,
     SendEventRequestEntity,
+    SendMessageRequestEntity,
 )
 from src.domain.entities.task_messages import (
     MessageAuthor,
@@ -455,9 +456,11 @@ class SlackGatewayUseCase:
         resolved once per turn in ``_run_turn`` and passed in.
 
         The task is keyed on the Slack thread (``slack:{thread_ts}``), so a thread is one
-        long-lived task/workflow. TASK_CREATE runs only on the FIRST turn; follow-ups in
-        the same thread skip it (the workflow is already running — re-creating raises
-        WorkflowAlreadyStarted) and just send the next event.
+        conversation. ASYNC/AGENTIC agents (e.g. golden-agent) get a long-lived workflow:
+        TASK_CREATE on the FIRST turn (re-creating a running workflow raises
+        WorkflowAlreadyStarted), then event/send + poll for the reply. SYNC agents have
+        no event stream — a single message/send get-or-creates the task and returns the
+        reply synchronously.
         """
         # Local import avoids a domain -> temporal import cycle at module load.
         from src.temporal.scheduled_agent_run_factory import (
@@ -468,28 +471,48 @@ class SlackGatewayUseCase:
             GlobalDependencies(), principal, request_headers=auth_headers
         )
         agent = await acp.agent_repository.get(name=target.agent_name)
-        thread_ts = inbound.thread_ts
-        task_name = f"slack:{thread_ts}"
+        task_name = f"slack:{inbound.thread_ts}"
+        content = TextContentEntity(
+            author=MessageAuthor.USER,
+            content=_turn_content(inbound, prompt),
+            format=TextFormat.MARKDOWN,
+        )
+        # First-turn task params: golden-agent's agent_config id (when this turn resolved
+        # to one) + any gateway-default MCPs. A routed non-golden agent carries no
+        # config_id and ignores params it doesn't use.
+        create_params: dict[str, Any] = {}
+        if target.config_id:
+            create_params["config_id"] = target.config_id
+        if _DEFAULT_MCPS:
+            create_params["mcps"] = _DEFAULT_MCPS
 
+        # SYNC agents have no event stream: one message/send get-or-creates the task and
+        # returns the reply synchronously. (event/send is async/agentic-only, which is
+        # why routing to a SYNC agent otherwise fails with "Unsupported method".)
+        if agent.acp_type == ACPType.SYNC:
+            replies = await acp.handle_rpc_request(
+                method=AgentRPCMethod.MESSAGE_SEND,
+                params=SendMessageRequestEntity(
+                    task_name=task_name,
+                    content=content,
+                    task_params=create_params,
+                    stream=False,
+                ),
+                agent_id=agent.id,
+            )
+            return _agent_text(replies or [])
+
+        # ASYNC / AGENTIC: TASK_CREATE only on the first turn, then event/send + poll.
         task = await self._existing_task(acp.task_service, task_name)
         if task is None:
-            # First turn in this thread → start the task/workflow.
             task_metadata = {
                 "channel": "slack",
                 "sender_id": target.label(),
-                "thread_ts": thread_ts,
+                "thread_ts": inbound.thread_ts,
                 "channel_id": inbound.channel,
             }
-            # target.config_id was chosen by _resolve_target (the selector's SGP config,
-            # or the default id); a routed runtime agent carries None and resolves its own
-            # config. golden-agent turns the id -> full turn config (prompt/model/tools).
-            config_id = target.config_id
-            create_params: dict[str, Any] = {}
-            if config_id:
-                task_metadata["config_id"] = config_id
-                create_params["config_id"] = config_id
-            if _DEFAULT_MCPS:
-                create_params["mcps"] = _DEFAULT_MCPS
+            if target.config_id:
+                task_metadata["config_id"] = target.config_id
             try:
                 task = await acp.handle_rpc_request(
                     method=AgentRPCMethod.TASK_CREATE,
@@ -509,18 +532,11 @@ class SlackGatewayUseCase:
 
         # Snapshot existing messages so we can isolate THIS turn's reply.
         seen = await self._seen_message_ids(acp.task_message_service, task.id)
-
-        content = TextContentEntity(
-            author=MessageAuthor.USER,
-            content=_turn_content(inbound, prompt),
-            format=TextFormat.MARKDOWN,
-        )
         await acp.handle_rpc_request(
             method=AgentRPCMethod.EVENT_SEND,
             params=SendEventRequestEntity(task_name=task_name, content=content),
             agent_id=agent.id,
         )
-
         # Poll the task's messages for this turn's settled agent reply.
         return await self._collect_reply(acp.task_message_service, task.id, seen)
 

--- a/agentex/src/domain/use_cases/slack_gateway_use_case.py
+++ b/agentex/src/domain/use_cases/slack_gateway_use_case.py
@@ -490,16 +490,20 @@ class SlackGatewayUseCase:
         # returns the reply synchronously. (event/send is async/agentic-only, which is
         # why routing to a SYNC agent otherwise fails with "Unsupported method".)
         if agent.acp_type == ACPType.SYNC:
-            replies = await acp.handle_rpc_request(
-                method=AgentRPCMethod.MESSAGE_SEND,
-                params=SendMessageRequestEntity(
-                    task_name=task_name,
-                    content=content,
-                    task_params=create_params,
-                    stream=False,
-                ),
-                agent_id=agent.id,
+            send = SendMessageRequestEntity(
+                task_name=task_name,
+                content=content,
+                task_params=create_params,
+                stream=False,
             )
+            try:
+                replies = await acp.handle_rpc_request(
+                    method=AgentRPCMethod.MESSAGE_SEND, params=send, agent_id=agent.id
+                )
+            except DuplicateItemError:
+                replies = await acp.handle_rpc_request(
+                    method=AgentRPCMethod.MESSAGE_SEND, params=send, agent_id=agent.id
+                )
             return _agent_text(replies or [])
 
         # ASYNC / AGENTIC: TASK_CREATE only on the first turn, then event/send + poll.

--- a/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
+++ b/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
@@ -488,6 +488,56 @@ class TestDispatch:
         assert acp.task_service.get_task.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_async_create_race_retries_lookup_through_replica_lag(
+        self, monkeypatch
+    ):
+        # After the create-race, the fallback get_task reads the replica — which may lag
+        # and miss the winner's task. Retry until it catches up rather than dropping the
+        # turn with ItemDoesNotExist.
+        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
+        monkeypatch.setattr(sg, "_CREATE_RACE_BACKOFF_S", 0.0)
+        winner_task = SimpleNamespace(id="task_1", task_metadata=None)
+        acp = MagicMock()
+        acp.agent_repository.get = AsyncMock(
+            return_value=SimpleNamespace(id="agt_1", acp_type=sg.ACPType.ASYNC)
+        )
+        acp.task_message_service.get_messages = AsyncMock(return_value=[])
+        # probe (absent) → resolve miss (replica lag) → resolve hit (winner).
+        acp.task_service.get_task = AsyncMock(
+            side_effect=[
+                sg.ItemDoesNotExist("no task"),
+                sg.ItemDoesNotExist("replica lag"),
+                winner_task,
+            ]
+        )
+
+        async def rpc(*, method, **_):
+            if method == AgentRPCMethod.TASK_CREATE:
+                raise sg.DuplicateItemError("name taken")
+            return None  # EVENT_SEND
+
+        acp.handle_rpc_request = AsyncMock(side_effect=rpc)
+        monkeypatch.setattr(
+            "src.temporal.scheduled_agent_run_factory.build_acp_use_case_for_principal",
+            MagicMock(return_value=acp),
+        )
+        monkeypatch.setattr(
+            SlackGatewayUseCase, "_collect_reply", AsyncMock(return_value=None)
+        )
+
+        inbound = sg.InboundSlack(
+            team_id="T", channel="C1", user="U", text="hi", thread_ts="1", selector=None
+        )
+        await SlackGatewayUseCase()._dispatch(
+            Target("golden-agent"), inbound, "hi", None, {}
+        )
+
+        assert acp.task_service.get_task.await_count == 3  # probe + miss + hit
+        methods = [c.kwargs["method"] for c in acp.handle_rpc_request.await_args_list]
+        assert methods == [AgentRPCMethod.TASK_CREATE, AgentRPCMethod.EVENT_SEND]
+
+    @pytest.mark.asyncio
     async def test_sync_agent_uses_message_send_and_returns_reply(self, monkeypatch):
         # A SYNC agent has no event stream: dispatch does ONE message/send (get-or-create
         # + reply), not task/create + event/send + poll.
@@ -523,36 +573,81 @@ class TestDispatch:
         assert call.kwargs["params"].task_name == "slack:1"
         assert reply == "sync reply"  # extracted from the message/send result directly
 
+    @staticmethod
+    def _sync_race_acp(monkeypatch, side_effect):
+        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
+        monkeypatch.setattr(
+            sg, "_CREATE_RACE_BACKOFF_S", 0.0
+        )  # no real sleeps in tests
+        acp, _ = _fake_acp(acp_type=sg.ACPType.SYNC)
+        acp.handle_rpc_request = AsyncMock(side_effect=side_effect)
+        monkeypatch.setattr(
+            "src.temporal.scheduled_agent_run_factory.build_acp_use_case_for_principal",
+            MagicMock(return_value=acp),
+        )
+        return acp
+
     @pytest.mark.asyncio
     async def test_sync_agent_retries_message_send_on_create_race(self, monkeypatch):
         # Two first messages for the same thread race on the globally-unique task name;
         # the loser's message/send raises DuplicateItemError. It must retry (get-or-create
         # now finds the winner's task) rather than drop the turn.
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
-        monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
-        acp, _ = _fake_acp(acp_type=sg.ACPType.SYNC)
         reply_msg = SimpleNamespace(
             content=SimpleNamespace(author=sg.MessageAuthor.AGENT, content="ok")
         )
-        acp.handle_rpc_request = AsyncMock(
-            side_effect=[sg.DuplicateItemError("name taken"), [reply_msg]]
+        acp = self._sync_race_acp(
+            monkeypatch, [sg.DuplicateItemError("name taken"), [reply_msg]]
         )
-        monkeypatch.setattr(
-            "src.temporal.scheduled_agent_run_factory.build_acp_use_case_for_principal",
-            MagicMock(return_value=acp),
-        )
-
         inbound = sg.InboundSlack(
             team_id="T", channel="C1", user="U", text="hi", thread_ts="1", selector=None
         )
         reply = await SlackGatewayUseCase()._dispatch(
             Target("math-agent"), inbound, "hi", None, {}
         )
-
         assert acp.handle_rpc_request.await_count == 2  # first raised, retry succeeded
-        methods = [c.kwargs["method"] for c in acp.handle_rpc_request.await_args_list]
-        assert methods == [AgentRPCMethod.MESSAGE_SEND, AgentRPCMethod.MESSAGE_SEND]
         assert reply == "ok"  # the retry's reply, not a dropped turn
+
+    @pytest.mark.asyncio
+    async def test_sync_agent_retries_through_replica_lag(self, monkeypatch):
+        # A single retry can still miss the winner's task if the read replica lags, so
+        # the retry races the create AGAIN. Keep retrying until replication catches up.
+        reply_msg = SimpleNamespace(
+            content=SimpleNamespace(author=sg.MessageAuthor.AGENT, content="ok")
+        )
+        acp = self._sync_race_acp(
+            monkeypatch,
+            [
+                sg.DuplicateItemError("race"),
+                sg.DuplicateItemError("replica still lagging"),
+                [reply_msg],
+            ],
+        )
+        inbound = sg.InboundSlack(
+            team_id="T", channel="C1", user="U", text="hi", thread_ts="1", selector=None
+        )
+        reply = await SlackGatewayUseCase()._dispatch(
+            Target("math-agent"), inbound, "hi", None, {}
+        )
+        assert acp.handle_rpc_request.await_count == 3  # two misses, then success
+        assert reply == "ok"
+
+    @pytest.mark.asyncio
+    async def test_sync_agent_gives_up_after_exhausting_retries(self, monkeypatch):
+        # Persistent lag (all attempts dup) surfaces the error to _run_turn rather than
+        # looping forever.
+        monkeypatch.setattr(sg, "_CREATE_RACE_ATTEMPTS", 3)
+        acp = self._sync_race_acp(
+            monkeypatch, [sg.DuplicateItemError("still racing")] * 3
+        )
+        inbound = sg.InboundSlack(
+            team_id="T", channel="C1", user="U", text="hi", thread_ts="1", selector=None
+        )
+        with pytest.raises(sg.DuplicateItemError):
+            await SlackGatewayUseCase()._dispatch(
+                Target("math-agent"), inbound, "hi", None, {}
+            )
+        assert acp.handle_rpc_request.await_count == 3
 
 
 @pytest.mark.unit

--- a/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
+++ b/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
@@ -523,6 +523,37 @@ class TestDispatch:
         assert call.kwargs["params"].task_name == "slack:1"
         assert reply == "sync reply"  # extracted from the message/send result directly
 
+    @pytest.mark.asyncio
+    async def test_sync_agent_retries_message_send_on_create_race(self, monkeypatch):
+        # Two first messages for the same thread race on the globally-unique task name;
+        # the loser's message/send raises DuplicateItemError. It must retry (get-or-create
+        # now finds the winner's task) rather than drop the turn.
+        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
+        acp, _ = _fake_acp(acp_type=sg.ACPType.SYNC)
+        reply_msg = SimpleNamespace(
+            content=SimpleNamespace(author=sg.MessageAuthor.AGENT, content="ok")
+        )
+        acp.handle_rpc_request = AsyncMock(
+            side_effect=[sg.DuplicateItemError("name taken"), [reply_msg]]
+        )
+        monkeypatch.setattr(
+            "src.temporal.scheduled_agent_run_factory.build_acp_use_case_for_principal",
+            MagicMock(return_value=acp),
+        )
+
+        inbound = sg.InboundSlack(
+            team_id="T", channel="C1", user="U", text="hi", thread_ts="1", selector=None
+        )
+        reply = await SlackGatewayUseCase()._dispatch(
+            Target("math-agent"), inbound, "hi", None, {}
+        )
+
+        assert acp.handle_rpc_request.await_count == 2  # first raised, retry succeeded
+        methods = [c.kwargs["method"] for c in acp.handle_rpc_request.await_args_list]
+        assert methods == [AgentRPCMethod.MESSAGE_SEND, AgentRPCMethod.MESSAGE_SEND]
+        assert reply == "ok"  # the retry's reply, not a dropped turn
+
 
 @pytest.mark.unit
 class TestRunTurn:

--- a/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
+++ b/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
@@ -342,11 +342,15 @@ class TestResolveTarget:
         assert prompt == "do it"  # selector stripped
 
 
-def _fake_acp(existing_task=None):
+def _fake_acp(existing_task=None, acp_type=None):
     """Fake ACP use case. existing_task=None → task doesn't exist yet (get_task raises,
-    so _dispatch will TASK_CREATE); pass a task to simulate a resumed thread."""
+    so _dispatch will TASK_CREATE); pass a task to simulate a resumed thread. acp_type
+    defaults to ASYNC (the golden-agent path); pass ACPType.SYNC for the message/send
+    path."""
     acp = MagicMock()
-    acp.agent_repository.get = AsyncMock(return_value=SimpleNamespace(id="agt_1"))
+    acp.agent_repository.get = AsyncMock(
+        return_value=SimpleNamespace(id="agt_1", acp_type=acp_type or sg.ACPType.ASYNC)
+    )
     created = SimpleNamespace(id="task_1", task_metadata=None)
     acp.handle_rpc_request = AsyncMock(return_value=created)
     acp.task_message_service.get_messages = AsyncMock(
@@ -447,7 +451,9 @@ class TestDispatch:
         monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
         winner_task = SimpleNamespace(id="task_1", task_metadata=None)
         acp = MagicMock()
-        acp.agent_repository.get = AsyncMock(return_value=SimpleNamespace(id="agt_1"))
+        acp.agent_repository.get = AsyncMock(
+            return_value=SimpleNamespace(id="agt_1", acp_type=sg.ACPType.ASYNC)
+        )
         acp.task_message_service.get_messages = AsyncMock(return_value=[])
         # 1st get_task = existence probe (absent); 2nd = post-race fallback (winner).
         acp.task_service.get_task = AsyncMock(
@@ -480,6 +486,42 @@ class TestDispatch:
         methods = [c.kwargs["method"] for c in acp.handle_rpc_request.await_args_list]
         assert methods == [AgentRPCMethod.TASK_CREATE, AgentRPCMethod.EVENT_SEND]
         assert acp.task_service.get_task.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_sync_agent_uses_message_send_and_returns_reply(self, monkeypatch):
+        # A SYNC agent has no event stream: dispatch does ONE message/send (get-or-create
+        # + reply), not task/create + event/send + poll.
+        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
+        acp, _ = _fake_acp(acp_type=sg.ACPType.SYNC)
+        reply_msg = SimpleNamespace(
+            content=SimpleNamespace(author=sg.MessageAuthor.AGENT, content="sync reply")
+        )
+        acp.handle_rpc_request = AsyncMock(
+            return_value=[reply_msg]
+        )  # message/send result
+        monkeypatch.setattr(
+            "src.temporal.scheduled_agent_run_factory.build_acp_use_case_for_principal",
+            MagicMock(return_value=acp),
+        )
+
+        inbound = sg.InboundSlack(
+            team_id="T",
+            channel="C1",
+            user="U",
+            text="2+2?",
+            thread_ts="1",
+            selector=None,
+        )
+        reply = await SlackGatewayUseCase()._dispatch(
+            Target("math-agent"), inbound, "2+2?", None, {}
+        )
+
+        acp.handle_rpc_request.assert_awaited_once()
+        call = acp.handle_rpc_request.await_args
+        assert call.kwargs["method"] == AgentRPCMethod.MESSAGE_SEND
+        assert call.kwargs["params"].task_name == "slack:1"
+        assert reply == "sync reply"  # extracted from the message/send result directly
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What
Let the Slack gateway invoke **`ACPType.SYNC`** agents, not just async/agentic ones.

## Why
`_dispatch` hard-coded `task/create` + `event/send`. `event/send` is only in the allowed method set for `ASYNC`/`AGENTIC` agents, so routing `@agent <a-sync-agent>` from Slack failed the turn with:

```
ClientError: Unsupported method: AgentRPCMethod.EVENT_SEND for ACP type: ACPType.SYNC
```

and the user just saw "Something went wrong."

## How
Branch `_dispatch` on `agent.acp_type`:
- **SYNC** → a single `message/send` (`SendMessageRequestEntity`), which get-or-creates the thread task and returns the reply messages **synchronously** — no `task/create`, no `event/send`, no polling.
- **ASYNC / AGENTIC** (e.g. golden-agent) → unchanged: `task/create` on the first turn (with the `DuplicateItemError` create-race fallback) + `event/send` + poll for the settled reply.

Reply text is extracted the same way for both (`_agent_text`), and first-turn params (config_id / default MCPs) are built once and passed to whichever create path runs. `task_metadata.channel="slack"` (origin gating for golden-agent) is still set on the async path only, which is where it applies.

## Testing
- New unit test: a SYNC agent triggers exactly one `message/send` (task_name = the thread key) and the reply is returned directly; the async/agentic tests are unchanged (the fake agent now carries `acp_type`).
- Full gateway unit suite green (52), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Slack gateway support for synchronous ACP agents and introduces bounded recovery for concurrent task-creation races.
- Routes SYNC agents through a single synchronous `message/send` request.
- Preserves `task/create`, `event/send`, and reply polling for ASYNC and AGENTIC agents.
- Adds retry helpers and tests for create races and temporary replica lag.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because concurrent first turns can still be dropped when read-replica lag outlasts the fixed retry window.

Both previously reported create-race paths now retry, but they still depend on the same read-only lookup becoming consistent within a default 0.75-second backoff period; after that period, the SYNC path propagates `DuplicateItemError` and the async path propagates `ItemDoesNotExist`, producing the generic Slack failure response.

**Files Needing Attention:** agentex/src/domain/use_cases/slack_gateway_use_case.py
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/slack_gateway_use_case.py | Adds ACP-type-specific dispatch and race retries, but bounded read-replica recovery still drops turns when replication lag exceeds the configured window. |
| agentex/tests/unit/use_cases/test_slack_gateway_use_case.py | Covers SYNC dispatch and short-lived replica lag, but does not establish safe recovery when lag outlasts the retry window. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Slack turn] --> B{Agent ACP type}
    B -->|SYNC| C[message/send]
    C --> D{DuplicateItemError?}
    D -->|No| E[Return synchronous reply]
    D -->|Yes| F[Backoff and retry]
    F --> C
    B -->|ASYNC or AGENTIC| G[Look up thread task]
    G --> H{Task exists?}
    H -->|No| I[task/create]
    I --> J{DuplicateItemError?}
    J -->|Yes| K[Retry read-only task lookup]
    J -->|No| L[event/send]
    K -->|Task visible| L
    K -->|Retries exhausted| M[Generic Slack failure]
    H -->|Yes| L
    L --> N[Poll and return reply]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `agentex/src/domain/use_cases/slack_gateway_use_case.py`, line 497 ([link](https://github.com/scaleapi/scale-agentex/blob/e01c659dd3f4121d71dac6f4f612d35cf2f75fb8/agentex/src/domain/use_cases/slack_gateway_use_case.py#L497)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Replica retry still drops turns**

   If the configured read replica remains behind the primary longer than the fixed retry window, every `get_task` attempt misses the winning task and the helper raises `ItemDoesNotExist`, causing `_run_turn` to drop the Slack turn and return the generic failure response.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: agentex/src/domain/use_cases/slack_gateway_use_case.py
   Line: 497

   Comment:
   **Replica retry still drops turns**

   If the configured read replica remains behind the primary longer than the fixed retry window, every `get_task` attempt misses the winning task and the helper raises `ItemDoesNotExist`, causing `_run_turn` to drop the Slack turn and return the generic failure response.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%0ALine%3A%20497%0A%0AComment%3A%0A**Replica%20retry%20still%20drops%20turns**%0A%0AIf%20the%20configured%20read%20replica%20remains%20behind%20the%20primary%20longer%20than%20the%20fixed%20retry%20window%2C%20every%20%60get_task%60%20attempt%20misses%20the%20winning%20task%20and%20the%20helper%20raises%20%60ItemDoesNotExist%60%2C%20causing%20%60_run_turn%60%20to%20drop%20the%20Slack%20turn%20and%20return%20the%20generic%20failure%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%0ALine%3A%20497%0A%0AComment%3A%0A**Replica%20retry%20still%20drops%20turns**%0A%0AIf%20the%20configured%20read%20replica%20remains%20behind%20the%20primary%20longer%20than%20the%20fixed%20retry%20window%2C%20every%20%60get_task%60%20attempt%20misses%20the%20winning%20task%20and%20the%20helper%20raises%20%60ItemDoesNotExist%60%2C%20causing%20%60_run_turn%60%20to%20drop%20the%20Slack%20turn%20and%20return%20the%20generic%20failure%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22mc%2Fslack-gateway-sync-agents%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mc%2Fslack-gateway-sync-agents%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20agentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%0ALine%3A%20497%0A%0AComment%3A%0A**Replica%20retry%20still%20drops%20turns**%0A%0AIf%20the%20configured%20read%20replica%20remains%20behind%20the%20primary%20longer%20than%20the%20fixed%20retry%20window%2C%20every%20%60get_task%60%20attempt%20misses%20the%20winning%20task%20and%20the%20helper%20raises%20%60ItemDoesNotExist%60%2C%20causing%20%60_run_turn%60%20to%20drop%20the%20Slack%20turn%20and%20return%20the%20generic%20failure%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A497%0A**Replica%20retry%20still%20drops%20turns**%0A%0AIf%20the%20configured%20read%20replica%20remains%20behind%20the%20primary%20longer%20than%20the%20fixed%20retry%20window%2C%20every%20%60get_task%60%20attempt%20misses%20the%20winning%20task%20and%20the%20helper%20raises%20%60ItemDoesNotExist%60%2C%20causing%20%60_run_turn%60%20to%20drop%20the%20Slack%20turn%20and%20return%20the%20generic%20failure%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A497%0A**Replica%20retry%20still%20drops%20turns**%0A%0AIf%20the%20configured%20read%20replica%20remains%20behind%20the%20primary%20longer%20than%20the%20fixed%20retry%20window%2C%20every%20%60get_task%60%20attempt%20misses%20the%20winning%20task%20and%20the%20helper%20raises%20%60ItemDoesNotExist%60%2C%20causing%20%60_run_turn%60%20to%20drop%20the%20Slack%20turn%20and%20return%20the%20generic%20failure%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22mc%2Fslack-gateway-sync-agents%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mc%2Fslack-gateway-sync-agents%22.%0A%0A%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A497%0A**Replica%20retry%20still%20drops%20turns**%0A%0AIf%20the%20configured%20read%20replica%20remains%20behind%20the%20primary%20longer%20than%20the%20fixed%20retry%20window%2C%20every%20%60get_task%60%20attempt%20misses%20the%20winning%20task%20and%20the%20helper%20raises%20%60ItemDoesNotExist%60%2C%20causing%20%60_run_turn%60%20to%20drop%20the%20Slack%20turn%20and%20return%20the%20generic%20failure%20response.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
agentex/src/domain/use_cases/slack_gateway_use_case.py:497
**Replica retry still drops turns**

If the configured read replica remains behind the primary longer than the fixed retry window, every `get_task` attempt misses the winning task and the helper raises `ItemDoesNotExist`, causing `_run_turn` to drop the Slack turn and return the generic failure response.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(agentex): make the Slack create-race..."](https://github.com/scaleapi/scale-agentex/commit/e01c659dd3f4121d71dac6f4f612d35cf2f75fb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50145620)</sub>

<!-- /greptile_comment -->