### PR TITLE
fix(ui): manually created tasks render as "Unnamed task" in the sidebar

### DIFF
--- a/agentex-ui/components/primary-content/prompt-input.tsx
+++ b/agentex-ui/components/primary-content/prompt-input.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/hooks/use-safe-search-params';
 import { useSendMessage } from '@/hooks/use-task-messages';
 import { useTask } from '@/hooks/use-tasks';
+import { deriveTaskDisplayName } from '@/lib/task-utils';
 import { TaskStatusEnum } from '@/lib/types';
 
 type PromptInputProps = {
@@ -139,6 +140,7 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
           description: prompt,
           content: currentPrompt,
         },
+        task_metadata: { display_name: deriveTaskDisplayName(prompt) },
       });
       currentTaskId = task.id;
       updateParams({ [SearchParamKey.TASK_ID]: currentTaskId });

--- a/agentex-ui/hooks/use-create-task.test.tsx
+++ b/agentex-ui/hooks/use-create-task.test.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import { agentRPCNonStreaming } from 'agentex/lib';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useCreateTask } from './use-create-task';
+
+import type AgentexSDK from 'agentex';
+
+vi.mock('agentex/lib', () => ({
+  agentRPCNonStreaming: vi.fn(),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function mockCreatedTask(task: Record<string, unknown>) {
+  vi.mocked(agentRPCNonStreaming).mockResolvedValue({
+    jsonrpc: '2.0',
+    id: 'rpc-1',
+    result: task,
+    error: null,
+  } as never);
+}
+
+describe('useCreateTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards task_metadata in the task/create request body', async () => {
+    mockCreatedTask({
+      id: 'task-1',
+      name: null,
+      task_metadata: { display_name: 'say hello' },
+    });
+    const agentexClient = {} as unknown as AgentexSDK;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useCreateTask({ agentexClient }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        agentName: 'my-agent',
+        params: { description: 'say hello', content: 'say hello' },
+        task_metadata: { display_name: 'say hello' },
+      });
+    });
+
+    expect(agentRPCNonStreaming).toHaveBeenCalledWith(
+      agentexClient,
+      { agentName: 'my-agent' },
+      'task/create',
+      {
+        params: { description: 'say hello', content: 'say hello' },
+        task_metadata: { display_name: 'say hello' },
+      }
+    );
+  });
+
+  it('sends null task_metadata when none is provided', async () => {
+    mockCreatedTask({ id: 'task-2', name: null, task_metadata: null });
+    const agentexClient = {} as unknown as AgentexSDK;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useCreateTask({ agentexClient }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        agentName: 'my-agent',
+        params: { description: 'say hello' },
+      });
+    });
+
+    expect(agentRPCNonStreaming).toHaveBeenCalledWith(
+      agentexClient,
+      { agentName: 'my-agent' },
+      'task/create',
+      {
+        params: { description: 'say hello' },
+        task_metadata: null,
+      }
+    );
+  });
+});

--- a/agentex-ui/hooks/use-create-task.ts
+++ b/agentex-ui/hooks/use-create-task.ts
@@ -78,6 +78,7 @@ export function updateTaskInInfiniteQuery(
 type CreateTaskParams = {
   agentName: string;
   params?: Record<string, unknown>;
+  task_metadata?: Record<string, unknown>;
 };
 
 /**
@@ -101,6 +102,7 @@ export function useCreateTask({
     mutationFn: async ({
       agentName,
       params,
+      task_metadata,
     }: CreateTaskParams): Promise<Task> => {
       const response = await agentRPCNonStreaming(
         agentexClient,
@@ -108,6 +110,7 @@ export function useCreateTask({
         'task/create',
         {
           params: params ?? {},
+          task_metadata: task_metadata ?? null,
         }
       );
 

--- a/agentex-ui/lib/task-utils.test.ts
+++ b/agentex-ui/lib/task-utils.test.ts
@@ -73,6 +73,18 @@ describe('deriveTaskDisplayName', () => {
     expect(deriveTaskDisplayName(prompt)).toBe('a'.repeat(80));
   });
 
+  it('keeps an astral character whole at the truncation boundary', () => {
+    // '😀' is two UTF-16 units; a unit-based slice(0, 80) would cut it in
+    // half here, leaving a lone surrogate that Postgres JSONB rejects.
+    const prompt = 'a'.repeat(79) + '😀 rest of the prompt';
+    expect(deriveTaskDisplayName(prompt)).toBe('a'.repeat(79) + '😀');
+  });
+
+  it('counts astral characters as single characters when truncating', () => {
+    const prompt = '😀'.repeat(100);
+    expect(deriveTaskDisplayName(prompt)).toBe('😀'.repeat(80));
+  });
+
   it('produces a label createTaskName resolves for a UI-created task', () => {
     // Writer/reader contract: a task shaped like the prompt-input writer's
     // output (display_name set, name null) must not render as "Unnamed task".

--- a/agentex-ui/lib/task-utils.test.ts
+++ b/agentex-ui/lib/task-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { createTaskName } from '@/lib/task-utils';
+import { createTaskName, deriveTaskDisplayName } from '@/lib/task-utils';
 
 import type { TaskListResponse } from 'agentex/resources';
 
@@ -50,5 +50,38 @@ describe('createTaskName', () => {
     } as unknown as TaskListResponse.TaskListResponseItem;
 
     expect(createTaskName(task)).toBe('Unnamed task');
+  });
+});
+
+describe('deriveTaskDisplayName', () => {
+  it('returns a short prompt unchanged', () => {
+    expect(deriveTaskDisplayName('say hello')).toBe('say hello');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(deriveTaskDisplayName('  say hello \n')).toBe('say hello');
+  });
+
+  it('collapses internal whitespace and newlines to single spaces', () => {
+    expect(deriveTaskDisplayName('summarize\nthis   report\tplease')).toBe(
+      'summarize this report please'
+    );
+  });
+
+  it('truncates to 80 characters', () => {
+    const prompt = 'a'.repeat(100);
+    expect(deriveTaskDisplayName(prompt)).toBe('a'.repeat(80));
+  });
+
+  it('produces a label createTaskName resolves for a UI-created task', () => {
+    // Writer/reader contract: a task shaped like the prompt-input writer's
+    // output (display_name set, name null) must not render as "Unnamed task".
+    const task = {
+      id: '123',
+      name: null,
+      task_metadata: { display_name: deriveTaskDisplayName('say hello') },
+    } as unknown as TaskListResponse.TaskListResponseItem;
+
+    expect(createTaskName(task)).toBe('say hello');
   });
 });

--- a/agentex-ui/lib/task-utils.ts
+++ b/agentex-ui/lib/task-utils.ts
@@ -16,7 +16,10 @@ export function isScheduledTask(
  * a globally-unique get-or-create idempotency key, not a label.
  */
 export function deriveTaskDisplayName(prompt: string): string {
-  return prompt.trim().replace(/\s+/g, ' ').slice(0, 80);
+  // Truncate by code points, not UTF-16 units: a unit-based slice can split a
+  // surrogate pair, and Postgres rejects lone surrogates in JSONB, failing the
+  // whole task/create request.
+  return Array.from(prompt.trim().replace(/\s+/g, ' ')).slice(0, 80).join('');
 }
 
 export function createTaskName(

--- a/agentex-ui/lib/task-utils.ts
+++ b/agentex-ui/lib/task-utils.ts
@@ -9,6 +9,16 @@ export function isScheduledTask(
   return typeof scheduleId === 'string' && scheduleId.length > 0;
 }
 
+/**
+ * Derives the task_metadata.display_name written at task creation from the
+ * user's prompt. This is the writer-side counterpart of createTaskName, which
+ * reads display_name first — do not write the prompt into task.name, which is
+ * a globally-unique get-or-create idempotency key, not a label.
+ */
+export function deriveTaskDisplayName(prompt: string): string {
+  return prompt.trim().replace(/\s+/g, ' ').slice(0, 80);
+}
+
 export function createTaskName(
   task: TaskListResponse.TaskListResponseItem
 ): string {


### PR DESCRIPTION
## Summary

Every task created by typing into the prompt box renders as **"Unnamed task"** in the sidebar. The message and reply are fine — only the label is wrong. Scheduled tasks are unaffected.

#377 made the list-tasks response a lean `TaskSummary` that omits `params` (correctly — `params` is the arbitrary caller-supplied create-time payload and can carry sensitive material, so it must not be exposed in bulk). The sidebar's label resolver was repointed accordingly, from `params.description` to `task_metadata.display_name` → `task.name`. But the **writer** was never updated to match: the prompt box still created tasks with only `params.description`, which the sidebar can no longer see, so the label fell all the way through to the default.

## Fix

Frontend-only — the backend already accepts and persists `task_metadata` on `task/create` and returns it in both the create and list responses:

- `prompt-input.tsx` now writes the label the resolver reads first: `task_metadata: { display_name: deriveTaskDisplayName(prompt) }`.
- `deriveTaskDisplayName` (in `task-utils.ts`, next to the reader) trims, collapses whitespace/newlines, and truncates to 80 chars.
- `useCreateTask` now plumbs `task_metadata` through to the RPC body; previously anything besides `agentName`/`params` was silently dropped.

The label renders immediately on create (the optimistic cache insert uses the create response, which carries `task_metadata`) and correctly after reload (the list response includes `task_metadata`).

**Deliberately not used: `task.name`.** It looks like the obvious fix given the resolver's fallback, but `name` is a globally-unique get-or-create idempotency key: `task/create` with an existing name returns that task (and can overwrite its params). Writing prompts into it would silently merge unrelated conversations — a data-correctness bug worse than the cosmetic one being fixed.

**Trade-off, stated explicitly:** this intentionally publishes a normalized 80-char prefix of the prompt into `task_metadata`, which the broadly-scoped list response includes. That is strictly less exposure than pre-#377 behavior (full `params`, including the full prompt, in every list item), and it is the same mechanism the scheduler already uses to title tasks — but `display_name` should be treated as a public-ish display field, and nothing sensitive should ever be auto-derived into it beyond this.

## Tests

- `task-utils.test.ts`: unit coverage for `deriveTaskDisplayName`, plus a writer/reader contract test — a task shaped like the prompt-box writer's output must not resolve to "Unnamed task". The absence of exactly this test is how the writer and reader drifted apart unnoticed.
- `use-create-task.test.tsx` (new): asserts the mutation forwards `task_metadata` in the `task/create` request body, and sends `null` when omitted.

## Not addressed here

- Tasks created after #377 with null `task_metadata` keep their default label (no backfill; cosmetic).
- The stock notebook template in the Python SDK repo sets `name` (an idempotency key) as its only human-visible identifier, which now surfaces in the sidebar as `<uuid>-task`; fixing that to also set `display_name` is a follow-up in that repo.

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` — all green (82 tests, 7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns manually created task labels with the sidebar’s metadata-based reader.

- Derives a normalized display name from the submitted prompt.
- Forwards task metadata through the task-creation hook.
- Adds coverage for metadata forwarding and task-name normalization.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agentex-ui/components/primary-content/prompt-input.tsx | Adds a normalized prompt-derived display name to newly created task metadata. |
| agentex-ui/hooks/use-create-task.ts | Extends task creation to forward optional task metadata to the RPC. |
| agentex-ui/lib/task-utils.ts | Adds the display-name normalization and truncation helper. |
| agentex-ui/hooks/use-create-task.test.tsx | Verifies task metadata is forwarded and omitted metadata is sent as null. |
| agentex-ui/lib/task-utils.test.ts | Covers normalization, code-point truncation, and the writer/reader naming contract. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant Input as PromptInput
  participant Hook as useCreateTask
  participant API as task/create
  participant Sidebar
  User->>Input: Submit prompt
  Input->>Input: Derive display_name
  Input->>Hook: params + task_metadata
  Hook->>API: Create task
  API-->>Hook: Task with task_metadata
  Hook-->>Sidebar: Seed task cache
  Sidebar->>Sidebar: Resolve display_name
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): truncate display\_name by code p..."](https://github.com/scaleapi/scale-agentex/commit/01bfb4faab8d16ef2fb6926d983d5ebe6fc3d25f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54461260)</sub>

**Context used:**

- Knowledge Base — [Frontend task experience](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/frontend-task-experience.md)
- Knowledge Base — [Agentex shared frontend UI](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/frontend-shared-ui.md)

<!-- /greptile_comment -->