### PR TITLE
feat(dev): ignore local Neovim config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ pids
 # VSCode
 *.code-workspace
 
+# Neovim
+.nvim.lua
+
 # filesystem files
 .DS_Store
 


### PR DESCRIPTION
Add `.nvim.lua` to the gitignore to give Neovim developers a way to configure their editor settings for this repo.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds repository-wide Git ignore handling for Neovim’s local `.nvim.lua` configuration file.
- Adds a Neovim section to `.gitignore`.
- Prevents local `.nvim.lua` editor settings from being committed accidentally.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new ignore entry consistently excludes the intended local Neovim configuration, and no existing tracked files, fixtures, or repository conventions conflict with it.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .gitignore | Adds the intended Neovim configuration ignore pattern without affecting tracked repository files. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dev): ignore local Neovim config fi..."](https://github.com/scaleapi/scale-agentex/commit/1558af281ef773a72bfd56ce8cf568bcf19a9969) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57852194)</sub>

<!-- /greptile_comment -->