### PR TITLE
fix(agentex): Slack gateway — empty ack body + clearer breadcrumb attribution

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -2563,10 +2563,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                additionalProperties: true
-                type: object
-                title: Response Slack Commands Slack Commands Post
+              schema: {}
   /slack/interactions:
     post:
       tags:
@@ -2578,10 +2575,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                additionalProperties: true
-                type: object
-                title: Response Slack Interactions Slack Interactions Post
+              schema: {}
   /tracker/{tracker_id}:
     get:
       tags:

--- a/agentex/src/api/routes/slack.py
+++ b/agentex/src/api/routes/slack.py
@@ -6,11 +6,20 @@ is the auth, verified in the use case against the app's signing secret from the
 secrets microservice. Delegates all logic to SlackGatewayUseCase.
 """
 
-from fastapi import APIRouter, BackgroundTasks, Request
+from fastapi import APIRouter, BackgroundTasks, Request, Response
+from fastapi.responses import JSONResponse
 
 from src.domain.use_cases.slack_gateway_use_case import DSlackGatewayUseCase
 
 router = APIRouter(prefix="/slack", tags=["Slack"])
+
+
+def _slack_ack(result: dict) -> Response:
+    """Serialize a slash-command / interaction response for Slack. An ack-only result
+    (empty dict) becomes a truly EMPTY 200 body — Slack renders a bare ``{}`` JSON body
+    as a stray message, so "show nothing" must send no body, not ``{}``. A non-empty
+    result (ephemeral message / response_action) is sent as JSON."""
+    return JSONResponse(result) if result else Response(status_code=200)
 
 
 @router.post("/events", summary="Slack Events API ingress for the @agent app")
@@ -31,13 +40,15 @@ async def slack_events(
 async def slack_commands(
     request: Request,
     use_case: DSlackGatewayUseCase,
-) -> dict:
+) -> Response:
     # Slash commands are application/x-www-form-urlencoded, not JSON. Read the raw
     # body first (needed for signature verification), then parse the form.
     body = await request.body()
     form = dict(await request.form())
     headers = {k.lower(): v for k, v in request.headers.items()}
-    return await use_case.handle_slash_command(body=body, headers=headers, form=form)
+    return _slack_ack(
+        await use_case.handle_slash_command(body=body, headers=headers, form=form)
+    )
 
 
 @router.post("/interactions", summary="Slack interactivity ingress (modals, shortcuts)")
@@ -45,12 +56,14 @@ async def slack_interactions(
     request: Request,
     background: BackgroundTasks,
     use_case: DSlackGatewayUseCase,
-) -> dict:
+) -> Response:
     # Interactions are form-encoded with a JSON `payload` field. Raw body first (for
     # signature verification), then the form. The turn runs out-of-band like events.
     body = await request.body()
     form = dict(await request.form())
     headers = {k.lower(): v for k, v in request.headers.items()}
-    return await use_case.handle_interaction(
-        body=body, headers=headers, form=form, background=background
+    return _slack_ack(
+        await use_case.handle_interaction(
+            body=body, headers=headers, form=form, background=background
+        )
     )

--- a/agentex/src/domain/use_cases/slack_gateway_use_case.py
+++ b/agentex/src/domain/use_cases/slack_gateway_use_case.py
@@ -531,7 +531,7 @@ class SlackGatewayUseCase:
                         "elements": [
                             {
                                 "type": "mrkdwn",
-                                "text": f"via <@{user}> through *{agent}*",
+                                "text": f"<@{user}> asked *{agent}*",
                             }
                         ],
                     },

--- a/agentex/tests/unit/api/test_slack_routes.py
+++ b/agentex/tests/unit/api/test_slack_routes.py
@@ -1,0 +1,23 @@
+"""Slack route ack helper: an ack-only result (empty dict) must be a TRULY EMPTY 200
+body — Slack renders a bare ``{}`` JSON body as a stray message, so "show nothing" has
+to send no body, not ``{}``. A non-empty result is sent as JSON."""
+
+import json
+
+import pytest
+from fastapi.responses import JSONResponse
+from src.api.routes.slack import _slack_ack
+
+
+@pytest.mark.unit
+class TestSlackAck:
+    def test_empty_result_is_empty_200_body(self):
+        resp = _slack_ack({})
+        assert resp.status_code == 200
+        assert resp.body == b""  # not b"{}" — nothing for Slack to render
+
+    def test_non_empty_result_is_json(self):
+        payload = {"response_type": "ephemeral", "text": "hi"}
+        resp = _slack_ack(payload)
+        assert isinstance(resp, JSONResponse)
+        assert json.loads(resp.body) == payload


### PR DESCRIPTION
Two small Slack-gateway polish fixes.

## `{}` stray message
Slack renders a bare `{}` JSON body as a **stray message** in the channel. The ack-only responses (modal opened, `view_submission` close, ignored interactions) were returning `{}`, so Slack posted junk. Added a `_slack_ack` helper: an empty result → a **truly empty 200 body**; a non-empty result → JSON as before. Applied to `/slack/commands` and `/slack/interactions` (events keep their JSON — the `url_verification` challenge needs it, and events aren't user-facing).

## Breadcrumb wording
The `/agents` breadcrumb footer said `via <@user> through *agent*` — "via" and "through" are synonyms back-to-back, which reads as word soup. Now: **`<@user> asked *agent*`** (e.g. "@michaelchou asked **golden-agent**").

## Testing
`_slack_ack` unit test (empty → empty 200 body, non-empty → JSON); full Slack gateway suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes Slack command and interaction acknowledgements so empty results produce a truly empty HTTP 200 response while non-empty results remain JSON, and clarifies modal breadcrumb attribution.

- Adds a shared Slack acknowledgement response helper and focused unit coverage.
- Applies empty-body acknowledgement handling to slash-command and interaction routes.
- Updates the generated OpenAPI artifact for the changed response annotations.
- Rewords the `/agents` breadcrumb footer without changing its identity or routing behavior.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code failure identified.

All current slash-command and interaction return paths align with the new empty-versus-JSON acknowledgement behavior, and the breadcrumb change is presentation-only.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex/src/api/routes/slack.py | Introduces `_slack_ack` and consistently maps all current empty handler results to bodyless 200 responses while retaining JSON for actionable Slack payloads. |
| agentex/src/domain/use_cases/slack_gateway_use_case.py | Rewords the modal breadcrumb attribution; interpolation, identity selection, and dispatch behavior remain unchanged. |
| agentex/tests/unit/api/test_slack_routes.py | Directly verifies the helper’s empty-body and non-empty JSON serialization paths. |
| agentex/openapi.yaml | Reflects the generated schema resulting from the routes’ explicit `Response` return type. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agentex): Slack gateway — empty ack ..."](https://github.com/scaleapi/scale-agentex/commit/734cf797df7a8faf9651694a96f65d49d6f58877) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54026361)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agentex external gateways and protocol boundaries](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/backend-integrations.md)
- Knowledge Base — [Backend API and request pipeline](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/backend-api-and-request-pipeline.md)
- Knowledge Base — [Repository Operations and Delivery](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/repository-operations-and-delivery.md)
</details>

<!-- /greptile_comment -->