### PR TITLE
refactor(agentex): Slack gateway reads bot credentials from env, not DB

### DIFF
--- a/agentex/src/domain/repositories/agent_api_key_repository.py
+++ b/agentex/src/domain/repositories/agent_api_key_repository.py
@@ -112,25 +112,6 @@ class AgentAPIKeyRepository(PostgresCRUDRepository[AgentAPIKeyORM, AgentAPIKeyEn
             row = result.scalars().first()
             return AgentAPIKeyEntity.model_validate(row) if row else None
 
-    async def get_by_name_and_type(
-        self, name: str, api_key_type: AgentAPIKeyType
-    ) -> AgentAPIKeyEntity | None:
-        """Get an API key by (name, type) alone — agent-agnostic. The Slack gateway's
-        shared app isn't tied to one agent, so it stores its signing secret / bot token
-        here keyed by name (api_app_id and api_app_id:bot). Returns the first match."""
-        async with self.start_async_db_session(allow_writes=False) as session:
-            query = (
-                select(AgentAPIKeyORM)
-                .where(
-                    AgentAPIKeyORM.name == name,
-                    AgentAPIKeyORM.api_key_type == api_key_type,
-                )
-                .limit(1)
-            )
-            result = await session.execute(query)
-            row = result.scalars().first()
-            return AgentAPIKeyEntity.model_validate(row) if row else None
-
     async def get_by_agent_name_and_key_name(
         self, agent_name: str, key_name: str, api_key_type: AgentAPIKeyType
     ) -> AgentAPIKeyEntity | None:

--- a/agentex/src/domain/use_cases/slack_gateway_use_case.py
+++ b/agentex/src/domain/use_cases/slack_gateway_use_case.py
@@ -622,11 +622,21 @@ class SlackGatewayUseCase:
         """The gateway's bot identity. The bot API key + account come from env /
         k8s-secret. Verify the key -> principal (for authz), and return the credential
         headers (delegated to the agent, where x-api-key becomes x-acting-user-api-key).
-        Auth needs BOTH x-api-key and x-selected-account-id — the key alone 401s. No key
-        configured -> (None, {}) i.e. dev/authz-bypass."""
+        Auth needs BOTH x-api-key and x-selected-account-id — the key alone 401s.
+
+        Missing bot key: FAIL CLOSED when authz is enabled (AGENTEX_AUTH_URL set), so a
+        misconfigured deploy never dispatches unauthenticated (which would run with no
+        principal, bypassing the per-turn authz boundary). Only the authz-off local case
+        (no AGENTEX_AUTH_URL) is allowed to run with no principal — the dev bypass."""
         api_key = _ACTING_BOT_API_KEY
         if not api_key:
-            return None, {}
+            if os.getenv("AGENTEX_AUTH_URL"):
+                raise RuntimeError(
+                    "SLACK_GATEWAY_ACTING_BOT_API_KEY is unset while authz is enabled "
+                    "(AGENTEX_AUTH_URL); refusing to dispatch a Slack turn without a bot "
+                    "principal."
+                )
+            return None, {}  # authz off (local dev) — run with no principal
         account_id = _ACTING_ACCOUNT_ID
         # Local imports avoid an import cycle at module load.
         from src.adapters.authentication.adapter_agentex_authn_proxy import (

--- a/agentex/src/domain/use_cases/slack_gateway_use_case.py
+++ b/agentex/src/domain/use_cases/slack_gateway_use_case.py
@@ -11,21 +11,16 @@ Deliberately NOT layered onto ``/agents/forward`` — that route is the generic,
 per-agent verifying proxy. This is its own module so Slack-specific logic stays out
 of the generic path.
 
-v1 identity: every Slack turn acts as ONE shared SGP identity — the acting-user API
-key (``SLACK_GATEWAY_ACTING_USER_API_KEY``, env/secret only). It's forwarded as
-``x-api-key``, which the platform (a) verifies -> principal for authz and (b) converts
-to ``x-acting-user-api-key`` so the agent's tools act as that user via
-resolve_user_secrets. Everyone shares its access: fine for a controlled internal
-deploy, NOT customer/multi-tenant. STILL STUBBED (marked TODO): the signing-secret/
-bot-token fetch (sgp-secrets microservice), name->config resolution against
-``agent_configs``, and reply delivery. Dispatch, delegation, and idempotency are real.
-
-Future — per-user identity (post-v1): resolve the Slack user -> SGP user via a verified
-link. When a user is unlinked, nudge them with an **ephemeral in-channel message**
-(``chat.postEphemeral`` — needs only ``chat:write``, no DM/``im:write``) carrying a
-signed one-time link to ``/link/slack``; the SGP OIDC login on that page proves the SGP
-side and the callback writes ``(team_id, slack_user_id) -> sgp_user_id``. Don't dispatch
-until linked.
+Identity: every Slack turn acts as the gateway's own SGP identity — a dedicated bot
+service account (``SLACK_GATEWAY_ACTING_BOT_API_KEY`` + ``SLACK_GATEWAY_ACCOUNT_ID``,
+env / k8s-secret only). The key is forwarded as ``x-api-key``, which the platform (a)
+verifies -> principal for authz and (b) converts to ``x-acting-user-api-key`` so the
+agent's tools act as the bot via resolve_user_secrets. The bot is a first-class entity,
+not a proxy for the invoking user: all Slack traffic shares its account and its tasks
+are owned by it — fine for a controlled internal deploy, NOT per-user multi-tenant.
+Deliberately NOT per-user: we don't conflate the invoking user's SGP identity with the
+bot's. The bot's Slack credentials (signing secret, bot token) live in the same
+env / k8s-secret set. Dispatch, delegation, and idempotency are real.
 """
 
 from __future__ import annotations
@@ -49,7 +44,6 @@ from src.config.dependencies import (
     database_async_read_write_engine,
     database_async_read_write_session_maker,
 )
-from src.domain.entities.agent_api_keys import AgentAPIKeyType
 from src.domain.entities.agents import ACPType, AgentStatus
 from src.domain.entities.agents_rpc import (
     AgentRPCMethod,
@@ -62,7 +56,6 @@ from src.domain.entities.task_messages import (
     TextContentEntity,
     TextFormat,
 )
-from src.domain.repositories.agent_api_key_repository import AgentAPIKeyRepository
 from src.domain.repositories.agent_repository import AgentRepository
 from src.utils.logging import make_logger
 
@@ -73,17 +66,16 @@ _MENTION_RE = re.compile(r"^\s*<@[A-Z0-9]+>\s*")
 # agent is "golden-agent", not "golden_agent" (verified against the sgp-dev directory).
 _DEFAULT_AGENT_NAME = "golden-agent"
 
-# v1: every Slack turn acts as ONE shared SGP identity — this acting-user API key.
-# Forwarded as x-api-key: the platform verifies it -> principal (authz) and converts it
-# to x-acting-user-api-key downstream (tools act as that user via resolve_user_secrets).
-# Everyone shares its access — controlled-internal only, NOT customer/multi-tenant.
-# Secret lives in env only, never in code. TODO: replace with a per-user key resolved
-# from verified Slack->SGP linking.
-_ACTING_USER_API_KEY = os.getenv("SLACK_GATEWAY_ACTING_USER_API_KEY", "")
+# Every Slack turn acts as the gateway's own SGP identity — a dedicated bot service
+# account. Forwarded as x-api-key: the platform verifies it -> principal (authz) and
+# converts it to x-acting-user-api-key downstream (tools act as the bot via
+# resolve_user_secrets). The bot is its own entity, not a proxy for the invoking user;
+# all Slack traffic shares its account. Env / k8s-secret only, never in code.
+_ACTING_BOT_API_KEY = os.getenv("SLACK_GATEWAY_ACTING_BOT_API_KEY", "")
 
-# Account the shared identity acts within. REQUIRED alongside the API key — the backend
-# authenticates on (x-api-key + x-selected-account-id) together; the key alone 401s
-# (verified against sgp-dev). Also forwarded downstream so the agent runs in this account.
+# Account the bot acts within. REQUIRED alongside the API key — the backend authenticates
+# on (x-api-key + x-selected-account-id) together; the key alone 401s. Also forwarded
+# downstream so the agent runs in this account.
 _ACTING_ACCOUNT_ID = os.getenv("SLACK_GATEWAY_ACCOUNT_ID", "")
 
 # DEV ONLY. When true, skip Slack signature verification so the backend pipeline can be
@@ -135,18 +127,6 @@ _DEFAULT_MCPS = [
     for m in os.getenv("SLACK_GATEWAY_DEFAULT_MCPS", "").split(",")
     if m.strip()
 ]
-
-# Fixed, descriptive names for the gateway's own Slack credentials in the throwaway
-# agent_api_keys store. One shared app, so we key by these readable names rather than
-# the cryptic api_app_id (also avoids colliding with per-agent webhook rows, which use
-# name=api_app_id). TODO: replace this whole store with sgp-secrets user-scope.
-_BOT_TOKEN_NAME = "slack-bot-token"
-_SIGNING_SECRET_NAME = "slack-signing-secret"
-# v1 shared acting identity (SGP acting-user API key + account) — same throwaway
-# DB store as the tokens, so a deployed (authz-on) gateway can dispatch with a real
-# principal. Not a Slack token, but kept in the one gateway-config store for now.
-_ACTING_API_KEY_NAME = "slack-acting-user-api-key"
-_ACTING_ACCOUNT_ID_NAME = "slack-acting-account-id"
 
 
 # --------------------------------------------------------------------------- shaping
@@ -639,20 +619,15 @@ class SlackGatewayUseCase:
         return last
 
     async def _acting_identity(self) -> tuple[Any, dict[str, str]]:
-        """v1 shared identity. The acting-user API key + account come from the DB
-        (agent_api_keys, same throwaway store as the tokens), env fallback. Verify the
-        key -> principal (for authz), and return the credential headers (delegated to
-        the agent, where x-api-key becomes x-acting-user-api-key). Auth needs BOTH
-        x-api-key and x-selected-account-id — the key alone 401s. No key configured ->
-        (None, {}) i.e. dev/authz-bypass."""
-        api_key = (
-            await self._gateway_secret(_ACTING_API_KEY_NAME) or _ACTING_USER_API_KEY
-        )
+        """The gateway's bot identity. The bot API key + account come from env /
+        k8s-secret. Verify the key -> principal (for authz), and return the credential
+        headers (delegated to the agent, where x-api-key becomes x-acting-user-api-key).
+        Auth needs BOTH x-api-key and x-selected-account-id — the key alone 401s. No key
+        configured -> (None, {}) i.e. dev/authz-bypass."""
+        api_key = _ACTING_BOT_API_KEY
         if not api_key:
             return None, {}
-        account_id = (
-            await self._gateway_secret(_ACTING_ACCOUNT_ID_NAME) or _ACTING_ACCOUNT_ID
-        )
+        account_id = _ACTING_ACCOUNT_ID
         # Local imports avoid an import cycle at module load.
         from src.adapters.authentication.adapter_agentex_authn_proxy import (
             AgentexAuthenticationProxy,
@@ -672,39 +647,10 @@ class SlackGatewayUseCase:
         principal = await authn.verify_headers(headers)
         return principal, headers
 
-    # --- STUBS (each is a real net-new piece; do NOT ship as-is) ----------------
-
-    async def _gateway_secret(self, name: str) -> str:
-        """Read a Slack gateway secret from the ``agent_api_keys`` table by (name,
-        SLACK). THROWAWAY store — plaintext, reusing the existing table by naming
-        convention (api_app_id = signing secret, api_app_id:bot = bot token) so it
-        needs no migration. To be replaced by sgp-secrets user-scope. Fail-safe: any
-        error (incl. no DB in unit tests) returns "" so callers fall back to env."""
-        if not name:
-            return ""
-        try:
-            engine = database_async_read_write_engine()
-            repo = AgentAPIKeyRepository(
-                database_async_read_write_session_maker(engine),
-                database_async_read_only_session_maker(engine),
-            )
-            row = await repo.get_by_name_and_type(name, AgentAPIKeyType.SLACK)
-            return row.api_key if row else ""
-        except Exception:  # noqa: BLE001 - fail-safe to env fallback
-            logger.debug(
-                "gateway-secret DB read failed for %r; env fallback",
-                name,
-                exc_info=True,
-            )
-            return ""
-
     async def _fetch_signing_secret(self, api_app_id: str) -> str:
-        # Throwaway DB store (agent_api_keys, name="slack-signing-secret", type SLACK);
-        # env fallback for local dev. Empty => verify_signature fails closed. api_app_id
-        # is unused (one shared app) but kept on the interface.
-        return await self._gateway_secret(_SIGNING_SECRET_NAME) or os.getenv(
-            "SLACK_SIGNING_SECRET", ""
-        )
+        # Signing secret from env / k8s-secret. Empty => verify_signature fails closed.
+        # api_app_id is unused (one shared app) but kept on the interface.
+        return os.getenv("SLACK_SIGNING_SECRET", "")
 
     async def _resolve_account(self, team_id: str) -> str:
         # TODO: Slack team_id -> SGP account (tenant-aware from day one). v1 derives the
@@ -781,11 +727,8 @@ class SlackGatewayUseCase:
         return True
 
     async def _fetch_bot_token(self) -> str:
-        # Throwaway DB store (agent_api_keys, name="slack-bot-token", type SLACK); env
-        # fallback for local dev.
-        return await self._gateway_secret(_BOT_TOKEN_NAME) or os.getenv(
-            "SLACK_BOT_TOKEN", ""
-        )
+        # Bot token from env / k8s-secret.
+        return os.getenv("SLACK_BOT_TOKEN", "")
 
     async def _set_status(self, inbound: InboundSlack, status: str) -> None:
         """AI-app 'thinking…' indicator (assistant.threads.setStatus). Shows in the

--- a/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
+++ b/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
@@ -370,7 +370,7 @@ class TestDispatch:
     @pytest.mark.asyncio
     async def test_new_thread_creates_task_then_sends_event(self, monkeypatch):
         monkeypatch.setattr(
-            sg, "_ACTING_USER_API_KEY", ""
+            sg, "_ACTING_BOT_API_KEY", ""
         )  # -> (None, {}), no authn proxy
         monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
         acp, _ = _fake_acp(existing_task=None)  # new thread → create
@@ -416,7 +416,7 @@ class TestDispatch:
     async def test_existing_thread_skips_create_but_sends_event(self, monkeypatch):
         # Same-thread follow-up: the task/workflow already exists, so we must NOT
         # TASK_CREATE (it would re-start the running workflow) — only EVENT_SEND.
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "")
         monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
         existing = SimpleNamespace(id="task_1", task_metadata=None)
         acp, _ = _fake_acp(existing_task=existing)
@@ -447,7 +447,7 @@ class TestDispatch:
         # globally-unique task name is already taken), so TASK_CREATE raises
         # DuplicateItemError. It must fall back to the task the winner created and
         # still send its own event rather than dropping the turn.
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "")
         monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
         winner_task = SimpleNamespace(id="task_1", task_metadata=None)
         acp = MagicMock()
@@ -494,7 +494,7 @@ class TestDispatch:
         # After the create-race, the fallback get_task reads the replica — which may lag
         # and miss the winner's task. Retry until it catches up rather than dropping the
         # turn with ItemDoesNotExist.
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "")
         monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
         monkeypatch.setattr(sg, "_CREATE_RACE_BACKOFF_S", 0.0)
         winner_task = SimpleNamespace(id="task_1", task_metadata=None)
@@ -541,7 +541,7 @@ class TestDispatch:
     async def test_sync_agent_uses_message_send_and_returns_reply(self, monkeypatch):
         # A SYNC agent has no event stream: dispatch does ONE message/send (get-or-create
         # + reply), not task/create + event/send + poll.
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "")
         monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
         acp, _ = _fake_acp(acp_type=sg.ACPType.SYNC)
         reply_msg = SimpleNamespace(
@@ -575,7 +575,7 @@ class TestDispatch:
 
     @staticmethod
     def _sync_race_acp(monkeypatch, side_effect):
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "")
         monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
         monkeypatch.setattr(
             sg, "_CREATE_RACE_BACKOFF_S", 0.0
@@ -792,7 +792,7 @@ class TestNonGoldenAgent:
 
     @pytest.mark.asyncio
     async def test_dispatch_looks_up_the_target_agent_by_name(self, monkeypatch):
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
+        monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "")
         monkeypatch.setattr(sg, "GlobalDependencies", MagicMock())
         acp, _ = _fake_acp(existing_task=None)
         monkeypatch.setattr(
@@ -970,41 +970,27 @@ class TestDeliver:
 
 @pytest.mark.unit
 class TestGatewaySecrets:
-    """The throwaway DB store: bot token / signing secret read from agent_api_keys
-    (via _gateway_secret), env fallback, and fail-safe when there's no DB."""
+    """Bot token / signing secret read straight from env / k8s-secret."""
 
     @pytest.mark.asyncio
-    async def test_bot_token_from_db(self, monkeypatch):
-        uc = SlackGatewayUseCase()
-        monkeypatch.setattr(
-            uc, "_gateway_secret", AsyncMock(return_value="xoxb-from-db")
-        )
-        assert await uc._fetch_bot_token() == "xoxb-from-db"
-        uc._gateway_secret.assert_awaited_once_with("slack-bot-token")
-
-    @pytest.mark.asyncio
-    async def test_bot_token_env_fallback(self, monkeypatch):
+    async def test_bot_token_from_env(self, monkeypatch):
         monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-env")
-        uc = SlackGatewayUseCase()
-        monkeypatch.setattr(uc, "_gateway_secret", AsyncMock(return_value=""))
-        assert await uc._fetch_bot_token() == "xoxb-env"
+        assert await SlackGatewayUseCase()._fetch_bot_token() == "xoxb-env"
 
     @pytest.mark.asyncio
-    async def test_signing_secret_from_db(self, monkeypatch):
-        uc = SlackGatewayUseCase()
-        monkeypatch.setattr(uc, "_gateway_secret", AsyncMock(return_value="sign-db"))
-        assert await uc._fetch_signing_secret("A123") == "sign-db"
-        uc._gateway_secret.assert_awaited_once_with("slack-signing-secret")
+    async def test_bot_token_absent_is_empty(self, monkeypatch):
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        assert await SlackGatewayUseCase()._fetch_bot_token() == ""
 
     @pytest.mark.asyncio
-    async def test_gateway_secret_fail_safe_without_db(self, monkeypatch):
-        # No engine / GlobalDependencies in a unit test → fail-safe to "".
-        monkeypatch.setattr(
-            sg,
-            "database_async_read_write_engine",
-            MagicMock(side_effect=RuntimeError("no db")),
-        )
-        assert await SlackGatewayUseCase()._gateway_secret("A123:bot") == ""
+    async def test_signing_secret_from_env(self, monkeypatch):
+        monkeypatch.setenv("SLACK_SIGNING_SECRET", "sign-env")
+        assert await SlackGatewayUseCase()._fetch_signing_secret("A123") == "sign-env"
+
+    @pytest.mark.asyncio
+    async def test_signing_secret_absent_is_empty(self, monkeypatch):
+        monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+        assert await SlackGatewayUseCase()._fetch_signing_secret("A123") == ""
 
 
 def _patch_authn(monkeypatch, user_id="u1"):
@@ -1025,49 +1011,23 @@ def _patch_authn(monkeypatch, user_id="u1"):
 class TestActingIdentity:
     @pytest.mark.asyncio
     async def test_no_key_is_dev_bypass(self, monkeypatch):
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "")
-        uc = SlackGatewayUseCase()
-        monkeypatch.setattr(
-            uc, "_gateway_secret", AsyncMock(return_value="")
-        )  # no DB value
-        principal, headers = await uc._acting_identity()
+        monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "")
+        principal, headers = await SlackGatewayUseCase()._acting_identity()
         assert principal is None
         assert headers == {}
 
     @pytest.mark.asyncio
-    async def test_env_fallback_sends_both_headers(self, monkeypatch):
-        # DB empty → fall back to env; auth needs x-api-key AND x-selected-account-id.
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "ssk_test")
+    async def test_sends_both_headers(self, monkeypatch):
+        # Auth needs x-api-key AND x-selected-account-id together.
+        monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "ssk_test")
         monkeypatch.setattr(sg, "_ACTING_ACCOUNT_ID", "acct_1")
-        uc = SlackGatewayUseCase()
-        monkeypatch.setattr(uc, "_gateway_secret", AsyncMock(return_value=""))
         fake_authn = _patch_authn(monkeypatch)
 
-        principal, headers = await uc._acting_identity()
+        principal, headers = await SlackGatewayUseCase()._acting_identity()
 
         assert headers == {"x-api-key": "ssk_test", "x-selected-account-id": "acct_1"}
         fake_authn.verify_headers.assert_awaited_once_with(headers)
         assert principal.user_id == "u1"
-
-    @pytest.mark.asyncio
-    async def test_db_takes_precedence_over_env(self, monkeypatch):
-        # DB values (slack-acting-user-api-key / slack-acting-account-id) win over env.
-        monkeypatch.setattr(sg, "_ACTING_USER_API_KEY", "env-key")
-        monkeypatch.setattr(sg, "_ACTING_ACCOUNT_ID", "env-acct")
-        uc = SlackGatewayUseCase()
-
-        async def fake_secret(name):
-            return {
-                "slack-acting-user-api-key": "db-key",
-                "slack-acting-account-id": "db-acct",
-            }.get(name, "")
-
-        monkeypatch.setattr(uc, "_gateway_secret", AsyncMock(side_effect=fake_secret))
-        _patch_authn(monkeypatch)
-
-        _, headers = await uc._acting_identity()
-
-        assert headers == {"x-api-key": "db-key", "x-selected-account-id": "db-acct"}
 
 
 @pytest.mark.unit

--- a/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
+++ b/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
@@ -1010,11 +1010,21 @@ def _patch_authn(monkeypatch, user_id="u1"):
 @pytest.mark.unit
 class TestActingIdentity:
     @pytest.mark.asyncio
-    async def test_no_key_is_dev_bypass(self, monkeypatch):
+    async def test_no_key_authz_off_is_dev_bypass(self, monkeypatch):
+        # authz off (no AGENTEX_AUTH_URL) + no bot key -> local dev bypass, no principal.
         monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "")
+        monkeypatch.delenv("AGENTEX_AUTH_URL", raising=False)
         principal, headers = await SlackGatewayUseCase()._acting_identity()
         assert principal is None
         assert headers == {}
+
+    @pytest.mark.asyncio
+    async def test_no_key_authz_on_fails_closed(self, monkeypatch):
+        # authz on (AGENTEX_AUTH_URL set) + no bot key -> refuse to dispatch unauthenticated.
+        monkeypatch.setattr(sg, "_ACTING_BOT_API_KEY", "")
+        monkeypatch.setenv("AGENTEX_AUTH_URL", "http://auth")
+        with pytest.raises(RuntimeError, match="refusing to dispatch"):
+            await SlackGatewayUseCase()._acting_identity()
 
     @pytest.mark.asyncio
     async def test_sends_both_headers(self, monkeypatch):


### PR DESCRIPTION
## What

The Slack gateway acts as **one fixed identity** — a dedicated bot service account, not a per-user proxy — so its credentials (signing secret, bot token, acting API key + account) are static, app-level values. This moves them out of the throwaway `agent_api_keys` DB store and into env / k8s-secret, where static deployment secrets belong.

## Why

The DB store only ever existed as a bridge toward per-user, per-request secrets that vary by user and can't live in static pod env (the code itself called it a *"THROWAWAY store — plaintext … To be replaced by sgp-secrets user-scope"*). With the gateway settled as a single bot identity, that justification is gone: these are one-per-deployment secrets, so the environment's secret is the right home. It also gets plaintext secrets out of the application database and removes the DB read path entirely.

## Changes

- Drop `_gateway_secret` and the DB-store name constants; `_fetch_bot_token`, `_fetch_signing_secret`, and `_acting_identity` read env directly.
- Rename the acting identity user → bot (`SLACK_GATEWAY_ACTING_BOT_API_KEY`) to reflect that the bot is its own entity, not the invoking user.
- Remove the now-unused `get_by_name_and_type` repository method.
- Update unit tests to the env-based reads.

## Deploy note

The gateway now reads four env vars — `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`, `SLACK_GATEWAY_ACTING_BOT_API_KEY`, `SLACK_GATEWAY_ACCOUNT_ID` — from the deployment secret. They must be present in an environment's secret before this rolls out there.

## Testing

- `73 passed` (gateway + delegation-header unit tests), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves the Slack gateway’s fixed bot credentials from the database to deployment environment secrets and removes the obsolete repository lookup. It also closes the previously reported missing-identity path by refusing to dispatch without a bot API key when authorization is enabled.

- Reads the signing secret, bot token, bot API key, and account ID from environment-backed deployment secrets.
- Fails closed when the bot API key is absent in an authorization-enabled environment.
- Removes the unused agent-agnostic API-key repository method and updates unit tests for environment-based credential loading.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the previously reported unauthenticated-dispatch path now aborts before dispatch when authorization is enabled.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/slack_gateway_use_case.py | Replaces database-backed gateway secret reads with environment-backed bot credentials and adds the required fail-closed identity guard. |
| agentex/src/domain/repositories/agent_api_key_repository.py | Removes the now-unused agent-agnostic credential lookup method. |
| agentex/tests/unit/use_cases/test_slack_gateway_use_case.py | Updates credential tests for direct environment reads and covers both fail-closed and local-development missing-key behavior. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Slack turn] --> B[Read bot identity from environment]
  B --> C{Bot API key present?}
  C -- Yes --> D[Verify API key and account headers]
  D --> E[Resolve target and dispatch as bot principal]
  C -- No --> F{Authorization enabled?}
  F -- Yes --> G[Abort turn without dispatch]
  F -- No --> H[Local development bypass]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agentex): Slack gateway fails closed..."](https://github.com/scaleapi/scale-agentex/commit/64dada9020e00e48276aee310c7fe2f40454c635) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50251740)</sub>

<!-- /greptile_comment -->