### PR TITLE
fix(ui): scheduled-tasks UAT fixes — modals, display corrections, UX polish

### DIFF
--- a/agentex-ui/components/agentex-ui-root.tsx
+++ b/agentex-ui/components/agentex-ui-root.tsx
@@ -23,7 +23,7 @@ type AgentexUIRootProps = {
 export function AgentexUIRoot({
   agentRunSchedulesEnabled,
 }: AgentexUIRootProps) {
-  const { agentName, taskID, sgpAccountID, updateParams } =
+  const { agentName, taskID, view, sgpAccountID, updateParams } =
     useSafeSearchParams();
   const [isTracesSidebarOpen, setIsTracesSidebarOpen] = useState(false);
   const { agentexClient } = useAgentexClient();
@@ -103,8 +103,16 @@ export function AgentexUIRoot({
         event.preventDefault();
         handleSelectTask(null);
       }
-      // Escape to clear the selected agent on the home page
-      if (event.key === 'Escape' && !!agentName && !taskID) {
+      // Escape to clear the selected agent on the home page only. Other
+      // views own their Escape behavior (popovers, dialogs), and a handler
+      // that consumed the key marks it with preventDefault.
+      if (
+        event.key === 'Escape' &&
+        !event.defaultPrevented &&
+        !!agentName &&
+        !taskID &&
+        !view
+      ) {
         updateParams({
           [SearchParamKey.AGENT_NAME]: null,
         });
@@ -117,7 +125,14 @@ export function AgentexUIRoot({
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [handleSelectTask, agentName, taskID, updateParams, setLocalAgentName]);
+  }, [
+    handleSelectTask,
+    agentName,
+    taskID,
+    view,
+    updateParams,
+    setLocalAgentName,
+  ]);
 
   return (
     <>

--- a/agentex-ui/components/scheduled-tasks/all-schedules-list.tsx
+++ b/agentex-ui/components/scheduled-tasks/all-schedules-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ButtonHTMLAttributes } from 'react';
+import { useState } from 'react';
 
 import {
   CalendarX2,
@@ -17,6 +17,12 @@ import {
   EditScheduleModal,
 } from '@/components/scheduled-tasks/schedule-modals';
 import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useScheduleAction } from '@/hooks/use-agent-run-schedules';
 import type { AgentRunSchedule } from '@/lib/agent-run-schedules';
 import { describeCadence } from '@/lib/schedule-utils';
@@ -28,7 +34,6 @@ import {
   getNextRun,
   isSchedulePaused,
   type ScheduleListItem,
-  useCloseOnOutsideClick,
 } from './schedule-helpers';
 
 import type AgentexSDK from 'agentex';
@@ -160,9 +165,6 @@ export function ScheduleOverflowMenu({
   isSkipped?: boolean;
 }) {
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const menuRef = useCloseOnOutsideClick<HTMLDivElement>(isOpen, () =>
-    setIsOpen(false)
-  );
   const pause = useScheduleAction({ agentexClient, agentId, action: 'pause' });
   const resume = useScheduleAction({
     agentexClient,
@@ -185,113 +187,93 @@ export function ScheduleOverflowMenu({
 
   return (
     <>
-      <div ref={menuRef} className="relative">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => setIsOpen(open => !open)}
-          aria-label={`Open actions for ${schedule.name}`}
-        >
-          <MoreHorizontal className="size-4" />
-        </Button>
-        {isOpen && (
-          <div className="bg-popover text-popover-foreground absolute top-10 right-0 z-50 min-w-48 rounded-md border p-1 shadow-lg">
-            {showScheduleActions && (
-              <MenuButton
-                onClick={() => {
-                  setIsOpen(false);
-                  trigger.mutate(schedule.id);
+      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={`Open actions for ${schedule.name}`}
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-48">
+          {showScheduleActions && (
+            <DropdownMenuItem
+              onSelect={() => trigger.mutate(schedule.id)}
+              disabled={trigger.isPending}
+            >
+              <Play className="size-4" />
+              Run now
+            </DropdownMenuItem>
+          )}
+          {isSkipped ? (
+            <DropdownMenuItem
+              onSelect={() => {
+                if (!scheduledTime) return;
+                unskip.mutate({ scheduleId: schedule.id, scheduledTime });
+              }}
+              disabled={unskip.isPending || !scheduledTime}
+            >
+              <Clock3 className="size-4" />
+              Unskip run
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              onSelect={() => {
+                if (!scheduledTime) return;
+                skip.mutate({ scheduleId: schedule.id, scheduledTime });
+              }}
+              disabled={skip.isPending || !canSkip}
+            >
+              <CalendarX2 className="size-4" />
+              {showScheduleActions ? 'Skip next run' : 'Skip run'}
+            </DropdownMenuItem>
+          )}
+          {showScheduleActions && (
+            <DropdownMenuItem disabled title="Snooze support is coming soon">
+              <Clock3 className="size-4" />
+              Snooze — coming soon
+            </DropdownMenuItem>
+          )}
+          {showScheduleActions && (
+            <>
+              <DropdownMenuItem
+                onSelect={() => {
+                  if (isPaused) {
+                    resume.mutate(schedule.id);
+                  } else {
+                    pause.mutate(schedule.id);
+                  }
                 }}
-                disabled={trigger.isPending}
+                disabled={pause.isPending || resume.isPending}
               >
-                <Play className="size-4" />
-                Run now
-              </MenuButton>
-            )}
-            {isSkipped ? (
-              <MenuButton
-                onClick={() => {
-                  if (!scheduledTime) return;
-                  setIsOpen(false);
-                  unskip.mutate({ scheduleId: schedule.id, scheduledTime });
-                }}
-                disabled={unskip.isPending || !scheduledTime}
+                <PauseCircle className="size-4" />
+                {isPaused ? 'Resume' : 'Pause'}
+              </DropdownMenuItem>
+              {onEdit && (
+                <DropdownMenuItem onSelect={() => onEdit?.()}>
+                  <Pencil className="size-4" />
+                  Edit
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem
+                onSelect={() => setIsDeleteConfirmOpen(true)}
+                className="text-destructive focus:text-destructive [&_svg:not([class*='text-'])]:text-destructive"
               >
-                <Clock3 className="size-4" />
-                Unskip run
-              </MenuButton>
-            ) : (
-              <MenuButton
-                onClick={() => {
-                  if (!scheduledTime) return;
-                  setIsOpen(false);
-                  skip.mutate({ scheduleId: schedule.id, scheduledTime });
-                }}
-                disabled={skip.isPending || !canSkip}
-              >
-                <CalendarX2 className="size-4" />
-                {showScheduleActions ? 'Skip next run' : 'Skip run'}
-              </MenuButton>
-            )}
-            {showScheduleActions && (
-              <MenuButton disabled title="Snooze support is coming soon">
-                <Clock3 className="size-4" />
-                Snooze — coming soon
-              </MenuButton>
-            )}
-            {showScheduleActions && (
-              <>
-                <MenuButton
-                  onClick={() => {
-                    setIsOpen(false);
-                    if (isPaused) {
-                      resume.mutate(schedule.id);
-                    } else {
-                      pause.mutate(schedule.id);
-                    }
-                  }}
-                  disabled={pause.isPending || resume.isPending}
-                >
-                  <PauseCircle className="size-4" />
-                  {isPaused ? 'Resume' : 'Pause'}
-                </MenuButton>
-                {onEdit && (
-                  <MenuButton
-                    onClick={() => {
-                      setIsOpen(false);
-                      onEdit();
-                    }}
-                  >
-                    <Pencil className="size-4" />
-                    Edit
-                  </MenuButton>
-                )}
-                <MenuButton
-                  onClick={() => {
-                    setIsOpen(false);
-                    setIsDeleteConfirmOpen(true);
-                  }}
-                  className="text-destructive hover:text-destructive"
-                >
-                  <Trash2 className="size-4" />
-                  Delete
-                </MenuButton>
-              </>
-            )}
-            {!showScheduleActions && onEdit && (
-              <MenuButton
-                onClick={() => {
-                  setIsOpen(false);
-                  onEdit();
-                }}
-              >
-                <Pencil className="size-4" />
-                Edit schedule
-              </MenuButton>
-            )}
-          </div>
-        )}
-      </div>
+                <Trash2 className="size-4" />
+                Delete
+              </DropdownMenuItem>
+            </>
+          )}
+          {!showScheduleActions && onEdit && (
+            <DropdownMenuItem onSelect={() => onEdit?.()}>
+              <Pencil className="size-4" />
+              Edit schedule
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
       {isDeleteConfirmOpen && (
         <DeleteScheduleModal
           agentId={agentId}
@@ -301,24 +283,5 @@ export function ScheduleOverflowMenu({
         />
       )}
     </>
-  );
-}
-
-function MenuButton({
-  children,
-  className,
-  ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) {
-  return (
-    <button
-      type="button"
-      className={cn(
-        'hover:bg-accent hover:text-accent-foreground flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm disabled:pointer-events-none disabled:opacity-50',
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </button>
   );
 }

--- a/agentex-ui/components/scheduled-tasks/all-schedules-list.tsx
+++ b/agentex-ui/components/scheduled-tasks/all-schedules-list.tsx
@@ -95,7 +95,9 @@ function ScheduleRow({
         <div className="truncate text-sm font-semibold">{schedule.name}</div>
         <div className="text-muted-foreground truncate text-sm">
           {describeCadence(schedule)}
-          {` · ${formatTimezone(schedule.timezone)}`}
+          {schedule.interval_seconds == null
+            ? ` · ${formatTimezone(schedule.timezone)}`
+            : ''}
           {showAgentName ? ` · ${agentName}` : ''}
           {` · ${describeRunCount(schedule.num_actions_taken)}`}
         </div>

--- a/agentex-ui/components/scheduled-tasks/all-schedules-list.tsx
+++ b/agentex-ui/components/scheduled-tasks/all-schedules-list.tsx
@@ -6,7 +6,6 @@ import {
   CalendarX2,
   Clock3,
   MoreHorizontal,
-  PauseCircle,
   Pencil,
   Play,
   Trash2,
@@ -111,7 +110,9 @@ function ScheduleRow({
           disabled={pause.isPending || resume.isPending}
           className={cn(
             'flex h-6 w-11 items-center rounded-full p-0.5 transition-colors disabled:opacity-60',
-            isPaused ? 'bg-slate-200 dark:bg-slate-700' : 'bg-[#6F4DFF]'
+            isPaused
+              ? 'bg-slate-200 dark:bg-slate-700'
+              : 'bg-primary-foreground'
           )}
           aria-label={isPaused ? 'Activate schedule' : 'Deactivate schedule'}
         >
@@ -167,12 +168,6 @@ export function ScheduleOverflowMenu({
   isSkipped?: boolean;
 }) {
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const pause = useScheduleAction({ agentexClient, agentId, action: 'pause' });
-  const resume = useScheduleAction({
-    agentexClient,
-    agentId,
-    action: 'resume',
-  });
   const skip = useScheduleAction({ agentexClient, agentId, action: 'skip' });
   const unskip = useScheduleAction({
     agentexClient,
@@ -240,19 +235,6 @@ export function ScheduleOverflowMenu({
           )}
           {showScheduleActions && (
             <>
-              <DropdownMenuItem
-                onSelect={() => {
-                  if (isPaused) {
-                    resume.mutate(schedule.id);
-                  } else {
-                    pause.mutate(schedule.id);
-                  }
-                }}
-                disabled={pause.isPending || resume.isPending}
-              >
-                <PauseCircle className="size-4" />
-                {isPaused ? 'Resume' : 'Pause'}
-              </DropdownMenuItem>
               {onEdit && (
                 <DropdownMenuItem onSelect={() => onEdit?.()}>
                   <Pencil className="size-4" />

--- a/agentex-ui/components/scheduled-tasks/cadence-picker.tsx
+++ b/agentex-ui/components/scheduled-tasks/cadence-picker.tsx
@@ -224,12 +224,19 @@ export function CadencePicker({
               />
             )}
 
-            <div className="flex items-center gap-3">
-              <span className="text-muted-foreground text-sm font-medium">
-                Timezone
-              </span>
-              <TimezoneSelect timezone={timezone} onChange={onTimezoneChange} />
-            </div>
+            {/* Intervals are epoch-aligned; the backend only applies the
+                timezone to cron cadences, so don't offer it for intervals. */}
+            {cadence.type !== 'interval' && (
+              <div className="flex items-center gap-3">
+                <span className="text-muted-foreground text-sm font-medium">
+                  Timezone
+                </span>
+                <TimezoneSelect
+                  timezone={timezone}
+                  onChange={onTimezoneChange}
+                />
+              </div>
+            )}
           </div>
 
           <div

--- a/agentex-ui/components/scheduled-tasks/cadence-picker.tsx
+++ b/agentex-ui/components/scheduled-tasks/cadence-picker.tsx
@@ -134,7 +134,9 @@ export function CadencePicker({
                 className={cn(
                   'rounded-lg px-3 py-2 text-sm font-medium capitalize transition-colors',
                   cadence.type === type
-                    ? 'text-primary-foreground bg-white shadow-sm dark:bg-slate-800'
+                    ? // violet-400 for dark: the token is #714dff in both
+                      // themes, which fails contrast on dark slate.
+                      'text-primary-foreground bg-white shadow-sm dark:bg-slate-800 dark:text-violet-400'
                     : 'text-muted-foreground hover:text-foreground'
                 )}
               >

--- a/agentex-ui/components/scheduled-tasks/cadence-picker.tsx
+++ b/agentex-ui/components/scheduled-tasks/cadence-picker.tsx
@@ -134,7 +134,7 @@ export function CadencePicker({
                 className={cn(
                   'rounded-lg px-3 py-2 text-sm font-medium capitalize transition-colors',
                   cadence.type === type
-                    ? 'bg-white text-[#5B3FFF] shadow-sm dark:bg-slate-800 dark:text-[#A78BFA]'
+                    ? 'text-primary-foreground bg-white shadow-sm dark:bg-slate-800'
                     : 'text-muted-foreground hover:text-foreground'
                 )}
               >
@@ -156,8 +156,8 @@ export function CadencePicker({
                       className={cn(
                         'flex size-10 items-center justify-center rounded-full border text-sm font-semibold transition-colors',
                         selected
-                          ? 'border-[#6F4DFF] bg-[#6F4DFF] text-white'
-                          : 'border-input text-muted-foreground hover:border-[#6F4DFF]/50'
+                          ? 'border-primary-foreground bg-primary-foreground text-white'
+                          : 'border-input text-muted-foreground hover:border-primary-foreground/50'
                       )}
                       aria-label={label}
                       aria-pressed={selected}

--- a/agentex-ui/components/scheduled-tasks/schedule-composer.tsx
+++ b/agentex-ui/components/scheduled-tasks/schedule-composer.tsx
@@ -80,7 +80,11 @@ export function ScheduleComposer({
     setCreationFeedback({
       status: 'pending',
       title: name,
-      cadenceLabel: `${describeCadenceConfig(cadence)} · ${formatTimezone(timezone)}`,
+      // Intervals are epoch-aligned and ignore the timezone, so don't echo it.
+      cadenceLabel:
+        cadence.type === 'interval'
+          ? describeCadenceConfig(cadence)
+          : `${describeCadenceConfig(cadence)} · ${formatTimezone(timezone)}`,
     });
     setPrompt('');
     try {

--- a/agentex-ui/components/scheduled-tasks/schedule-composer.tsx
+++ b/agentex-ui/components/scheduled-tasks/schedule-composer.tsx
@@ -120,6 +120,7 @@ export function ScheduleComposer({
             }
           }}
           placeholder="What should this agent do on a schedule?"
+          aria-label="Schedule prompt"
           className="min-h-20 resize-none border-0 bg-transparent text-sm leading-6 outline-none focus:border-0 focus:ring-0 focus:outline-none focus-visible:outline-none"
         />
         <div className="flex flex-wrap items-center gap-3">

--- a/agentex-ui/components/scheduled-tasks/schedule-composer.tsx
+++ b/agentex-ui/components/scheduled-tasks/schedule-composer.tsx
@@ -200,13 +200,13 @@ function ScheduleCreationStatus({
           className={cn(
             'border-border bg-card flex items-center gap-3 rounded-2xl border px-4 py-3 shadow-sm',
             feedback.status === 'success' &&
-              'border-emerald-500/30 bg-emerald-500/5'
+              'border-green-600/30 bg-green-600/5'
           )}
           aria-live="polite"
         >
           {feedback.status === 'pending' ? (
             <motion.span
-              className="size-2.5 shrink-0 rounded-full bg-[#7C5CFF]"
+              className="bg-primary-foreground size-2.5 shrink-0 rounded-full"
               animate={
                 reduceMotion
                   ? false
@@ -219,7 +219,7 @@ function ScheduleCreationStatus({
               }}
             />
           ) : (
-            <CheckCircle2 className="size-5 shrink-0 text-emerald-600" />
+            <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
           )}
           <div className="min-w-0 flex-1">
             <div className="truncate text-sm font-medium">

--- a/agentex-ui/components/scheduled-tasks/schedule-helpers.ts
+++ b/agentex-ui/components/scheduled-tasks/schedule-helpers.ts
@@ -80,18 +80,14 @@ export function sortScheduleItems(
   view: ScheduleView
 ) {
   return [...items].sort((a, b) => {
-    const aNextRun = getNextRunTime(a.schedule);
-    const bNextRun = getNextRunTime(b.schedule);
-
     if (view === 'upcoming') {
-      return (aNextRun ?? 0) - (bNextRun ?? 0);
+      return (
+        (getNextRunTime(a.schedule) ?? 0) - (getNextRunTime(b.schedule) ?? 0)
+      );
     }
 
-    if (aNextRun != null && bNextRun != null) {
-      return aNextRun - bNextRun;
-    }
-    if (aNextRun != null) return -1;
-    if (bNextRun != null) return 1;
+    // Name order keeps the Schedules tab stable: sorting by next run made a
+    // row jump to the bottom the moment its schedule was paused.
     return a.schedule.name.localeCompare(b.schedule.name);
   });
 }

--- a/agentex-ui/components/scheduled-tasks/schedule-helpers.ts
+++ b/agentex-ui/components/scheduled-tasks/schedule-helpers.ts
@@ -204,6 +204,9 @@ export function useCloseOnOutsideClick<T extends HTMLElement>(
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
+        // Mark the key consumed so global Escape handlers (e.g. clear
+        // selected agent) don't also fire.
+        event.preventDefault();
         onClose();
       }
     };

--- a/agentex-ui/components/scheduled-tasks/schedule-helpers.ts
+++ b/agentex-ui/components/scheduled-tasks/schedule-helpers.ts
@@ -65,9 +65,10 @@ export function isSchedulePaused(schedule: AgentRunSchedule) {
   return schedule.state === 'PAUSED' || schedule.paused;
 }
 
+// "Scheduled" is load-bearing: the count is the schedule's own fire count
+// (Temporal num_actions), which manual Run now triggers deliberately bypass.
 export function describeRunCount(count: number) {
-  if (count === 0) return '0 runs';
-  return count === 1 ? '1 run' : `${count} runs`;
+  return count === 1 ? '1 scheduled run' : `${count} scheduled runs`;
 }
 
 export function formatTimezone(timezone: string) {
@@ -95,10 +96,13 @@ export function sortScheduleItems(
   });
 }
 
+// Times render in the browser's timezone; the timezone name makes that
+// visible when the schedule was created in a different zone.
 function formatRunTime(date: Date) {
   return date.toLocaleTimeString(undefined, {
     hour: 'numeric',
     minute: '2-digit',
+    timeZoneName: 'short',
   });
 }
 
@@ -108,6 +112,7 @@ function formatRunDateTime(date: Date) {
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
+    timeZoneName: 'short',
   });
 }
 

--- a/agentex-ui/components/scheduled-tasks/schedule-modals.tsx
+++ b/agentex-ui/components/scheduled-tasks/schedule-modals.tsx
@@ -6,6 +6,12 @@ import { Loader2, Trash2 } from 'lucide-react';
 
 import { CadencePicker } from '@/components/scheduled-tasks/cadence-picker';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { toast } from '@/components/ui/toast';
 import {
   useScheduleAction,
@@ -258,16 +264,23 @@ function BasicModal({
   onClose: () => void;
 }) {
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
-      <div className="bg-background w-full max-w-lg rounded-2xl border p-5 shadow-xl">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-base font-semibold">{title}</h2>
-          <Button variant="ghost" size="sm" onClick={onClose}>
-            Close
-          </Button>
+    <Dialog
+      open
+      onOpenChange={open => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent showCloseButton={false} aria-describedby={undefined}>
+        <div className="flex items-center justify-between">
+          <DialogTitle className="text-base">{title}</DialogTitle>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm">
+              Close
+            </Button>
+          </DialogClose>
         </div>
         <div className="flex flex-col gap-4">{children}</div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/agentex-ui/components/scheduled-tasks/schedule-modals.tsx
+++ b/agentex-ui/components/scheduled-tasks/schedule-modals.tsx
@@ -170,7 +170,9 @@ export function EditScheduleModal({
             onClick={() => setIsActive(current => !current)}
             className={cn(
               'flex h-6 w-11 items-center rounded-full p-0.5 transition-colors',
-              isActive ? 'bg-[#6F4DFF]' : 'bg-slate-200 dark:bg-slate-700'
+              isActive
+                ? 'bg-primary-foreground'
+                : 'bg-slate-200 dark:bg-slate-700'
             )}
             aria-label={isActive ? 'Pause schedule' : 'Activate schedule'}
             aria-pressed={isActive}

--- a/agentex-ui/components/scheduled-tasks/schedule-modals.tsx
+++ b/agentex-ui/components/scheduled-tasks/schedule-modals.tsx
@@ -6,12 +6,7 @@ import { Loader2, Trash2 } from 'lucide-react';
 
 import { CadencePicker } from '@/components/scheduled-tasks/cadence-picker';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { toast } from '@/components/ui/toast';
 import {
   useScheduleAction,
@@ -115,6 +110,12 @@ export function EditScheduleModal({
     agentId,
   });
   const cadenceError = getCadenceValidationError(cadence);
+  const hasUnsavedChanges =
+    name !== schedule.name ||
+    prompt !== schedule.initial_input.content ||
+    timezone !== schedule.timezone ||
+    isActive !== !isSchedulePaused(schedule) ||
+    JSON.stringify(cadence) !== JSON.stringify(scheduleToCadence(schedule));
 
   const handleSave = async () => {
     if (cadenceError) {
@@ -141,7 +142,13 @@ export function EditScheduleModal({
 
   return (
     <>
-      <BasicModal title="Edit scheduled task" onClose={onClose}>
+      <BasicModal
+        title="Edit scheduled task"
+        onClose={onClose}
+        // An accidental Escape or backdrop click must not discard edits or
+        // interrupt a save; Cancel and Close remain the explicit exits.
+        canDismiss={() => !hasUnsavedChanges && !updateSchedule.isPending}
+      >
         <ScheduleNameInput name={name} setName={setName} />
         <label className="flex flex-col gap-1 text-sm">
           <span className="font-medium">Prompt</span>
@@ -260,26 +267,31 @@ function BasicModal({
   title,
   children,
   onClose,
+  canDismiss,
 }: {
   title: string;
   children: ReactNode;
   onClose: () => void;
+  /**
+   * Gates Escape / backdrop-click dismissal only. The explicit Close and
+   * Cancel buttons always work; use this to keep an accidental dismissal
+   * from discarding in-progress state.
+   */
+  canDismiss?: () => boolean;
 }) {
   return (
     <Dialog
       open
       onOpenChange={open => {
-        if (!open) onClose();
+        if (!open && (canDismiss?.() ?? true)) onClose();
       }}
     >
       <DialogContent showCloseButton={false} aria-describedby={undefined}>
         <div className="flex items-center justify-between">
           <DialogTitle className="text-base">{title}</DialogTitle>
-          <DialogClose asChild>
-            <Button variant="ghost" size="sm">
-              Close
-            </Button>
-          </DialogClose>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
         </div>
         <div className="flex flex-col gap-4">{children}</div>
       </DialogContent>

--- a/agentex-ui/components/scheduled-tasks/scheduled-tasks-page.tsx
+++ b/agentex-ui/components/scheduled-tasks/scheduled-tasks-page.tsx
@@ -138,6 +138,7 @@ export function ScheduledTasksPage() {
           scope={scheduleScope}
           selectedAgent={selectedAgent}
           agents={agents}
+          isLoading={agentsLoading}
           onChange={nextScope =>
             updateParams({
               [SearchParamKey.SCHEDULE_SCOPE]:
@@ -201,12 +202,14 @@ function ScheduleScopeSelector({
   scope,
   selectedAgent,
   agents,
+  isLoading,
   onChange,
   onSelectAgent,
 }: {
   scope: ScheduleScope;
   selectedAgent: Agent | null;
   agents: Agent[];
+  isLoading: boolean;
   onChange: (scope: ScheduleScope) => void;
   onSelectAgent: (agentName: string) => void;
 }) {
@@ -314,6 +317,15 @@ function ScheduleScopeSelector({
               <CalendarClock className="size-4" />
               All agents
             </button>
+            {isLoading && (
+              <div
+                className="text-muted-foreground flex items-center gap-2 px-2 py-3 text-sm"
+                role="status"
+              >
+                <Loader2 className="size-4 animate-spin" />
+                Loading agents…
+              </div>
+            )}
             {filteredAgents.map(agent => (
               <button
                 key={agent.id}
@@ -330,7 +342,7 @@ function ScheduleScopeSelector({
                 <span className="truncate">{agent.name}</span>
               </button>
             ))}
-            {query.trim() && filteredAgents.length === 0 && (
+            {!isLoading && query.trim() && filteredAgents.length === 0 && (
               <p className="text-muted-foreground px-2 py-3 text-center text-sm">
                 No agents found
               </p>

--- a/agentex-ui/components/scheduled-tasks/scheduled-tasks-page.tsx
+++ b/agentex-ui/components/scheduled-tasks/scheduled-tasks-page.tsx
@@ -36,6 +36,9 @@ import type { Agent } from 'agentex/resources';
 
 export function ScheduledTasksPage() {
   const { agentName, scheduleScope, updateParams } = useSafeSearchParams();
+  // With no agent selected there is nothing to scope to, so browse all
+  // agents instead of showing a "select an agent" empty state.
+  const effectiveScope = agentName ? scheduleScope : ScheduleScope.ALL;
   const { agentexClient } = useAgentexClient();
   const { data: agents = [], isLoading: agentsLoading } =
     useAgents(agentexClient);
@@ -53,7 +56,7 @@ export function ScheduledTasksPage() {
   const allScheduleQueries = useAgentRunSchedulesForAgents(
     agentexClient,
     agents,
-    scheduleScope === ScheduleScope.ALL
+    effectiveScope === ScheduleScope.ALL
   );
 
   const currentItems = useMemo<ScheduleListItem[]>(
@@ -81,7 +84,7 @@ export function ScheduledTasksPage() {
   );
 
   const baseItems =
-    scheduleScope === ScheduleScope.ALL ? allItems : currentItems;
+    effectiveScope === ScheduleScope.ALL ? allItems : currentItems;
   const unavailableLiveDataCount = useMemo(
     () =>
       baseItems.filter(
@@ -105,17 +108,17 @@ export function ScheduledTasksPage() {
   }, [baseItems, scheduleView]);
 
   const isLoading =
-    scheduleScope === ScheduleScope.ALL
+    effectiveScope === ScheduleScope.ALL
       ? agentsLoading || allScheduleQueries.some(query => query.isLoading)
       : schedulesQuery.isLoading;
   const error =
-    scheduleScope === ScheduleScope.ALL
+    effectiveScope === ScheduleScope.ALL
       ? (allScheduleQueries.find(query => query.error)?.error ?? null)
       : schedulesQuery.error;
   const emptyMessage =
     scheduleView === 'upcoming'
       ? 'No upcoming scheduled runs'
-      : scheduleScope === ScheduleScope.ALL
+      : effectiveScope === ScheduleScope.ALL
         ? 'No schedules across agents yet'
         : 'No scheduled tasks yet';
 
@@ -127,7 +130,7 @@ export function ScheduledTasksPage() {
             Scheduled Tasks
           </h1>
           <p className="text-muted-foreground text-sm">
-            {scheduleScope === ScheduleScope.ALL
+            {effectiveScope === ScheduleScope.ALL
               ? 'Browse schedules across all agents.'
               : agentName
                 ? `Run ${agentName} automatically on a cadence.`
@@ -135,7 +138,7 @@ export function ScheduledTasksPage() {
           </p>
         </div>
         <ScheduleScopeSelector
-          scope={scheduleScope}
+          scope={effectiveScope}
           selectedAgent={selectedAgent}
           agents={agents}
           isLoading={agentsLoading}
@@ -155,11 +158,11 @@ export function ScheduledTasksPage() {
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-8 py-6">
-        {scheduleScope === ScheduleScope.CURRENT && !selectedAgent ? (
+        {effectiveScope === ScheduleScope.CURRENT && !selectedAgent ? (
           <EmptyState message="Select an agent to create scheduled tasks." />
         ) : (
           <>
-            {scheduleScope === ScheduleScope.CURRENT && selectedAgent && (
+            {effectiveScope === ScheduleScope.CURRENT && selectedAgent && (
               <ScheduleComposer
                 agentId={selectedAgent.id}
                 agentexClient={agentexClient}
@@ -188,7 +191,7 @@ export function ScheduledTasksPage() {
               isLoading={isLoading}
               error={error}
               emptyMessage={emptyMessage}
-              showAgentName={scheduleScope === ScheduleScope.ALL}
+              showAgentName={effectiveScope === ScheduleScope.ALL}
               view={scheduleView}
             />
           </>

--- a/agentex-ui/components/scheduled-tasks/scheduled-tasks-page.tsx
+++ b/agentex-ui/components/scheduled-tasks/scheduled-tasks-page.tsx
@@ -132,9 +132,7 @@ export function ScheduledTasksPage() {
           <p className="text-muted-foreground text-sm">
             {effectiveScope === ScheduleScope.ALL
               ? 'Browse schedules across all agents.'
-              : agentName
-                ? `Run ${agentName} automatically on a cadence.`
-                : 'Select an agent to schedule recurring tasks.'}
+              : `Run ${agentName} automatically on a cadence.`}
           </p>
         </div>
         <ScheduleScopeSelector
@@ -239,6 +237,8 @@ function ScheduleScopeSelector({
     };
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
+        // Mark the key consumed so global Escape handlers don't also fire.
+        event.preventDefault();
         setIsOpen(false);
         setQuery('');
         triggerRef.current?.focus();

--- a/agentex-ui/components/scheduled-tasks/upcoming-schedule-list.tsx
+++ b/agentex-ui/components/scheduled-tasks/upcoming-schedule-list.tsx
@@ -120,14 +120,14 @@ function UpcomingScheduleRow({
   return (
     <>
       <div className="relative flex items-center justify-between gap-4">
-        <span className="absolute top-2 -left-8 z-10 size-2 rounded-full bg-[#7C5CFF]" />
+        <span className="bg-primary-foreground absolute top-2 -left-8 z-10 size-2 rounded-full" />
         <div className="min-w-0">
           <div className="truncate text-sm font-semibold">{schedule.name}</div>
           <div className="text-muted-foreground flex flex-wrap items-center gap-2 text-sm">
             <span>{formatUpcomingSubtitle(item.runTime)}</span>
             {showAgentName && <span>· {agentName}</span>}
             {item.isSkipped && (
-              <span className="rounded-full bg-[#7C5CFF]/10 px-2 py-0.5 text-xs font-medium text-[#6F4DFF]">
+              <span className="bg-primary-foreground/10 text-primary-foreground rounded-full px-2 py-0.5 text-xs font-medium">
                 Skipped
               </span>
             )}
@@ -290,7 +290,7 @@ function RunNowOption({
       disabled={disabled}
       className="border-border hover:bg-muted/40 flex w-full items-start gap-3 rounded-xl border p-4 text-left transition-colors disabled:pointer-events-none disabled:opacity-60"
     >
-      <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-xl bg-[#7C5CFF]/10 text-[#6F4DFF]">
+      <span className="bg-primary-foreground/10 text-primary-foreground mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-xl">
         {icon}
       </span>
       <span>

--- a/agentex-ui/components/scheduled-tasks/upcoming-schedule-list.tsx
+++ b/agentex-ui/components/scheduled-tasks/upcoming-schedule-list.tsx
@@ -2,11 +2,18 @@
 
 import { useMemo, useState, type ReactNode } from 'react';
 
-import { CalendarX2, ChevronDown, ChevronUp, Play, X } from 'lucide-react';
+import { CalendarX2, ChevronDown, ChevronUp, Play } from 'lucide-react';
 
 import { ScheduleOverflowMenu } from '@/components/scheduled-tasks/all-schedules-list';
 import { EditScheduleModal } from '@/components/scheduled-tasks/schedule-modals';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { useScheduleAction } from '@/hooks/use-agent-run-schedules';
 import type { AgentRunSchedule } from '@/lib/agent-run-schedules';
 
@@ -219,19 +226,19 @@ function RunNowModal({
   const runLabel = formatUpcomingSubtitle(runTime);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
-      <div className="bg-background w-full max-w-md rounded-2xl border p-5 shadow-xl">
-        <div className="mb-5 flex items-center justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-semibold">Run task now</h2>
-            <p className="text-muted-foreground mt-1 text-sm">
-              Choose how to handle the scheduled run at {runLabel}.
-            </p>
-          </div>
-          <Button variant="ghost" size="icon" onClick={onClose}>
-            <X className="size-4" />
-          </Button>
-        </div>
+    <Dialog
+      open
+      onOpenChange={open => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Run task now</DialogTitle>
+          <DialogDescription>
+            Choose how to handle the scheduled run at {runLabel}.
+          </DialogDescription>
+        </DialogHeader>
 
         <div className="flex flex-col gap-2">
           <RunNowOption
@@ -250,7 +257,7 @@ function RunNowModal({
           />
         </div>
 
-        <div className="mt-4 flex items-center justify-between gap-3">
+        <div className="flex items-center justify-between gap-3">
           <p className="text-muted-foreground text-xs">
             Skipping only affects this occurrence; the schedule remains active.
           </p>
@@ -258,8 +265,8 @@ function RunNowModal({
             Cancel
           </Button>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/agentex-ui/components/task-sidebar/task-sidebar-body.tsx
+++ b/agentex-ui/components/task-sidebar/task-sidebar-body.tsx
@@ -15,15 +15,23 @@ import { useInfiniteTasks } from '@/hooks/use-tasks';
 import { cn } from '@/lib/utils';
 
 export type TaskSidebarBodyProps = {
+  agentRunSchedulesEnabled: boolean;
   className?: string;
 };
 
-export const TaskSidebarBody = ({ className }: TaskSidebarBodyProps) => {
+export const TaskSidebarBody = ({
+  agentRunSchedulesEnabled,
+  className,
+}: TaskSidebarBodyProps) => {
   const { agentexClient } = useAgentexClient();
   const { agentName, scheduleScope, view } = useSafeSearchParams();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Gate on the flag, not just the URL params, so the cross-agent view can't
+  // be reached by URL while the scheduled-tasks feature is off.
   const showTasksAcrossAgents =
-    view === AppView.SCHEDULED_TASKS && scheduleScope === ScheduleScope.ALL;
+    agentRunSchedulesEnabled &&
+    view === AppView.SCHEDULED_TASKS &&
+    scheduleScope === ScheduleScope.ALL;
 
   const {
     data,

--- a/agentex-ui/components/task-sidebar/task-sidebar.tsx
+++ b/agentex-ui/components/task-sidebar/task-sidebar.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-import { MessageSquarePlus, PanelLeftOpen } from 'lucide-react';
+import { CalendarClock, MessageSquarePlus, PanelLeftOpen } from 'lucide-react';
 
 import { TaskSidebarBody } from '@/components/task-sidebar/task-sidebar-body';
 import { TaskSidebarFooter } from '@/components/task-sidebar/task-sidebar-footer';
@@ -9,6 +9,7 @@ import { IconButton } from '@/components/ui/icon-button';
 import { ResizableSidebar } from '@/components/ui/resizable-sidebar';
 import { Separator } from '@/components/ui/separator';
 import {
+  AppView,
   SearchParamKey,
   useSafeSearchParams,
 } from '@/hooks/use-safe-search-params';
@@ -25,6 +26,13 @@ export function TaskSidebar({ agentRunSchedulesEnabled }: TaskSidebarProps) {
     updateParams({
       [SearchParamKey.TASK_ID]: null,
       [SearchParamKey.VIEW]: null,
+    });
+  }, [updateParams]);
+
+  const handleScheduledTasks = useCallback(() => {
+    updateParams({
+      [SearchParamKey.TASK_ID]: null,
+      [SearchParamKey.VIEW]: AppView.SCHEDULED_TASKS,
     });
   }, [updateParams]);
 
@@ -55,6 +63,15 @@ export function TaskSidebar({ agentRunSchedulesEnabled }: TaskSidebarProps) {
               className="text-foreground"
               aria-label="New Chat"
             />
+            {agentRunSchedulesEnabled && (
+              <IconButton
+                icon={CalendarClock}
+                onClick={handleScheduledTasks}
+                variant="ghost"
+                className="text-foreground"
+                aria-label="Scheduled Tasks"
+              />
+            )}
           </div>
           <TaskSidebarFooter collapsed className="mt-auto pb-2" />
         </>
@@ -66,7 +83,10 @@ export function TaskSidebar({ agentRunSchedulesEnabled }: TaskSidebarProps) {
         handleNewChat={handleNewChat}
       />
       <Separator />
-      <TaskSidebarBody className="flex-1" />
+      <TaskSidebarBody
+        className="flex-1"
+        agentRunSchedulesEnabled={agentRunSchedulesEnabled}
+      />
       <Separator />
       <TaskSidebarFooter />
     </ResizableSidebar>

--- a/agentex-ui/components/ui/dialog.tsx
+++ b/agentex-ui/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import * as React from 'react';
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/30',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl border p-5 shadow-xl duration-200 sm:max-w-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="hover:bg-accent hover:text-accent-foreground focus-visible:ring-primary-foreground/50 absolute top-4 right-4 flex size-8 items-center justify-center rounded-md outline-none focus-visible:ring-[3px] disabled:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-1 text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex items-center justify-end gap-2', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/agentex-ui/components/ui/dropdown-menu.tsx
+++ b/agentex-ui/components/ui/dropdown-menu.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import * as React from 'react';
+
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+
+import { cn } from '@/lib/utils';
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-lg',
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label>) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+};

--- a/agentex-ui/hooks/use-agent-run-schedules.ts
+++ b/agentex-ui/hooks/use-agent-run-schedules.ts
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-query';
 
 import { toast } from '@/components/ui/toast';
+import { tasksKeys } from '@/hooks/use-tasks';
 import {
   type AgentRunSchedule,
   type CreateAgentRunScheduleRequest,
@@ -232,6 +233,11 @@ export function useScheduleAction({
         queryKey: scheduleKeys.byAgentId(agentId),
         exact: true,
       });
+      if (action === 'trigger') {
+        // A manual run creates a task server-side; refresh the task list so it
+        // appears without a page reload.
+        queryClient.invalidateQueries({ queryKey: tasksKeys.all });
+      }
       toast.success(
         action === 'trigger'
           ? 'Scheduled task triggered'

--- a/agentex-ui/hooks/use-agent-run-schedules.ts
+++ b/agentex-ui/hooks/use-agent-run-schedules.ts
@@ -148,7 +148,6 @@ export function useUpdateAgentRunSchedule({
         scheduleKeys.detail(agentId, schedule.id),
         schedule
       );
-      toast.success('Scheduled task updated');
     },
     onError: error => {
       toast.error({
@@ -235,18 +234,11 @@ export function useScheduleAction({
       });
       if (action === 'trigger') {
         // A manual run creates a task server-side; refresh the task list so it
-        // appears without a page reload.
+        // appears without a page reload. This is also the only action whose
+        // outcome isn't visible in place, so it keeps its success toast.
         queryClient.invalidateQueries({ queryKey: tasksKeys.all });
+        toast.success('Scheduled task triggered');
       }
-      toast.success(
-        action === 'trigger'
-          ? 'Scheduled task triggered'
-          : action === 'skip'
-            ? 'Scheduled run skipped'
-            : action === 'unskip'
-              ? 'Scheduled run restored'
-              : `Scheduled task ${action === 'delete' ? 'deleted' : `${action}d`}`
-      );
     },
     onError: error => {
       toast.error({

--- a/agentex-ui/lib/schedule-utils.ts
+++ b/agentex-ui/lib/schedule-utils.ts
@@ -213,8 +213,19 @@ export function describeCadence(schedule: AgentRunSchedule): string {
 
   if (!schedule.cron_expression) return 'No cadence';
   // UI-created schedules use simple crons that round-trip through this config.
-  // If complex external crons are supported, fall back to the raw expression.
-  return describeCadenceConfig(scheduleToCadence(schedule));
+  // A cron the picker can't express (created outside the UI) would otherwise
+  // be described confidently and wrongly, so show it raw instead.
+  const cadence = scheduleToCadence(schedule);
+  try {
+    if (
+      cadenceToPayload(cadence).cron_expression === schedule.cron_expression
+    ) {
+      return describeCadenceConfig(cadence);
+    }
+  } catch {
+    // Parsed config fails validation — not a picker-shaped cron.
+  }
+  return schedule.cron_expression;
 }
 
 export function scheduleToCadence(schedule: AgentRunSchedule): CadenceConfig {

--- a/agentex-ui/package-lock.json
+++ b/agentex-ui/package-lock.json
@@ -13,6 +13,8 @@
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.38.6",
         "@hookform/resolvers": "^5.2.1",
+        "@radix-ui/react-dialog": "^1.1.23",
+        "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
@@ -2098,9 +2100,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2116,9 +2115,6 @@
       "integrity": "sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2136,9 +2132,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2154,9 +2147,6 @@
       "integrity": "sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2275,6 +2265,12 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
       "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -2350,10 +2346,570 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
       "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2427,6 +2983,352 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
@@ -2481,6 +3383,44 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
@@ -2499,6 +3439,237 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2805,6 +3976,21 @@
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -9896,9 +11082,10 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
-      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
         "react-style-singleton": "^2.2.3",

--- a/agentex-ui/package.json
+++ b/agentex-ui/package.json
@@ -24,6 +24,8 @@
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.38.6",
     "@hookform/resolvers": "^5.2.1",
+    "@radix-ui/react-dialog": "^1.1.23",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
@@ -71,7 +73,6 @@
     "@types/react-dom": "^19",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^5.1.4",
-    "vite": "^7.3.2",
     "@vitest/coverage-v8": "^4.0.6",
     "@vitest/ui": "^4.0.6",
     "eslint": "9.32.0",
@@ -82,6 +83,7 @@
     "jsdom": "^27.1.0",
     "prettier": "^3.4.2",
     "prettier-plugin-tailwindcss": "^0.7.1",
+    "vite": "^7.3.2",
     "vitest": "^4.0.6"
   }
 }


### PR DESCRIPTION
## Summary

Batch of small UI fixes for Scheduled Tasks surfaced while writing and running the V1 UAT. Backend behaviour is correct in every case; these are display and interaction fixes in the chat UI.

### Task list freshness
- Invalidate the tasks query when a manual trigger succeeds, so the task a **Run now** creates appears in the sidebar without a page reload. (Scheduled fires appearing without a reload is a broader data-freshness question — the sidebar query never refetches by design — and is deliberately not addressed here.)

### Modals & keyboard support
- Add `@radix-ui/react-dialog` and `@radix-ui/react-dropdown-menu` with shadcn-style wrappers, and rebuild the Edit/Delete/Run-now modals and the schedule overflow menu on them. This adds Escape + backdrop-click dismissal, focus trapping, focus return, arrow-key menu navigation, and proper dialog/menu semantics — none of which the hand-rolled versions had. The Delete modal still refuses to dismiss while its request is in flight.
- Label the composer prompt textarea; the Run-now close control now has an accessible name via the shared dialog close.

### Display corrections
- Hide the Timezone control for interval cadences and omit the timezone from interval rows in the Schedules list. Intervals are epoch-aligned; the backend only applies a timezone to cron cadences, so the UI was echoing back a setting it discarded.
- Label Upcoming run times with the short timezone name so a schedule created in a foreign timezone can be reconciled with the local times shown.
- Relabel the run count as "scheduled runs" — the value is the schedule's own fire count, which manual runs deliberately bypass.
- Show a cron the picker can't express as the raw expression instead of a confidently wrong description (`0 */2 * * *` previously rendered as "Daily at 12:00 AM").
- Show a loading row in the agent scope dropdown while agents load.
- Add a Scheduled Tasks entry to the collapsed task sidebar (the feature was unreachable without expanding it).
- Gate the sidebar's cross-agent task view behind the schedules feature flag instead of URL params alone.

### UX polish from testers
- Sort the Schedules tab by name so pausing a schedule no longer reorders the list under the cursor.
- Drop success toasts for actions whose outcome is already visible in place; keep error toasts and the Run-now toast.
- Remove Pause/Resume from the overflow menu — the row toggle is the single pause control.
- Default to the all-agents scope when no agent is selected, instead of an empty select-an-agent state.
- Replace hardcoded purple hexes with the `primary-foreground` token and align the success card with the greens used elsewhere.

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npm test` (75/75)
- [ ] Browser pass: modal Escape/backdrop/focus behaviour, menu keyboard nav, Run now → task appears in sidebar, interval schedules hide timezone, Upcoming shows timezone labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR polishes the Scheduled Tasks UI and improves task-list freshness after manual runs.

- Rebuilds schedule dialogs and action menus with Radix primitives for keyboard, focus, and dismissal behavior.
- Corrects cadence, timezone, run-count, sorting, scope, and sidebar displays.
- Invalidates task queries after successful manual triggers and adds feature-flag-aware navigation.
- Adds the required Radix dialog and dropdown-menu dependencies.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex-ui/components/scheduled-tasks/schedule-modals.tsx | Migrates edit and delete flows to the shared Radix dialog while preserving guarded accidental dismissal. |
| agentex-ui/components/scheduled-tasks/all-schedules-list.tsx | Replaces the hand-rolled action menu and corrects interval schedule metadata. |
| agentex-ui/components/scheduled-tasks/scheduled-tasks-page.tsx | Defaults unselected users to all-agent scope and improves loading and stable schedule presentation. |
| agentex-ui/hooks/use-agent-run-schedules.ts | Refreshes task queries after manual triggers and simplifies mutation success feedback. |
| agentex-ui/components/ui/dialog.tsx | Adds a shared Radix dialog wrapper with accessible close behavior. |
| agentex-ui/components/ui/dropdown-menu.tsx | Adds a shared Radix dropdown-menu wrapper supporting keyboard navigation. |
| agentex-ui/lib/schedule-utils.ts | Falls back to raw cron expressions when the cadence picker cannot represent them accurately. |
| agentex-ui/package.json | Adds the Radix dialog and dropdown-menu runtime dependencies reflected in the lockfile. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  U[Scheduled Tasks UI] --> A[Schedule actions]
  A --> M[Radix dialogs and menus]
  A --> S[Schedule mutation]
  S --> Q[Invalidate schedule queries]
  S -->|Manual trigger| T[Invalidate task queries]
  T --> B[Refresh task sidebar]
  U --> D[Correct cadence, timezone, scope, and run displays]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into jerome/uat-sche..."](https://github.com/scaleapi/scale-agentex/commit/666b1f1f1ec5dc258703290cfcaffb906b297e41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52709594)</sub>

<!-- /greptile_comment -->



https://github.com/user-attachments/assets/6665cbbb-fab0-4a93-bd8c-6d9cae827bee

