### PR TITLE
fix(ui): thinking indicator never clears on a failed task

### DIFF
--- a/agentex-ui/components/primary-content/prompt-input.tsx
+++ b/agentex-ui/components/primary-content/prompt-input.tsx
@@ -21,8 +21,7 @@ import {
 } from '@/hooks/use-safe-search-params';
 import { useSendMessage } from '@/hooks/use-task-messages';
 import { useTask } from '@/hooks/use-tasks';
-import { deriveTaskDisplayName } from '@/lib/task-utils';
-import { TaskStatusEnum } from '@/lib/types';
+import { deriveTaskDisplayName, isTaskEnded } from '@/lib/task-utils';
 
 type PromptInputProps = {
   prompt: string;
@@ -65,7 +64,7 @@ export function PromptInput({ prompt, setPrompt }: PromptInputProps) {
 
   const isTaskTerminal = useMemo(() => {
     if (!taskID || !task) return false;
-    return task.status != null && task.status !== TaskStatusEnum.RUNNING;
+    return isTaskEnded(task.status);
   }, [taskID, task]);
 
   const handleSetJson = useCallback(

--- a/agentex-ui/components/task-messages/task-messages.test.tsx
+++ b/agentex-ui/components/task-messages/task-messages.test.tsx
@@ -1,0 +1,79 @@
+import { createRef } from 'react';
+
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TaskMessages } from './task-messages';
+
+import type { TaskMessage } from 'agentex/resources';
+
+const useTaskMessagesMock = vi.fn();
+const useTaskMock = vi.fn();
+
+vi.mock('@/components/providers', () => ({
+  useAgentexClient: () => ({ agentexClient: {}, sgpAppURL: '' }),
+}));
+vi.mock('@/hooks/use-safe-search-params', () => ({
+  useSafeSearchParams: () => ({ agentName: 'my-agent' }),
+}));
+vi.mock('@/hooks/use-agents', () => ({
+  useAgents: () => ({ data: [] }),
+}));
+vi.mock('@/hooks/use-task-messages', () => ({
+  useTaskMessages: () => useTaskMessagesMock(),
+}));
+vi.mock('@/hooks/use-tasks', () => ({
+  useTask: () => useTaskMock(),
+}));
+
+/** What a failed turn actually leaves behind: a user message, no reply. */
+const USER_MESSAGE = {
+  id: 'user-1',
+  task_id: 'task-1',
+  content: { type: 'text', author: 'user', content: 'hello' },
+  streaming_status: 'DONE',
+  created_at: '2026-08-24T00:00:00.000Z',
+  updated_at: '2026-08-24T00:00:00.000Z',
+} as unknown as TaskMessage;
+
+function renderForTaskStatus(status: string) {
+  useTaskMessagesMock.mockReturnValue({
+    messages: [USER_MESSAGE],
+    // What the subscription writes on a cold load — no client-local error.
+    rpcStatus: 'success',
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  });
+  useTaskMock.mockReturnValue({ data: { id: 'task-1', status } });
+
+  return render(
+    <TaskMessages
+      taskId="task-1"
+      headerRef={createRef<HTMLDivElement>()}
+      scrollContainerRef={createRef<HTMLDivElement>()}
+    />
+  );
+}
+
+// ShimmeringText renders one span per character, so query the concatenated text.
+const THINKING = 'Thinking ...';
+
+describe('TaskMessages thinking indicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows while a running task has no reply yet', () => {
+    const { container } = renderForTaskStatus('RUNNING');
+    expect(container.textContent).toContain(THINKING);
+  });
+
+  it.each(['FAILED', 'CANCELED', 'TERMINATED', 'TIMED_OUT', 'COMPLETED'])(
+    'hides on a %s task loaded with no client-local error state',
+    status => {
+      const { container } = renderForTaskStatus(status);
+      expect(container.textContent).not.toContain(THINKING);
+    }
+  );
+});

--- a/agentex-ui/components/task-messages/task-messages.tsx
+++ b/agentex-ui/components/task-messages/task-messages.tsx
@@ -22,6 +22,8 @@ import { ShimmeringText } from '@/components/ui/shimmering-text';
 import { useAgents } from '@/hooks/use-agents';
 import { useSafeSearchParams } from '@/hooks/use-safe-search-params';
 import { useTaskMessages } from '@/hooks/use-task-messages';
+import { useTask } from '@/hooks/use-tasks';
+import { isTaskEnded } from '@/lib/task-utils';
 
 import type {
   TaskMessage,
@@ -34,6 +36,7 @@ type TaskMessagesProps = {
   headerRef: React.RefObject<HTMLDivElement | null>;
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
 };
+
 type MessagePair = {
   id: string;
   userMessage: TaskMessage | null;
@@ -71,6 +74,7 @@ function TaskMessagesImpl({
     hasNextPage,
     isFetchingNextPage,
   } = useTaskMessages({ agentexClient, taskId });
+  const { data: task } = useTask({ agentexClient, taskId });
 
   const toolCallIdToResponseMap = useMemo<
     Map<string, TaskMessage & { content: ToolResponseContent }>
@@ -153,6 +157,9 @@ function TaskMessagesImpl({
     if (messagePairs.length === 0) return false;
     if (rpcStatus !== 'pending' && rpcStatus !== 'success') return false;
 
+    // Only a running task can be working on a reply.
+    if (isTaskEnded(task?.status)) return false;
+
     const lastPair = messagePairs[messagePairs.length - 1]!;
 
     // No agent messages yet — waiting for first response
@@ -178,7 +185,7 @@ function TaskMessagesImpl({
     // Last message is a completed tool_request, tool_response, reasoning, or data
     // with no following text — agent is thinking about the next step
     return true;
-  }, [messagePairs, rpcStatus, pendingToolCallIds]);
+  }, [messagePairs, rpcStatus, pendingToolCallIds, task?.status]);
 
   // Measure container height for last-pair min-height
   useEffect(() => {

--- a/agentex-ui/lib/task-utils.test.ts
+++ b/agentex-ui/lib/task-utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
-import { createTaskName, deriveTaskDisplayName } from '@/lib/task-utils';
+import {
+  createTaskName,
+  deriveTaskDisplayName,
+  isTaskEnded,
+} from '@/lib/task-utils';
 
 import type { TaskListResponse } from 'agentex/resources';
 
@@ -95,5 +99,23 @@ describe('deriveTaskDisplayName', () => {
     } as unknown as TaskListResponse.TaskListResponseItem;
 
     expect(createTaskName(task)).toBe('say hello');
+  });
+});
+
+describe('isTaskEnded', () => {
+  it('is false while the task is running', () => {
+    expect(isTaskEnded('RUNNING')).toBe(false);
+  });
+
+  it.each(['FAILED', 'CANCELED', 'TERMINATED', 'TIMED_OUT', 'COMPLETED'])(
+    'is true for %s',
+    status => {
+      expect(isTaskEnded(status as never)).toBe(true);
+    }
+  );
+
+  it('treats an unknown status as not ended', () => {
+    expect(isTaskEnded(null)).toBe(false);
+    expect(isTaskEnded(undefined)).toBe(false);
   });
 });

--- a/agentex-ui/lib/task-utils.ts
+++ b/agentex-ui/lib/task-utils.ts
@@ -1,3 +1,6 @@
+import { TaskStatusEnum } from '@/lib/types';
+import type { TaskStatus } from '@/lib/types';
+
 import type { TaskListResponse } from 'agentex/resources';
 
 const LEGACY_SCHEDULED_MESSAGE_PREFIX = 'Scheduled Message: ';
@@ -38,4 +41,14 @@ export function createTaskName(
   }
 
   return 'Unnamed task';
+}
+
+/**
+ * Whether a task has stopped — it failed, was cancelled, timed out, or
+ * finished. RUNNING is the only status meaning work may still happen.
+ *
+ * An unset status means "not known yet", which is not the same as ended.
+ */
+export function isTaskEnded(status: TaskStatus | null | undefined): boolean {
+  return status != null && status !== TaskStatusEnum.RUNNING;
 }


### PR DESCRIPTION
## Problem

Opening a task whose turn failed shows "Thinking ..." forever. The error toast fires, but the thread still reads as though the agent were working. It happens in two ways:

- the task fails during the current session, and
- a previously-failed task is opened or reloaded, with no client-local error state at all.

https://github.com/user-attachments/assets/fdffb999-92e3-4f68-a560-564007c1d669

## Cause

`shouldShowThinkingForLastPair` decided purely from this client's in-session RPC state and the message list. On a cold load neither mentions the failure: `rpcStatus` starts `'idle'`, the subscription's first `onMessagesChange` writes `'success'`, and a failed turn leaves a user message with no agent message — so the check fell into its "waiting for first response" branch and returned `true` indefinitely.

The UI already knew the task had failed; the indicator never consulted it.

## Fix

Consult the task's own status, the authoritative signal available in both cases:

```js
// Only a running task can be working on a reply.
if (isTaskEnded(task?.status)) return false;
```

`prompt-input.tsx` already made the same `RUNNING` comparison to decide whether sending is allowed, so the rule is extracted to `isTaskEnded` in `lib/task-utils.ts` and shared rather than spelled two ways. Comparing against `RUNNING` also covers every settled status — including `DELETED` — without enumerating them.

## Testing

`components/task-messages/task-messages.test.tsx` renders the cold-load shape that was broken: a user message, no reply, and `rpcStatus: 'success'` as the subscription leaves it. Asserts the indicator shows on `RUNNING` and hides on every ended status. Removing the fix fails all five hide cases.

`isTaskEnded` is unit-tested for running, ended, and unknown statuses.

Also verified manually against a live agent locally whose turns fail — the indicator clears both when the task fails in-session and on a cold reload.

97 tests pass. `npm run typecheck`, `eslint`, and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes task-ended detection and uses authoritative task status to clear the thinking indicator after terminal outcomes.
- Adds shared `isTaskEnded` handling to the message view and prompt input.
- Adds coverage for running and terminal task statuses.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agentex-ui/lib/task-utils.ts | Adds the shared task-ended predicate used by task workspace components. |
| agentex-ui/components/task-messages/task-messages.tsx | Uses authoritative task status to suppress the thinking indicator once a task has ended. |
| agentex-ui/components/primary-content/prompt-input.tsx | Replaces its inline status comparison with the shared task-ended helper. |
| agentex-ui/components/task-messages/task-messages.test.tsx | Covers thinking-indicator behavior for running and terminal cold-loaded tasks. |
| agentex-ui/lib/task-utils.test.ts | Adds unit coverage for known, terminal, and unavailable task statuses. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): thinking indicator never clears..."](https://github.com/scaleapi/scale-agentex/commit/db2c4fba6bdd0921497a19e72b80e2a28b46fbbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56428049)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Task lifecycle and execution data](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/task-lifecycle.md)
- Knowledge Base — [Task messages, events, and streaming](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/task-messages-events-and-streaming.md)
- Knowledge Base — [Console task workspace](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/console-task-workspace.md)
</details>


<!-- /greptile_comment -->