### PR TITLE
feat(agentex): Slack /agents modal to pick an agent and dispatch

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -2567,6 +2567,21 @@ paths:
                 additionalProperties: true
                 type: object
                 title: Response Slack Commands Slack Commands Post
+  /slack/interactions:
+    post:
+      tags:
+      - Slack
+      summary: Slack interactivity ingress (modals, shortcuts)
+      operationId: slack_interactions_slack_interactions_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Slack Interactions Slack Interactions Post
   /tracker/{tracker_id}:
     get:
       tags:

--- a/agentex/src/api/routes/slack.py
+++ b/agentex/src/api/routes/slack.py
@@ -38,3 +38,19 @@ async def slack_commands(
     form = dict(await request.form())
     headers = {k.lower(): v for k, v in request.headers.items()}
     return await use_case.handle_slash_command(body=body, headers=headers, form=form)
+
+
+@router.post("/interactions", summary="Slack interactivity ingress (modals, shortcuts)")
+async def slack_interactions(
+    request: Request,
+    background: BackgroundTasks,
+    use_case: DSlackGatewayUseCase,
+) -> dict:
+    # Interactions are form-encoded with a JSON `payload` field. Raw body first (for
+    # signature verification), then the form. The turn runs out-of-band like events.
+    body = await request.body()
+    form = dict(await request.form())
+    headers = {k.lower(): v for k, v in request.headers.items()}
+    return await use_case.handle_interaction(
+        body=body, headers=headers, form=form, background=background
+    )

--- a/agentex/src/domain/use_cases/slack_gateway_use_case.py
+++ b/agentex/src/domain/use_cases/slack_gateway_use_case.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
+import json
 import os
 import re
 import time
@@ -227,6 +228,63 @@ def _agents_list_response(agents) -> dict:
     return {"response_type": "ephemeral", "text": text}
 
 
+_AGENTS_MODAL_CALLBACK = "agents_modal"
+
+
+def _build_agents_modal(agents, channel_id: str) -> dict:
+    """Block Kit view for the /agents picker: a dropdown of invocable agents + a
+    message box. ``channel_id`` rides in ``private_metadata`` so the view_submission
+    knows where to post. The selected value is the agent name, which the submission
+    handler feeds into the SAME selector->target resolution as an @mention."""
+    options = [
+        {
+            "text": {"type": "plain_text", "text": a.name[:75]},
+            "value": a.name[:75],
+            **(
+                {"description": {"type": "plain_text", "text": a.description[:75]}}
+                if getattr(a, "description", None)
+                else {}
+            ),
+        }
+        for a in agents[:100]  # Slack static_select caps at 100 options
+    ]
+    return {
+        "type": "modal",
+        "callback_id": _AGENTS_MODAL_CALLBACK,
+        "private_metadata": channel_id,
+        "title": {"type": "plain_text", "text": "Ask an agent"},
+        "submit": {"type": "plain_text", "text": "Send"},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "blocks": [
+            {
+                "type": "input",
+                "block_id": "agent_block",
+                "label": {"type": "plain_text", "text": "Agent"},
+                "element": {
+                    "type": "static_select",
+                    "action_id": "agent_select",
+                    "placeholder": {"type": "plain_text", "text": "Choose an agent"},
+                    "options": options,
+                },
+            },
+            {
+                "type": "input",
+                "block_id": "message_block",
+                "label": {"type": "plain_text", "text": "Message"},
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "message_input",
+                    "multiline": True,
+                    "placeholder": {
+                        "type": "plain_text",
+                        "text": "What do you want the agent to do?",
+                    },
+                },
+            },
+        ],
+    }
+
+
 def _agent_text(messages) -> str | None:
     """Join agent-authored text content from a list of task messages."""
     parts = []
@@ -358,11 +416,129 @@ class SlackGatewayUseCase:
 
         command = (form.get("command") or "").strip()
         if command == "/agents":
+            # Open the picker modal; fall back to the plain ephemeral list when we
+            # can't (no trigger_id, no agents, or views.open failed).
+            trigger_id = form.get("trigger_id") or ""
+            channel_id = form.get("channel_id") or ""
+            if trigger_id and await self._open_agents_modal(trigger_id, channel_id):
+                return {}  # empty 200: Slack shows nothing; the modal is already open
             return _agents_list_response(await self._list_agents())
         return {
             "response_type": "ephemeral",
             "text": f"Unsupported command: {command or '(none)'}",
         }
+
+    async def handle_interaction(
+        self,
+        *,
+        body: bytes,
+        headers: dict[str, str],
+        form: dict[str, Any],
+        background: BackgroundTasks,
+    ) -> dict:
+        """Handle a Slack interactivity POST. v1 handles the /agents modal's
+        ``view_submission`` (see _submit_agents_modal). Payload is form-encoded with a
+        JSON ``payload`` field; the signature covers the raw body (verified like slash
+        commands)."""
+        try:
+            payload = json.loads(form.get("payload") or "{}")
+        except (TypeError, ValueError):
+            return {}
+
+        if _DEV_SKIP_VERIFY:
+            logger.warning(
+                "SLACK_GATEWAY_DEV_SKIP_VERIFY is ON — skipping interaction signature "
+                "verification. DEV ONLY."
+            )
+        else:
+            api_app_id = payload.get("api_app_id") or ""
+            signing_secret = await self._fetch_signing_secret(api_app_id)
+            if not verify_signature(
+                signing_secret,
+                headers.get("x-slack-request-timestamp", ""),
+                headers.get("x-slack-signature", ""),
+                body,
+            ):
+                logger.warning(
+                    "slack interaction signature failed for app %s", api_app_id
+                )
+                return {}
+
+        if payload.get("type") != "view_submission":
+            return {}
+        view = payload.get("view") or {}
+        if view.get("callback_id") == _AGENTS_MODAL_CALLBACK:
+            return await self._submit_agents_modal(payload, view, background)
+        return {}  # not ours — ack empty
+
+    async def _submit_agents_modal(
+        self, payload: dict, view: dict, background: BackgroundTasks
+    ) -> dict:
+        """/agents modal submission: post a breadcrumb (records the request + anchors
+        the reply thread) then build the SAME InboundSlack an @mention would and run
+        the turn out-of-band."""
+        values = (view.get("state") or {}).get("values") or {}
+        agent_sel = (values.get("agent_block") or {}).get("agent_select") or {}
+        agent = (agent_sel.get("selected_option") or {}).get("value") or ""
+        message = ((values.get("message_block") or {}).get("message_input") or {}).get(
+            "value"
+        ) or ""
+        channel = view.get("private_metadata") or ""
+        user = (payload.get("user") or {}).get("id") or ""
+        team = (payload.get("team") or {}).get("id") or ""
+
+        if not (agent and message and channel):
+            return {
+                "response_action": "errors",
+                "errors": {"message_block": "Pick an agent and enter a message."},
+            }
+
+        # Breadcrumb: reads like the equivalent @mention, records who asked, and its ts
+        # anchors the reply thread. Posted by the bot, so normalize() ignores it (no
+        # second turn). If the bot isn't in the channel the post fails — the modal can
+        # be launched from anywhere, but we can only post where the bot is a member.
+        command = f"@agentex {agent} {message}"
+        crumb = await self._slack_api(
+            "chat.postMessage",
+            {
+                "channel": channel,
+                "text": command,  # notification / accessibility fallback
+                "blocks": [
+                    {"type": "section", "text": {"type": "mrkdwn", "text": command}},
+                    # Attribution as a context block — Slack renders it as a small,
+                    # muted footer rather than inline body text.
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": f"via <@{user}> through *{agent}*",
+                            }
+                        ],
+                    },
+                ],
+            },
+        )
+        if not crumb.get("ok"):
+            logger.warning("[slack] breadcrumb post failed: %s", crumb.get("error"))
+            return {
+                "response_action": "errors",
+                "errors": {
+                    "message_block": "I couldn't post in that channel — invite me to "
+                    "it (`/invite`), then try again."
+                },
+            }
+
+        inbound = InboundSlack(
+            team_id=team,
+            channel=channel,
+            user=user,
+            text=f"{agent} {message}",  # mirrors an @mention so _resolve_target matches
+            thread_ts=crumb.get("ts") or "",
+            selector=agent,
+        )
+        background.add_task(self._run_turn, inbound)
+        return {}  # empty 200 closes the modal
 
     async def _run_turn(self, inbound: InboundSlack) -> None:
         try:
@@ -803,6 +979,40 @@ class SlackGatewayUseCase:
             )
         else:
             logger.warning("[slack] chat.postMessage failed: %s", body.get("error"))
+
+    async def _slack_api(self, method: str, payload: dict) -> dict:
+        """POST to the Slack Web API with the bot token; returns the parsed body.
+        Returns ``{"ok": False, ...}`` (never raises) when the token is unset or the
+        request fails, so callers can branch on ``ok`` uniformly."""
+        token = await self._fetch_bot_token()
+        if not token:
+            logger.info("[slack] %s skipped: no bot token", method)
+            return {"ok": False, "error": "no_bot_token"}
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.post(
+                    f"https://slack.com/api/{method}",
+                    headers={"Authorization": f"Bearer {token}"},
+                    json=payload,
+                )
+            return resp.json()
+        except Exception:
+            logger.warning("[slack] %s request failed", method, exc_info=True)
+            return {"ok": False, "error": "request_failed"}
+
+    async def _open_agents_modal(self, trigger_id: str, channel_id: str) -> bool:
+        """Open the /agents picker modal. Returns False (caller falls back to the plain
+        ephemeral list) when there are no agents or ``views.open`` failed."""
+        agents = await self._list_agents()
+        if not agents:
+            return False
+        body = await self._slack_api(
+            "views.open",
+            {"trigger_id": trigger_id, "view": _build_agents_modal(agents, channel_id)},
+        )
+        if not body.get("ok"):
+            logger.warning("[slack] views.open failed: %s", body.get("error"))
+        return bool(body.get("ok"))
 
 
 DSlackGatewayUseCase = Annotated[SlackGatewayUseCase, Depends(SlackGatewayUseCase)]

--- a/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
+++ b/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
@@ -6,6 +6,7 @@ mocked). No running stack, no golden_agent, no Slack.
 
 import hashlib
 import hmac
+import json
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -1152,12 +1153,183 @@ class TestHandleSlashCommand:
         assert "pr-bot" in resp["text"]
 
     @pytest.mark.asyncio
+    async def test_agents_command_opens_modal_when_trigger_id_present(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(sg, "_DEV_SKIP_VERIFY", True)
+        uc = SlackGatewayUseCase()
+        opened = AsyncMock(return_value=True)
+        monkeypatch.setattr(uc, "_open_agents_modal", opened)
+        resp = await uc.handle_slash_command(
+            body=b"",
+            headers={},
+            form={"command": "/agents", "trigger_id": "TR1", "channel_id": "C1"},
+        )
+        assert resp == {}  # empty 200; the modal opened out of band
+        opened.assert_awaited_once_with("TR1", "C1")
+
+    @pytest.mark.asyncio
+    async def test_agents_command_falls_back_to_list_when_modal_fails(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(sg, "_DEV_SKIP_VERIFY", True)
+        uc = SlackGatewayUseCase()
+        monkeypatch.setattr(uc, "_open_agents_modal", AsyncMock(return_value=False))
+        monkeypatch.setattr(
+            uc,
+            "_list_agents",
+            AsyncMock(
+                return_value=[SimpleNamespace(name="pr-bot", description="Reviews PRs")]
+            ),
+        )
+        resp = await uc.handle_slash_command(
+            body=b"", headers={}, form={"command": "/agents", "trigger_id": "TR1"}
+        )
+        assert resp["response_type"] == "ephemeral"
+        assert "pr-bot" in resp["text"]
+
+    @pytest.mark.asyncio
     async def test_unknown_command_is_reported(self, monkeypatch):
         monkeypatch.setattr(sg, "_DEV_SKIP_VERIFY", True)
         resp = await SlackGatewayUseCase().handle_slash_command(
             body=b"", headers={}, form={"command": "/whoami"}
         )
         assert "Unsupported command" in resp["text"]
+
+
+@pytest.mark.unit
+class TestHandleInteraction:
+    """The /agents modal's view_submission: post a breadcrumb, then build the SAME
+    InboundSlack an @mention would and dispatch the turn (anchored on the breadcrumb)."""
+
+    def _payload(self, agent="golden-agent", message="summarize this"):
+        return {
+            "type": "view_submission",
+            "user": {"id": "U1"},
+            "team": {"id": "T1"},
+            "view": {
+                "callback_id": "agents_modal",
+                "private_metadata": "C1",
+                "state": {
+                    "values": {
+                        "agent_block": {
+                            "agent_select": {"selected_option": {"value": agent}}
+                        },
+                        "message_block": {"message_input": {"value": message}},
+                    }
+                },
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_submission_posts_breadcrumb_and_schedules_turn(self, monkeypatch):
+        monkeypatch.setattr(sg, "_DEV_SKIP_VERIFY", True)
+        uc = SlackGatewayUseCase()
+        api = AsyncMock(return_value={"ok": True, "ts": "1700.5"})
+        monkeypatch.setattr(uc, "_slack_api", api)
+        bg = BackgroundTasks()
+        result = await uc.handle_interaction(
+            body=b"",
+            headers={},
+            form={"payload": json.dumps(self._payload())},
+            background=bg,
+        )
+        assert result == {}  # empty 200 closes the modal
+        # breadcrumb: reconstructed command as the body, attribution as a context footer
+        method, payload = api.await_args.args
+        assert method == "chat.postMessage"
+        assert payload["channel"] == "C1"
+        assert "@agentex golden-agent summarize this" in payload["text"]
+        footer = payload["blocks"][-1]
+        assert footer["type"] == "context"
+        footer_text = footer["elements"][0]["text"]
+        assert "<@U1>" in footer_text and "golden-agent" in footer_text
+        # turn scheduled with an InboundSlack that mirrors an @mention
+        assert len(bg.tasks) == 1
+        inbound = bg.tasks[0].args[0]
+        assert inbound.selector == "golden-agent"
+        assert inbound.text == "golden-agent summarize this"
+        assert inbound.thread_ts == "1700.5"  # reply threads under the breadcrumb
+        assert inbound.channel == "C1"
+        assert inbound.user == "U1"
+
+    @pytest.mark.asyncio
+    async def test_breadcrumb_failure_returns_modal_error(self, monkeypatch):
+        monkeypatch.setattr(sg, "_DEV_SKIP_VERIFY", True)
+        uc = SlackGatewayUseCase()
+        monkeypatch.setattr(
+            uc,
+            "_slack_api",
+            AsyncMock(return_value={"ok": False, "error": "not_in_channel"}),
+        )
+        bg = BackgroundTasks()
+        result = await uc.handle_interaction(
+            body=b"",
+            headers={},
+            form={"payload": json.dumps(self._payload())},
+            background=bg,
+        )
+        assert result["response_action"] == "errors"
+        assert "message_block" in result["errors"]
+        assert len(bg.tasks) == 0  # not-in-channel -> no turn dispatched
+
+    @pytest.mark.asyncio
+    async def test_missing_message_returns_error_without_posting(self, monkeypatch):
+        monkeypatch.setattr(sg, "_DEV_SKIP_VERIFY", True)
+        uc = SlackGatewayUseCase()
+        api = AsyncMock()
+        monkeypatch.setattr(uc, "_slack_api", api)
+        bg = BackgroundTasks()
+        result = await uc.handle_interaction(
+            body=b"",
+            headers={},
+            form={"payload": json.dumps(self._payload(message=""))},
+            background=bg,
+        )
+        assert result["response_action"] == "errors"
+        api.assert_not_awaited()  # no breadcrumb attempted
+        assert len(bg.tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_non_modal_interaction_is_ignored(self, monkeypatch):
+        monkeypatch.setattr(sg, "_DEV_SKIP_VERIFY", True)
+        uc = SlackGatewayUseCase()
+        api = AsyncMock()
+        monkeypatch.setattr(uc, "_slack_api", api)
+        bg = BackgroundTasks()
+        form = {
+            "payload": json.dumps(
+                {"type": "block_actions", "view": {"callback_id": "other"}}
+            )
+        }
+        result = await uc.handle_interaction(
+            body=b"", headers={}, form=form, background=bg
+        )
+        assert result == {}
+        api.assert_not_awaited()
+        assert len(bg.tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_bad_signature_drops(self, monkeypatch):
+        monkeypatch.setattr(sg, "_DEV_SKIP_VERIFY", False)
+        uc = SlackGatewayUseCase()
+        monkeypatch.setattr(uc, "_fetch_signing_secret", AsyncMock(return_value="shh"))
+        api = AsyncMock()
+        monkeypatch.setattr(uc, "_slack_api", api)
+        bg = BackgroundTasks()
+        form = {"payload": json.dumps({"api_app_id": "A1", **self._payload()})}
+        result = await uc.handle_interaction(
+            body=b"whatever",
+            headers={
+                "x-slack-request-timestamp": str(int(time.time())),
+                "x-slack-signature": "v0=bad",
+            },
+            form=form,
+            background=bg,
+        )
+        assert result == {}
+        api.assert_not_awaited()
+        assert len(bg.tasks) == 0
 
     @pytest.mark.asyncio
     async def test_bad_signature_rejected(self, monkeypatch):


### PR DESCRIPTION
## What

`/agents` now opens a **Block Kit modal** (agent dropdown + message box) instead of only returning an ephemeral list. On submit, the gateway files the turn through the **same path as an `@mention`** — so target resolution, dispatch, and reply are identical.

## How it works

1. `/agents` → `handle_slash_command` calls `views.open` with a picker built from `_list_agents()` (falls back to the old ephemeral list if there's no `trigger_id` / no agents / `views.open` fails).
2. Submit → Slack posts a `view_submission` to the new **`POST /slack/interactions`** route → `handle_interaction` → `_submit_agents_modal`.
3. `_submit_agents_modal` posts a **breadcrumb** — `@agentex <agent> <message>` with a context-block footer (`via @user through <agent>`) — which both records the request in the channel and **anchors the reply thread** (its `ts` becomes `thread_ts`).
4. It then builds the **same `InboundSlack` an `@mention` produces** (`selector = agent`, `text = "{agent} {message}"`) and runs `_run_turn`, so nothing downstream changes.

If the bot isn't in the channel the breadcrumb post fails and the modal shows an inline "invite me first" error (no turn dispatched).

## Notes

- Signature-verified like the other Slack endpoints (skipped only under `SLACK_GATEWAY_DEV_SKIP_VERIFY`).
- `openapi.yaml` regenerated to include `/slack/interactions`.

## Config to enable (Slack app)

Interactivity & Shortcuts → **Request URL** = `https://agentex.dev-sgp.scale.com/slack/interactions`, then **reinstall**.

## Testing

`63 passed` in the Slack gateway unit suite (modal open, fallback, submission → breadcrumb + dispatch, not-in-channel error, signature drop); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes `/agents` from an ephemeral list into a Slack modal and adds an interaction endpoint that posts a breadcrumb before dispatching through the existing mention workflow.
- Adds the Block Kit agent picker and modal-submission handling.
- Adds signature verification and the `/slack/interactions` API route.
- Adds unit coverage for modal opening, fallback, submission, errors, and signature rejection.
- The submitted selector is truncated, and breadcrumb posting delays Slack’s interaction acknowledgment.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not safe to merge until modal selections preserve full agent identity and interaction submissions acknowledge Slack before potentially slow network work.

Long agent names can dispatch to the fallback agent, while synchronous breadcrumb posting can exceed Slack’s acknowledgment window and lead users to retry already-dispatched work.

**Files Needing Attention:** agentex/src/domain/use_cases/slack_gateway_use_case.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/slack_gateway_use_case.py | Adds modal construction and dispatch, but truncates target identity and performs a potentially slow API call before acknowledging submission. |
| agentex/src/api/routes/slack.py | Adds the form-encoded Slack interaction ingress and forwards raw request data for signature verification. |
| agentex/tests/unit/use_cases/test_slack_gateway_use_case.py | Covers primary modal flows but does not exercise long agent names or delayed Slack API responses. |
| agentex/openapi.yaml | Documents the new POST /slack/interactions endpoint. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as Slack user
    participant S as Slack
    participant G as Slack gateway
    participant API as Slack Web API
    participant A as Agent turn
    U->>S: /agents
    S->>G: Slash command
    G->>API: views.open
    API-->>U: Agent picker modal
    U->>S: Submit agent and message
    S->>G: POST /slack/interactions
    G->>API: chat.postMessage breadcrumb
    API-->>G: Breadcrumb timestamp
    G-->>S: Acknowledge submission
    G->>A: Background _run_turn
    A->>API: Reply in breadcrumb thread
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20scaleapi%2Fscale-agentex%20PR%20%23404%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=404&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A241%0A**Truncated%20selector%20loses%20agent%20identity**%0A%0AWhen%20an%20agent%20name%20exceeds%2075%20characters%20or%20shares%20its%20first%2075%20characters%20with%20another%20name%2C%20the%20modal%20submits%20the%20truncated%20option%20value%20to%20exact-name%20target%20resolution%2C%20causing%20the%20selected%20agent%20to%20be%20replaced%20by%20the%20fallback%20agent%20or%20become%20indistinguishable.%0A%0A%23%23%23%20Issue%202%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A501-521%0A**Breadcrumb%20blocks%20interaction%20acknowledgment**%0A%0AIf%20%60chat.postMessage%60%20exceeds%20Slack's%20interaction%20acknowledgment%20window%2C%20this%20handler%20waits%20for%20that%20request%20before%20acknowledging%20the%20submission%2C%20causing%20Slack%20to%20report%20a%20failed%20modal%20submission%20even%20when%20the%20breadcrumb%20and%20turn%20subsequently%20succeed%3B%20retrying%20then%20creates%20duplicate%20breadcrumbs%20and%20turns%20because%20this%20path%20has%20no%20idempotency%20guard.%0A%0A%23%23%23%20Issue%203%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A240-250%0A**Slack%20limits%20remain%20magic%20numbers**%0A%0AThe%20new%20modal%20builder%20and%20API%20helper%20embed%20%6075%60%2C%20%60100%60%2C%20and%20%6015%60%20directly%20for%20Slack%20text%2C%20option%2C%20and%20timeout%20constraints.%20Naming%20these%20limits%20as%20descriptive%20variables%20would%20make%20their%20semantics%20explicit%20and%20prevent%20inconsistent%20updates.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=404&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A241%0A**Truncated%20selector%20loses%20agent%20identity**%0A%0AWhen%20an%20agent%20name%20exceeds%2075%20characters%20or%20shares%20its%20first%2075%20characters%20with%20another%20name%2C%20the%20modal%20submits%20the%20truncated%20option%20value%20to%20exact-name%20target%20resolution%2C%20causing%20the%20selected%20agent%20to%20be%20replaced%20by%20the%20fallback%20agent%20or%20become%20indistinguishable.%0A%0A%23%23%23%20Issue%202%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A501-521%0A**Breadcrumb%20blocks%20interaction%20acknowledgment**%0A%0AIf%20%60chat.postMessage%60%20exceeds%20Slack's%20interaction%20acknowledgment%20window%2C%20this%20handler%20waits%20for%20that%20request%20before%20acknowledging%20the%20submission%2C%20causing%20Slack%20to%20report%20a%20failed%20modal%20submission%20even%20when%20the%20breadcrumb%20and%20turn%20subsequently%20succeed%3B%20retrying%20then%20creates%20duplicate%20breadcrumbs%20and%20turns%20because%20this%20path%20has%20no%20idempotency%20guard.%0A%0A%23%23%23%20Issue%203%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A240-250%0A**Slack%20limits%20remain%20magic%20numbers**%0A%0AThe%20new%20modal%20builder%20and%20API%20helper%20embed%20%6075%60%2C%20%60100%60%2C%20and%20%6015%60%20directly%20for%20Slack%20text%2C%20option%2C%20and%20timeout%20constraints.%20Naming%20these%20limits%20as%20descriptive%20variables%20would%20make%20their%20semantics%20explicit%20and%20prevent%20inconsistent%20updates.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=404&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22mc%2Fslack-agents-modal%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mc%2Fslack-agents-modal%22.%0A%0A%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A241%0A**Truncated%20selector%20loses%20agent%20identity**%0A%0AWhen%20an%20agent%20name%20exceeds%2075%20characters%20or%20shares%20its%20first%2075%20characters%20with%20another%20name%2C%20the%20modal%20submits%20the%20truncated%20option%20value%20to%20exact-name%20target%20resolution%2C%20causing%20the%20selected%20agent%20to%20be%20replaced%20by%20the%20fallback%20agent%20or%20become%20indistinguishable.%0A%0A%23%23%23%20Issue%202%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A501-521%0A**Breadcrumb%20blocks%20interaction%20acknowledgment**%0A%0AIf%20%60chat.postMessage%60%20exceeds%20Slack's%20interaction%20acknowledgment%20window%2C%20this%20handler%20waits%20for%20that%20request%20before%20acknowledging%20the%20submission%2C%20causing%20Slack%20to%20report%20a%20failed%20modal%20submission%20even%20when%20the%20breadcrumb%20and%20turn%20subsequently%20succeed%3B%20retrying%20then%20creates%20duplicate%20breadcrumbs%20and%20turns%20because%20this%20path%20has%20no%20idempotency%20guard.%0A%0A%23%23%23%20Issue%203%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A240-250%0A**Slack%20limits%20remain%20magic%20numbers**%0A%0AThe%20new%20modal%20builder%20and%20API%20helper%20embed%20%6075%60%2C%20%60100%60%2C%20and%20%6015%60%20directly%20for%20Slack%20text%2C%20option%2C%20and%20timeout%20constraints.%20Naming%20these%20limits%20as%20descriptive%20variables%20would%20make%20their%20semantics%20explicit%20and%20prevent%20inconsistent%20updates.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=404&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
agentex/src/domain/use_cases/slack_gateway_use_case.py:241
**Truncated selector loses agent identity**

When an agent name exceeds 75 characters or shares its first 75 characters with another name, the modal submits the truncated option value to exact-name target resolution, causing the selected agent to be replaced by the fallback agent or become indistinguishable.

### Issue 2
agentex/src/domain/use_cases/slack_gateway_use_case.py:501-521
**Breadcrumb blocks interaction acknowledgment**

If `chat.postMessage` exceeds Slack's interaction acknowledgment window, this handler waits for that request before acknowledging the submission, causing Slack to report a failed modal submission even when the breadcrumb and turn subsequently succeed; retrying then creates duplicate breadcrumbs and turns because this path has no idempotency guard.

### Issue 3
agentex/src/domain/use_cases/slack_gateway_use_case.py:240-250
**Slack limits remain magic numbers**

The new modal builder and API helper embed `75`, `100`, and `15` directly for Slack text, option, and timeout constraints. Naming these limits as descriptive variables would make their semantics explicit and prevent inconsistent updates.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agentex): Slack /agents modal to pi..."](https://github.com/scaleapi/scale-agentex/commit/364b91d8c02af01ea7cdd6ddbb2c8bd933114716) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53204042)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Store magic numbers as class or instance variables... ([source](https://app.greptile.com/scale-ai/-/custom-context?memory=002e0051-41ad-46c1-9098-47433c580150))

**Learned From**
[scaleapi/scaleapi#126388](https://github.com/scaleapi/scaleapi/pull/126388)

<!-- /greptile_comment -->