### PR TITLE
feat(agentex): DM unlinked Slack users a link to connect their account

### DIFF
--- a/agentex/src/api/routes/integrations.py
+++ b/agentex/src/api/routes/integrations.py
@@ -72,6 +72,26 @@ router = APIRouter(prefix="/integrations", tags=["Integrations"])
 # holding one indefinitely, so an unknown expiry becomes a short known one.
 _FALLBACK_TTL_DAYS = int(os.getenv("IDENTITY_LINK_FALLBACK_TTL_DAYS", "30"))
 
+# Require the Slack account's email to match the signed-in SGP account's.
+#
+# This is the only real defence against a *forwarded* link. The nonce stops an
+# attacker forging someone else's Slack identity, but nothing stops them sending
+# their OWN link to a victim: if the victim clicks it while signed in, the
+# attacker's Slack identity binds to the victim's SGP account, and thereafter the
+# attacker's Slack messages run as the victim, using the victim's integrations. The
+# confirmation page names both identities, which catches a mis-click but reduces to
+# user vigilance against a deliberate attempt.
+#
+# OFF by default because it needs the ``users:read.email`` Slack scope, which is not
+# granted until the app is reinstalled. Enabling it without the scope would refuse
+# every link (the check treats an unreadable email as a mismatch, deliberately), so
+# the flag and the scope have to be turned on together.
+_REQUIRE_EMAIL_MATCH = os.getenv("IDENTITY_LINK_REQUIRE_EMAIL_MATCH", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
 
 def _page(title: str, body: str, *, status: int = 200) -> HTMLResponse:
     """Minimal self-contained page. No external assets — this renders inside
@@ -246,6 +266,38 @@ async def slack_link_confirm(request: Request, nonce: str = Form("")) -> HTMLRes
             "workspace. Disconnect that one first.</p>",
             status=409,
         )
+
+    if _REQUIRE_EMAIL_MATCH:
+        # Local import: the gateway module owns the Slack token and HTTP calls, and
+        # importing it at module load would pull the use case into the route's import
+        # graph for a feature that is off by default.
+        from src.domain.use_cases.slack_gateway_use_case import slack_user_profile
+
+        slack_email = (await slack_user_profile(link_request.external_user_id)).get(
+            "email"
+        )
+        # An unreadable email is treated as a mismatch, not as "skip the check".
+        # Failing open here would silently disable the only defence against a
+        # forwarded link the moment the Slack scope lapsed.
+        if not slack_email or not email or slack_email.lower() != email.lower():
+            logger.warning(
+                "identity link refused: Slack/SGP email mismatch",
+                extra={
+                    "sgp_user_id": sgp_user_id,
+                    "external_user_id": link_request.external_user_id,
+                    "slack_email_known": bool(slack_email),
+                },
+            )
+            return _page(
+                "Accounts don't match",
+                "<h1>Those accounts don't match</h1>"
+                "<p>The Slack account this link was made for and the SGP account "
+                "you're signed in as belong to different people.</p>"
+                "<p class=muted>If someone sent you this link, don't use it — it "
+                "would let their Slack messages run as you. Mention the agent in "
+                "Slack yourself to get your own link.</p>",
+                status=403,
+            )
 
     secret = _session_credential(request)
     if not secret:

--- a/agentex/src/domain/use_cases/slack_gateway_use_case.py
+++ b/agentex/src/domain/use_cases/slack_gateway_use_case.py
@@ -131,6 +131,18 @@ _UNLINKED_MESSAGE = (
     "Connect your account and try again."
 )
 
+# Public origin for the link we DM. Must be a host the user's browser can reach AND
+# a sibling subdomain of the SGP host, or their session cookie never arrives and the
+# callback can't tell who they are. Unset => no offers (a broken link is worse than
+# no link).
+_PUBLIC_BASE_URL = os.getenv("SLACK_GATEWAY_PUBLIC_BASE_URL", "").rstrip("/")
+
+# How long before an unlinked user is offered the link again. ``claim_send`` already
+# caps DMs at 2 per live nonce, but a nonce only lives ~10 minutes, so without this a
+# persistent mentioner re-arms that budget every 10 minutes. Worst case becomes ~2
+# DMs an hour instead of ~12.
+_LINK_OFFER_COOLDOWN_S = int(os.getenv("SLACK_LINK_OFFER_COOLDOWN_S", "3600"))
+
 # Slack's HTTP Events API is at-least-once — it retries a delivery (up to ~3x, with an
 # X-Slack-Retry-Num header) if we don't 200 within ~3s. Dedup on the envelope's
 # ``event_id`` via Redis with a short TTL so a retry can't start a duplicate turn.
@@ -358,6 +370,46 @@ def _agent_text(messages) -> str | None:
             if text:
                 parts.append(text)
     return "\n\n".join(parts) if parts else None
+
+
+async def slack_user_profile(user_id: str) -> dict[str, str | None]:
+    """``{"display_name": …, "email": …}`` for a Slack user, best-effort.
+
+    Both fields can be None and callers must cope: ``display_name`` is only used to
+    make the confirmation page legible, and ``email`` requires the
+    ``users:read.email`` scope, which is *not* granted by default. A missing email is
+    therefore "unknown", never "does not match" — see the email-match check in the
+    link route, which refuses rather than assuming when it can't read one.
+
+    Never raises: an identity-link attempt shouldn't fail because a Slack lookup
+    hiccupped.
+    """
+    token = os.getenv("SLACK_BOT_TOKEN", "")
+    if not token or not user_id:
+        return {"display_name": None, "email": None}
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                "https://slack.com/api/users.info",
+                headers={"Authorization": f"Bearer {token}"},
+                params={"user": user_id},
+            )
+        body = resp.json()
+    except Exception:  # noqa: BLE001 - best-effort lookup
+        logger.warning("[slack] users.info failed for %s", user_id, exc_info=True)
+        return {"display_name": None, "email": None}
+    if not body.get("ok"):
+        # missing_scope here means users:read.email isn't granted; that's expected
+        # until the app is reinstalled, so it's info rather than a warning.
+        logger.info("[slack] users.info -> %s", body.get("error"))
+        return {"display_name": None, "email": None}
+    user = body.get("user") or {}
+    profile = user.get("profile") or {}
+    handle = user.get("name")
+    return {
+        "display_name": f"@{handle}" if handle else profile.get("real_name"),
+        "email": profile.get("email"),
+    }
 
 
 # --------------------------------------------------------------------------- use case
@@ -614,6 +666,15 @@ class SlackGatewayUseCase:
             # so an unlinked user still gets a working turn, just without their
             # personal integrations. Prompting them to link is a separate concern.
             principal, auth_headers, sgp_user_id = await self._turn_identity(inbound)
+
+            if sgp_user_id is None:
+                # Not running as a person: either unlinked, or linked with a
+                # credential we can't use (expired session, undecryptable). Offer the
+                # link either way — a dead credential needs the same fix as no
+                # credential. Rate-limited and best-effort; it never affects the turn,
+                # which continues as the bot below (or is refused just after).
+                await self._offer_link(inbound)
+
             if principal is None and auth_headers is None:
                 # Only reachable when linking is mandatory and this user hasn't.
                 await self._deliver(inbound, _UNLINKED_MESSAGE)
@@ -1179,6 +1240,156 @@ class SlackGatewayUseCase:
     async def _fetch_bot_token(self) -> str:
         # Bot token from env / k8s-secret.
         return os.getenv("SLACK_BOT_TOKEN", "")
+
+    async def _offer_link(self, inbound: InboundSlack) -> bool:
+        """DM the invoking user a one-time link to connect their SGP account.
+
+        Returns True only when a DM actually went out. Entirely best-effort: this runs
+        alongside a turn that is already proceeding (as the shared bot, or being
+        refused), and no failure here may change that outcome.
+
+        **The link is DMed, never posted in channel.** The nonce is a bearer token —
+        whoever holds it gets linked to this Slack identity by signing in as
+        themselves. In a channel, the first person to click it would bind *this*
+        user's Slack identity to *their own* SGP account. So if the DM can't be sent
+        we say so and stop, rather than falling back to somewhere visible.
+
+        Rate limiting is two-layer and deliberately so: ``claim_send`` caps DMs about
+        one live link (default 2, so a re-mention re-sends rather than going quiet),
+        and a cooldown key stops a fresh nonce from re-arming that budget on every
+        mention once the old one expires.
+        """
+        if not _PUBLIC_BASE_URL:
+            logger.info(
+                "[slack] link offer skipped: SLACK_GATEWAY_PUBLIC_BASE_URL is unset"
+            )
+            return False
+
+        from src.domain.services.link_nonce_service import LinkNonceService, LinkRequest
+
+        if not await self._claim_offer_cooldown(inbound):
+            logger.info(
+                "[slack] link offer suppressed by cooldown for %s", inbound.user
+            )
+            return False
+
+        profile = await slack_user_profile(inbound.user)
+        request = LinkRequest(
+            provider="slack",
+            external_team_id=inbound.team_id,
+            external_user_id=inbound.user,
+            display_name=profile.get("display_name") or inbound.user,
+            # Stored so a later change can answer the original question; nothing
+            # replays it yet.
+            pending_turn={
+                "text": inbound.text,
+                "channel": inbound.channel,
+                "thread_ts": inbound.thread_ts,
+            },
+        )
+
+        service = LinkNonceService()
+        try:
+            token, reused = await service.create_or_reuse(request)
+            allowed = await service.claim_send(request)
+        except Exception:  # noqa: BLE001 - Redis down: no offer, turn unaffected
+            logger.warning("[slack] link offer failed to mint a nonce", exc_info=True)
+            return False
+
+        if not allowed:
+            # Already DMed about this link. Acknowledge in-channel (ephemerally) so
+            # the user isn't left wondering, but don't send another DM.
+            await self._post_ephemeral(
+                inbound,
+                "I've already sent you a DM with a link to connect your account — "
+                "check your direct messages with me.",
+            )
+            return False
+
+        opened = await self._slack_api("conversations.open", {"users": inbound.user})
+        dm_channel = (
+            (opened.get("channel") or {}).get("id") if opened.get("ok") else None
+        )
+        if not dm_channel:
+            logger.warning(
+                "[slack] conversations.open failed for %s: %s",
+                inbound.user,
+                opened.get("error"),
+            )
+            return False
+
+        url = f"{_PUBLIC_BASE_URL}/integrations/slack/link?nonce={token}"
+        posted = await self._slack_api(
+            "chat.postMessage",
+            {
+                "channel": dm_channel,
+                "unfurl_links": False,
+                "text": (
+                    "Connect your SGP account and I'll use *your* tools "
+                    "(Notion, Linear, …) when you ask me things in Slack.\n\n"
+                    f"<{url}|Connect my account>\n\n"
+                    "This link is just for you and expires in a few minutes. "
+                    "Don't forward it — anyone who opens it could connect your "
+                    "Slack identity to their own SGP account."
+                ),
+            },
+        )
+        if not posted.get("ok"):
+            logger.warning(
+                "[slack] link DM failed for %s: %s", inbound.user, posted.get("error")
+            )
+            return False
+
+        logger.info(
+            "[slack] link offer DMed to %s (nonce %s)",
+            inbound.user,
+            "reused" if reused else "new",
+        )
+        await self._post_ephemeral(
+            inbound,
+            "I've DM'd you a link to connect your SGP account — once you do, I'll "
+            "use your own tools when you ask me things here.",
+        )
+        return True
+
+    async def _claim_offer_cooldown(self, inbound: InboundSlack) -> bool:
+        """True if we may offer this user a link now, and records the offer.
+
+        Fails *open* on a Redis problem: the alternative is never offering, and the
+        per-link ``claim_send`` cap still bounds the damage.
+        """
+        key = f"slack:link_offer:{inbound.team_id}:{inbound.user}"
+        try:
+            pool = GlobalDependencies().redis_pool
+            if pool is None:
+                return True
+            import redis.asyncio as redis
+
+            client = redis.Redis(connection_pool=pool)
+            # SET NX: only the first caller in the window wins.
+            return bool(await client.set(key, "1", nx=True, ex=_LINK_OFFER_COOLDOWN_S))
+        except Exception:  # noqa: BLE001 - see docstring
+            logger.warning("[slack] link offer cooldown check failed", exc_info=True)
+            return True
+
+    async def _post_ephemeral(self, inbound: InboundSlack, text: str) -> None:
+        """Post a message only the invoking user sees. Best-effort.
+
+        Ephemeral so a channel isn't cluttered with onboarding nudges aimed at one
+        person — and Slack rejects it outside a channel context (e.g. an assistant
+        pane), which we swallow.
+        """
+        body = await self._slack_api(
+            "chat.postEphemeral",
+            {
+                "channel": inbound.channel,
+                "user": inbound.user,
+                "thread_ts": inbound.thread_ts,
+                "text": text,
+            },
+        )
+        if not body.get("ok"):
+            logger.info("[slack] postEphemeral -> %s", body.get("error"))
 
     async def _set_status(self, inbound: InboundSlack, status: str) -> None:
         """AI-app 'thinking…' indicator (assistant.threads.setStatus). Shows in the

--- a/agentex/tests/unit/api/test_integrations_routes.py
+++ b/agentex/tests/unit/api/test_integrations_routes.py
@@ -255,3 +255,82 @@ class TestConfirm:
         )
         # Nonce preserved so the link works once the key is configured.
         wiring.nonce.consume.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestEmailMatch:
+    """The flagged defence against a *forwarded* link.
+
+    The nonce stops an attacker forging someone else's Slack identity. It does not
+    stop them sending their OWN link to a victim: if the victim clicks it while
+    signed in, the attacker's Slack identity binds to the victim's SGP account, and
+    from then on the attacker's Slack messages run as the victim. Comparing the two
+    accounts' emails is what closes that.
+
+    Off by default: it needs the `users:read.email` Slack scope, which isn't granted
+    until the app is reinstalled.
+    """
+
+    def _slack_email(self, monkeypatch, email):
+        import src.domain.use_cases.slack_gateway_use_case as sg
+
+        monkeypatch.setattr(
+            sg, "slack_user_profile", AsyncMock(return_value={"email": email})
+        )
+
+    async def test_disabled_by_default_does_not_call_slack(self, wiring, monkeypatch):
+        import src.domain.use_cases.slack_gateway_use_case as sg
+
+        probe = AsyncMock(return_value={"email": "someone.else@example.com"})
+        monkeypatch.setattr(sg, "slack_user_profile", probe)
+        monkeypatch.setattr(mod, "_REQUIRE_EMAIL_MATCH", False)
+
+        resp = await mod.slack_link_confirm(_request(_PRINCIPAL), nonce="tok")
+        assert resp.status_code == 200
+        probe.assert_not_awaited()
+
+    async def test_matching_emails_link_successfully(self, wiring, monkeypatch):
+        monkeypatch.setattr(mod, "_REQUIRE_EMAIL_MATCH", True)
+        self._slack_email(monkeypatch, _SGP_EMAIL)
+        resp = await mod.slack_link_confirm(_request(_PRINCIPAL), nonce="tok")
+        assert resp.status_code == 200
+        wiring.repo.upsert_link.assert_awaited_once()
+
+    async def test_match_is_case_insensitive(self, wiring, monkeypatch):
+        monkeypatch.setattr(mod, "_REQUIRE_EMAIL_MATCH", True)
+        self._slack_email(monkeypatch, _SGP_EMAIL.upper())
+        resp = await mod.slack_link_confirm(_request(_PRINCIPAL), nonce="tok")
+        assert resp.status_code == 200
+
+    async def test_mismatch_is_refused_and_stores_nothing(self, wiring, monkeypatch):
+        monkeypatch.setattr(mod, "_REQUIRE_EMAIL_MATCH", True)
+        self._slack_email(monkeypatch, "attacker@example.com")
+
+        resp = await mod.slack_link_confirm(_request(_PRINCIPAL), nonce="tok")
+
+        assert resp.status_code == 403
+        wiring.repo.upsert_link.assert_not_awaited()
+        # The nonce survives, so a legitimate owner can still use their own link.
+        wiring.nonce.consume.assert_not_awaited()
+        body = resp.body.decode().lower()
+        assert "don&#x27;t use it" in body or "don't use it" in body
+
+    async def test_unreadable_slack_email_fails_closed(self, wiring, monkeypatch):
+        # Missing scope, deleted user, API hiccup -> None. Treating that as "skip the
+        # check" would silently disable the defence the moment the scope lapsed.
+        monkeypatch.setattr(mod, "_REQUIRE_EMAIL_MATCH", True)
+        self._slack_email(monkeypatch, None)
+
+        resp = await mod.slack_link_confirm(_request(_PRINCIPAL), nonce="tok")
+        assert resp.status_code == 403
+        wiring.repo.upsert_link.assert_not_awaited()
+
+    async def test_missing_sgp_email_fails_closed(self, wiring, monkeypatch):
+        monkeypatch.setattr(mod, "_REQUIRE_EMAIL_MATCH", True)
+        self._slack_email(monkeypatch, "someone@example.com")
+        principal = {**_PRINCIPAL, "raw_user": {}}
+
+        resp = await mod.slack_link_confirm(_request(principal), nonce="tok")
+        assert resp.status_code == 403
+        wiring.repo.upsert_link.assert_not_awaited()

--- a/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
+++ b/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
@@ -1683,3 +1683,123 @@ class TestDispatchAttribution:
         create = acp.handle_rpc_request.await_args_list[0].kwargs["params"]
         assert create.name == "slack:1"
         assert "sgp_user_id" not in create.task_metadata
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestLinkOffer:
+    """DMing an unlinked user a connect link.
+
+    The security-critical property under test is that the link goes to a DM and
+    NOWHERE else. The nonce is a bearer token: whoever opens it gets linked to this
+    Slack identity by signing in as themselves, so a link posted in a channel lets
+    the first reader bind someone else's Slack identity to their own SGP account.
+    """
+
+    def _wire(self, monkeypatch, *, allowed=True, cooldown_ok=True, open_ok=True):
+        uc = SlackGatewayUseCase()
+        monkeypatch.setattr(sg, "_PUBLIC_BASE_URL", "https://agentex.example.com")
+        monkeypatch.setattr(
+            sg, "slack_user_profile", AsyncMock(return_value={"display_name": "@ada"})
+        )
+        monkeypatch.setattr(
+            uc, "_claim_offer_cooldown", AsyncMock(return_value=cooldown_ok)
+        )
+
+        nonce = MagicMock()
+        nonce.create_or_reuse = AsyncMock(return_value=("TOKEN123", False))
+        nonce.claim_send = AsyncMock(return_value=allowed)
+        monkeypatch.setattr(
+            "src.domain.services.link_nonce_service.LinkNonceService",
+            lambda *a, **k: nonce,
+        )
+
+        def _api(method, payload):
+            if method == "conversations.open":
+                return (
+                    {"ok": True, "channel": {"id": "D_DM"}}
+                    if open_ok
+                    else {"ok": False, "error": "cannot_dm_bot"}
+                )
+            return {"ok": True}
+
+        api = AsyncMock(side_effect=_api)
+        monkeypatch.setattr(uc, "_slack_api", api)
+        return uc, api, nonce
+
+    async def test_dms_the_link_and_acknowledges_in_channel(self, monkeypatch):
+        uc, api, _ = self._wire(monkeypatch)
+        assert await uc._offer_link(_inbound()) is True
+
+        calls = dict(c.args for c in api.await_args_list)
+        assert set(calls) == {
+            "conversations.open",
+            "chat.postMessage",
+            "chat.postEphemeral",
+        }
+        dm = calls["chat.postMessage"]
+        assert dm["channel"] == "D_DM"
+        assert "TOKEN123" in dm["text"]
+        assert "/integrations/slack/link?nonce=" in dm["text"]
+        # The nudge is ephemeral, so a channel isn't littered with one person's
+        # onboarding.
+        assert calls["chat.postEphemeral"]["user"] == "U1"
+
+    async def test_the_link_never_goes_to_the_origin_channel(self, monkeypatch):
+        uc, api, _ = self._wire(monkeypatch)
+        await uc._offer_link(_inbound(channel="C_PUBLIC"))
+        for method, payload in (c.args for c in api.await_args_list):
+            if payload.get("channel") == "C_PUBLIC":
+                assert "TOKEN123" not in str(
+                    payload
+                ), f"{method} leaked the nonce into the origin channel"
+
+    async def test_dm_warns_against_forwarding(self, monkeypatch):
+        uc, api, _ = self._wire(monkeypatch)
+        await uc._offer_link(_inbound())
+        dm = next(
+            p
+            for m, p in (c.args for c in api.await_args_list)
+            if m == "chat.postMessage"
+        )
+        assert "forward" in dm["text"].lower()
+
+    async def test_no_offer_without_a_public_base_url(self, monkeypatch):
+        uc, api, _ = self._wire(monkeypatch)
+        monkeypatch.setattr(sg, "_PUBLIC_BASE_URL", "")
+        # A link the user can't reach is worse than no link.
+        assert await uc._offer_link(_inbound()) is False
+        api.assert_not_awaited()
+
+    async def test_failed_dm_does_not_fall_back_to_the_channel(self, monkeypatch):
+        uc, api, _ = self._wire(monkeypatch, open_ok=False)
+        assert await uc._offer_link(_inbound()) is False
+        for _method, payload in (c.args for c in api.await_args_list):
+            assert "TOKEN123" not in str(payload)
+
+    async def test_send_cap_reached_says_so_without_a_second_dm(self, monkeypatch):
+        uc, api, _ = self._wire(monkeypatch, allowed=False)
+        assert await uc._offer_link(_inbound()) is False
+        methods = [m for m, _ in (c.args for c in api.await_args_list)]
+        # Acknowledge in-channel rather than going silent, but send no new DM.
+        assert methods == ["chat.postEphemeral"]
+
+    async def test_cooldown_suppresses_the_offer_entirely(self, monkeypatch):
+        uc, api, nonce = self._wire(monkeypatch, cooldown_ok=False)
+        assert await uc._offer_link(_inbound()) is False
+        nonce.create_or_reuse.assert_not_awaited()
+        api.assert_not_awaited()
+
+    async def test_redis_failure_is_swallowed(self, monkeypatch):
+        # The turn is already proceeding; a nonce-store outage must not break it.
+        uc, api, nonce = self._wire(monkeypatch)
+        nonce.create_or_reuse = AsyncMock(side_effect=RuntimeError("redis down"))
+        assert await uc._offer_link(_inbound()) is False
+
+    async def test_pending_turn_is_stashed_for_later_replay(self, monkeypatch):
+        uc, _api, nonce = self._wire(monkeypatch)
+        await uc._offer_link(_inbound(text="what's in my linear?", channel="C9"))
+        req = nonce.create_or_reuse.await_args.args[0]
+        assert req.external_user_id == "U1"
+        assert req.pending_turn["text"] == "what's in my linear?"
+        assert req.pending_turn["channel"] == "C9"


### PR DESCRIPTION
## What

The last piece of the identity-link flow. #409 added the storage, #410 the gateway
wiring and the link routes — but nothing ever handed a user a link, so the only way
in was a dev script. Now an unlinked mention offers one.

When a turn is **not** running as a person — unlinked, or linked with a credential we
can't use (expired session, undecryptable ciphertext) — the gateway:

```
1. mint (or reuse) a nonce carrying the Slack identity Slack's HMAC just verified,
   plus the message that triggered it
2. conversations.open -> chat.postMessage   DM that user the link
3. chat.postEphemeral                       tell them in-channel a DM is waiting
```

A dead credential gets the same offer as no credential, since re-linking is the fix
for both.

## The link is DMed and never posted in a channel

This is the part worth reviewing closely. The nonce is a **bearer token**: whoever
opens it gets linked to that Slack identity by signing in as themselves. Posted in a
channel, the first person to read it could bind someone else's Slack identity to
their own SGP account.

So when `conversations.open` or the DM fails, we log and stop — there is no fallback
to anywhere visible. A test asserts the token never appears in any payload addressed
to the origin channel, and another that a failed DM leaks it nowhere.

## Best-effort by construction

The turn is already proceeding (as the shared bot, or being refused immediately
after), and nothing in the offer path may change that. A Redis outage, a missing
scope, a closed DM — all end in "no offer" and an unaffected turn.

Offers also require `SLACK_GATEWAY_PUBLIC_BASE_URL`. Unset means no offers at all:
the host must be browser-reachable *and* a sibling subdomain of the SGP host or the
session cookie never arrives at the callback. A link that cannot work is worse than
no link.

## Rate limiting, two layers for two problems

- **`claim_send`** (from #410) caps DMs about one live link at 2, so a re-mention
  re-sends the same link rather than going quiet.
- **A cooldown key** (`SLACK_LINK_OFFER_COOLDOWN_S`, default 1h) stops a fresh nonce
  from re-arming that budget every time the old one expires. Without it, a persistent
  mentioner collects ~12 DMs an hour instead of ~2. It fails **open** on a Redis
  error — never offering is the worse failure, and `claim_send` still bounds it.

## Email match — shipped OFF

The nonce stops an attacker forging someone else's Slack identity. It does **not**
stop them forwarding their *own* link: if a victim clicks it while signed in, the
attacker's Slack identity binds to the victim's SGP account, and from then on the
attacker's Slack messages run as the victim, with the victim's integrations. The
confirmation page naming both identities catches a mis-click but reduces to user
vigilance against a deliberate attempt.

Comparing the Slack account's email against the signed-in SGP account's closes it.

It ships disabled because it needs the **`users:read.email` Slack scope, which is not
granted** — verified, `users.lookupByEmail` returns `missing_scope`. Enable
`IDENTITY_LINK_REQUIRE_EMAIL_MATCH` and the scope together.

⚠️ **The check treats an unreadable email as a MISMATCH, not as "skip".** So turning
the flag on without the scope refuses every link. That direction is deliberate:
failing open would silently disable the only defence the moment the scope lapsed.
Tests pin both directions.

## Not included

**Replaying the stashed turn.** `pending_turn` is recorded for it, but the
confirmation page still says "ask me again in Slack". Wiring the link route back into
the gateway is a coupling worth doing on its own, with care that a replay failure
can't undo a successful link.

## Testing

**15 new unit tests**, aimed at the failure modes rather than the happy path:

- link offer: the token never reaching the origin channel; a failed DM leaking it
  nowhere; no offer without a public base URL; the send cap acknowledging in-channel
  instead of going silent; the cooldown suppressing before a nonce is even minted; a
  Redis error swallowed; the DM text warning against forwarding; `pending_turn`
  stashed for a later replay.
- email match: disabled-by-default doesn't call Slack at all; matching (and
  case-insensitive) emails link; a mismatch refuses **and leaves the nonce intact**,
  so a legitimate owner can still use their own link; unreadable Slack email and
  missing SGP email both fail closed.

Full unit suite: **685 passed**. `ruff` clean.

The 193 local integration errors are the pre-existing testcontainers/Mongo issue in
files this PR doesn't touch — they reproduce identically on a clean checkout of main.

## Deploy notes

Nothing here activates on its own:

| Variable | Effect if unset |
|---|---|
| `SLACK_GATEWAY_PUBLIC_BASE_URL` | **no offers are sent at all** |
| `SLACK_LINK_OFFER_COOLDOWN_S` | defaults to 1h |
| `IDENTITY_LINK_REQUIRE_EMAIL_MATCH` | email match skipped (current state) |

Scopes: `im:write` and `chat:write` are already granted, so DMs and ephemerals work
today. `users:read.email` is the only addition needed, and only for the email match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Slack account-link offers for users whose turns cannot run under a usable personal identity, with bearer links delivered only through DMs and an ephemeral channel acknowledgment.
- Adds Slack profile lookup and optional Slack/SGP email matching during confirmation.
- Adds nonce reuse, delivery limits, and a per-user offer cooldown.
- Adds unit coverage for delivery confidentiality, failure handling, rate limiting, pending turns, and email matching.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The failed-delivery cooldown behavior should be fixed before merging because a transient Slack failure can prevent the user from receiving a link for an hour.

The gateway records the offer cooldown before attempting DM delivery and does not undo it on either Slack failure path, causing later mentions to be suppressed despite no successful offer.

**Files Needing Attention:** agentex/src/domain/use_cases/slack_gateway_use_case.py
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/slack_gateway_use_case.py | Adds the Slack DM offer flow, profile lookup, cooldown, and ephemeral acknowledgment; failed DM delivery incorrectly leaves the cooldown active. |
| agentex/src/api/routes/integrations.py | Adds an explicitly opt-in, fail-closed email correspondence check before persisting a Slack identity link. |
| agentex/tests/unit/use_cases/test_slack_gateway_use_case.py | Covers link confidentiality and major offer outcomes but does not verify that a failed delivery remains retryable. |
| agentex/tests/unit/api/test_integrations_routes.py | Covers enabled, disabled, matching, mismatching, and unreadable-email confirmation behavior. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as Slack user
    participant G as Slack gateway
    participant R as Redis/nonce service
    participant S as Slack API
    participant I as Link confirmation route
    G->>G: Resolve invoking identity
    alt No usable personal identity
        G->>R: Claim offer cooldown
        G->>R: Create or reuse nonce and claim send
        G->>S: conversations.open
        G->>S: chat.postMessage with bearer link
        G->>S: chat.postEphemeral acknowledgment
        U->>I: Open link and confirm while signed in
        I->>I: Optionally compare Slack and SGP email
        I->>R: Consume nonce and persist identity link
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20scaleapi%2Fscale-agentex%20PR%20%23412%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=412&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A1270%0A**Failed%20DMs%20consume%20the%20cooldown**%0A%0AWhen%20%60conversations.open%60%20or%20%60chat.postMessage%60%20fails%2C%20the%20cooldown%20has%20already%20been%20claimed%20and%20is%20not%20released%2C%20causing%20every%20subsequent%20mention%20to%20suppress%20another%20offer%20for%20up%20to%20one%20hour%20even%20though%20the%20user%20received%20no%20link.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A1270%0A**Failed%20DMs%20consume%20the%20cooldown**%0A%0AWhen%20%60conversations.open%60%20or%20%60chat.postMessage%60%20fails%2C%20the%20cooldown%20has%20already%20been%20claimed%20and%20is%20not%20released%2C%20causing%20every%20subsequent%20mention%20to%20suppress%20another%20offer%20for%20up%20to%20one%20hour%20even%20though%20the%20user%20received%20no%20link.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22mc%2Fslack-link-dm-trigger%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mc%2Fslack-link-dm-trigger%22.%0A%0A%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A1270%0A**Failed%20DMs%20consume%20the%20cooldown**%0A%0AWhen%20%60conversations.open%60%20or%20%60chat.postMessage%60%20fails%2C%20the%20cooldown%20has%20already%20been%20claimed%20and%20is%20not%20released%2C%20causing%20every%20subsequent%20mention%20to%20suppress%20another%20offer%20for%20up%20to%20one%20hour%20even%20though%20the%20user%20received%20no%20link.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
agentex/src/domain/use_cases/slack_gateway_use_case.py:1270
**Failed DMs consume the cooldown**

When `conversations.open` or `chat.postMessage` fails, the cooldown has already been claimed and is not released, causing every subsequent mention to suppress another offer for up to one hour even though the user received no link.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(agentex): DM unlinked Slack users a..."](https://github.com/scaleapi/scale-agentex/commit/ee8104a581ee6fd9b717dd26ca1408613f37858b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57819517)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->