### PR TITLE
fix(agentex): recover unhealthy agents after successful probes

### DIFF
--- a/agentex/src/temporal/activities/healthcheck_activities.py
+++ b/agentex/src/temporal/activities/healthcheck_activities.py
@@ -103,6 +103,11 @@ class HealthCheckActivities:
             new_status = AgentStatus(status)
             if agent.status == new_status:
                 return
+            if (
+                new_status == AgentStatus.READY
+                and agent.status != AgentStatus.UNHEALTHY
+            ):
+                return
             agent.status = new_status
             agent.status_reason = "Agent health check reported " + status
             await self.agent_repo.update(item=agent)

--- a/agentex/src/temporal/workflows/healthcheck_workflow.py
+++ b/agentex/src/temporal/workflows/healthcheck_workflow.py
@@ -46,6 +46,9 @@ class HealthCheckWorkflow:
         agent_id = workflow_args["agent_id"]
         acp_url = workflow_args["acp_url"]
 
+        # Fresh runs arm recovery; pre-patch histories retain their original commands.
+        recover_on_next_success = workflow.patched("recover-unhealthy-on-success")
+
         logger.info(f"Starting execution for agent {agent_id}")
 
         failure_counter = workflow_args.get("failure_counter", 0)
@@ -73,26 +76,32 @@ class HealthCheckWorkflow:
                 failure_counter += 1
             if failure_counter >= 5:
                 # Agent is officially unhealthy
-                await workflow.execute_activity(
-                    UPDATE_AGENT_STATUS_ACTIVITY,
-                    args=[agent_id, "Unhealthy"],
-                    start_to_close_timeout=timedelta(seconds=30),
-                    retry_policy=RetryPolicy(
-                        maximum_attempts=3,
-                        initial_interval=timedelta(seconds=1),
-                        backoff_coefficient=2.0,
-                    ),
-                )
+                await self._update_agent_status(agent_id, "Unhealthy")
                 # Stop health check workflow until agent registers again
                 return
 
             # If health check succeeds, reset the counter
             if success:
                 failure_counter = 0
+                if recover_on_next_success:
+                    await self._update_agent_status(agent_id, "Ready")
+                    recover_on_next_success = False
 
         workflow_args["failure_counter"] = failure_counter
         workflow.continue_as_new(
             arg=workflow_args,
+        )
+
+    async def _update_agent_status(self, agent_id: str, status: str) -> None:
+        await workflow.execute_activity(
+            UPDATE_AGENT_STATUS_ACTIVITY,
+            args=[agent_id, status],
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(
+                maximum_attempts=3,
+                initial_interval=timedelta(seconds=1),
+                backoff_coefficient=2.0,
+            ),
         )
 
     def should_continue_as_new(self) -> bool:

--- a/agentex/tests/unit/temporal/test_healthcheck_activities.py
+++ b/agentex/tests/unit/temporal/test_healthcheck_activities.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from src.domain.entities.agents import AgentStatus
+from src.temporal.activities.healthcheck_activities import HealthCheckActivities
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("current_status", "should_recover"),
+    [
+        (AgentStatus.UNHEALTHY, True),
+        (AgentStatus.READY, False),
+        (AgentStatus.BUILD_ONLY, False),
+        (AgentStatus.DELETED, False),
+        (AgentStatus.FAILED, False),
+        (AgentStatus.UNKNOWN, False),
+    ],
+)
+async def test_ready_status_update_only_recovers_unhealthy(
+    current_status,
+    should_recover,
+):
+    agent = SimpleNamespace(
+        status=current_status,
+        status_reason="Existing status reason",
+    )
+    agent_repo = AsyncMock()
+    agent_repo.get.return_value = agent
+    activities = HealthCheckActivities(agent_repo, AsyncMock())
+
+    await activities.update_agent_status_activity("agent-1", "Ready")
+
+    agent_repo.get.assert_awaited_once_with(id="agent-1")
+    if should_recover:
+        assert agent.status == AgentStatus.READY
+        assert agent.status_reason == "Agent health check reported Ready"
+        agent_repo.update.assert_awaited_once_with(item=agent)
+        return
+
+    assert agent.status == current_status
+    assert agent.status_reason == "Existing status reason"
+    agent_repo.update.assert_not_awaited()

--- a/agentex/tests/unit/temporal/test_healthcheck_workflow.py
+++ b/agentex/tests/unit/temporal/test_healthcheck_workflow.py
@@ -1,0 +1,133 @@
+from unittest.mock import Mock
+
+import pytest
+from src.temporal.activities.healthcheck_activities import (
+    CHECK_STATUS_ACTIVITY,
+    UPDATE_AGENT_STATUS_ACTIVITY,
+)
+from src.temporal.workflows import healthcheck_workflow
+from src.temporal.workflows.healthcheck_workflow import HealthCheckWorkflow
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("patch_enabled", "starting_failure_counter", "expected_status_updates"),
+    [
+        (True, 0, [["agent-1", "Ready"]]),
+        (True, 2, [["agent-1", "Ready"]]),
+        (False, 0, []),
+    ],
+)
+async def test_first_healthy_probe_recovers_new_workflows_once(
+    monkeypatch,
+    patch_enabled,
+    starting_failure_counter,
+    expected_status_updates,
+):
+    status_updates = []
+    trace = []
+    patch_ids = []
+    probe_results = iter([True, True])
+
+    async def execute_activity(activity_name, *, args, **kwargs):
+        if activity_name == CHECK_STATUS_ACTIVITY:
+            result = next(probe_results)
+            trace.append(["probe", result])
+            return result
+        if activity_name == UPDATE_AGENT_STATUS_ACTIVITY:
+            status_updates.append(args)
+            trace.append(["update", *args[1:]])
+            return None
+        raise AssertionError(f"Unexpected activity: {activity_name}")
+
+    async def sleep(_):
+        return None
+
+    workflow_instance = HealthCheckWorkflow()
+    workflow_instance.should_continue_as_new = Mock(side_effect=[False, False, True])
+    continue_as_new = Mock()
+    monkeypatch.setattr(healthcheck_workflow.workflow, "sleep", sleep)
+    monkeypatch.setattr(
+        healthcheck_workflow.workflow,
+        "execute_activity",
+        execute_activity,
+    )
+    monkeypatch.setattr(
+        healthcheck_workflow.workflow,
+        "continue_as_new",
+        continue_as_new,
+    )
+
+    def patched(patch_id):
+        patch_ids.append(patch_id)
+        return patch_enabled
+
+    monkeypatch.setattr(healthcheck_workflow.workflow, "patched", patched)
+
+    workflow_args = {
+        "agent_id": "agent-1",
+        "acp_url": "http://agent",
+        "failure_counter": starting_failure_counter,
+    }
+    await workflow_instance.run(workflow_args)
+
+    assert patch_ids == ["recover-unhealthy-on-success"]
+    assert status_updates == expected_status_updates
+    expected_trace = [["probe", True]]
+    if expected_status_updates:
+        expected_trace.append(["update", "Ready"])
+    expected_trace.append(["probe", True])
+    assert trace == expected_trace
+    assert workflow_args["failure_counter"] == 0
+    continue_as_new.assert_called_once_with(arg=workflow_args)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_five_failed_probes_mark_unhealthy_and_stop(monkeypatch):
+    status_updates = []
+    probe_count = 0
+
+    async def execute_activity(activity_name, *, args, **kwargs):
+        nonlocal probe_count
+        if activity_name == CHECK_STATUS_ACTIVITY:
+            probe_count += 1
+            return False
+        if activity_name == UPDATE_AGENT_STATUS_ACTIVITY:
+            status_updates.append(args)
+            return None
+        raise AssertionError(f"Unexpected activity: {activity_name}")
+
+    async def sleep(_):
+        return None
+
+    workflow_instance = HealthCheckWorkflow()
+    workflow_instance.should_continue_as_new = Mock(
+        side_effect=[False, False, False, False, False, True]
+    )
+    continue_as_new = Mock()
+    monkeypatch.setattr(healthcheck_workflow.workflow, "sleep", sleep)
+    monkeypatch.setattr(
+        healthcheck_workflow.workflow,
+        "execute_activity",
+        execute_activity,
+    )
+    monkeypatch.setattr(
+        healthcheck_workflow.workflow,
+        "continue_as_new",
+        continue_as_new,
+    )
+    monkeypatch.setattr(
+        healthcheck_workflow.workflow,
+        "patched",
+        lambda _: True,
+    )
+
+    await workflow_instance.run({"agent_id": "agent-1", "acp_url": "http://agent"})
+
+    assert status_updates == [
+        ["agent-1", "Unhealthy"]
+    ], "the fifth consecutive failed probe must mark the agent unhealthy"
+    assert probe_count == 5, "the workflow must wait for five failed probes"
+    continue_as_new.assert_not_called()


### PR DESCRIPTION
## Summary

- Recover an `Unhealthy` agent only after a new healthcheck workflow observes a successful `/healthz` probe.
- Preserve the existing five-failure latch: mark the agent `Unhealthy`, then stop until registration starts a new workflow run.
- Prevent the healthcheck workflow from promoting `BuildOnly` or otherwise rewriting non-`Unhealthy` states to `Ready`.

## Findings

After five consecutive failed probes, `HealthCheckWorkflow` persists `Unhealthy` and completes. Registration can start a fresh run with the same workflow ID because it uses `WorkflowIDReusePolicy.ALLOW_DUPLICATE`. However, a successful probe in that replacement run previously reset only its local failure counter; it never repaired the persisted agent status.

Deployment IDs are not supplied consistently across all deployment and registration paths, so making recovery depend on a new deployment-ID contract would expand this P0 across multiple callers without being necessary to fix the latch.

## P0 approach

- Use `workflow.patched("recover-unhealthy-on-success")` so new workflow histories arm recovery while existing histories replay their original command sequence.
- On the first successful probe in each new run, invoke the existing status-update activity with `Ready`, then disable further recovery writes for that run.
- Reset `failure_counter` on every successful probe independently of the recovery latch.
- In the status activity, permit `Ready` only when the stored status is `Unhealthy`; update the existing `status_reason` at the same time.
- Leave registration, promotion, repositories, workflow arguments, and deployment identity unchanged.

## Alternatives considered

- **Recover during registration:** rejected because registration would declare recovery before `/healthz` succeeds and the change would span several registration paths.
- **Persist from `check_status_activity`:** rejected because it would mix probing with status mutation and duplicate the existing update activity.
- **Add `recover_on_success` or a recovery deployment ID to workflow arguments:** rejected because fresh runs can arm recovery internally, and deployment IDs are not universal across callers.
- **Keep polling after five failures:** rejected because it changes the existing terminal failure behavior rather than repairing recovery after re-registration.
- **Add an atomic repository compare-and-set:** deferred because it is a broader persistence change than this P0 requires.

## Known limitations

- Recovery remains agent-scoped rather than fenced to the current production deployment; a healthy preview could clear an unhealthy parent status.
- The status activity retains the existing read/update sequence rather than an atomic compare-and-set.
- Registration during the brief interval between the fifth-failure update and workflow closure can still receive `WorkflowAlreadyExists`; a later registration or restart starts the replacement run normally.
- A `continue_as_new` run re-arms recovery, but its extra `Ready` attempt is a no-op once the row is already `Ready`.

## Verification

- Focused healthcheck tests: 10 passed.
- Full backend suite: 1,260 passed; one unrelated `TestAgentsCRUD.test_health_endpoints` readiness assertion failed (`503` instead of `200`) and passed immediately in isolation.
- Repository-pinned Ruff 0.3.4 lint and format hooks passed.
- OpenAPI regeneration was byte-identical to the checked-in specification.
- Sabotage checks confirmed the tests fail when the patch gate, immediate first-probe recovery, one-shot latch, five-failure threshold, status guard, counter reset, or recovery reason is broken.

The workflow tests cover both branches of `workflow.patched` with a stub; they do not replay a captured pre-patch Temporal history or validate a deployed restart end to end.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds probe-confirmed recovery for unhealthy agents while retaining the existing five-failure terminal behavior.

- Arms recovery for new Temporal workflow histories through a patch marker.
- Changes a successful probe to attempt a one-time Unhealthy-to-Ready transition.
- Guards the status activity against rewriting other agent states.
- Adds focused unit coverage for recovery, state guarding, counter reset, and failure latching.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agentex/src/temporal/workflows/healthcheck_workflow.py | Adds patch-gated, one-shot recovery after a successful probe and extracts the shared status-update activity invocation. |
| agentex/src/temporal/activities/healthcheck_activities.py | Restricts Ready updates to agents currently persisted as Unhealthy and updates the recovery reason with the status. |
| agentex/tests/unit/temporal/test_healthcheck_workflow.py | Covers recovery gating, one-shot behavior, counter reset, and the five-failure terminal transition. |
| agentex/tests/unit/temporal/test_healthcheck_activities.py | Covers allowed Unhealthy-to-Ready recovery and rejection of Ready writes from other statuses. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Health-check workflow starts] --> B[Wait 30 seconds]
  B --> C[Probe agent health endpoint]
  C --> D{Probe succeeds?}
  D -->|Yes| E[Reset failure counter]
  E --> F{Recovery armed and stored status Unhealthy?}
  F -->|Yes| G[Set status Ready]
  F -->|No| B
  G --> H[Disarm recovery for this run]
  H --> B
  D -->|No| I[Increment failure counter]
  I --> J{Five failures?}
  J -->|No| B
  J -->|Yes| K[Set status Unhealthy]
  K --> L[Complete workflow]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(agentex): recover unhealthy agents a..."](https://github.com/scaleapi/scale-agentex/commit/ee7c0871c0644db2944bfc323ef61e6c6990a80a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59240070)</sub>

**Context used:**

- Knowledge Base — [Workflow automation](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/workflow-automation.md)
- Knowledge Base — [Temporal health checks and retention cleanup](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/temporal-health-and-retention.md)

<!-- /greptile_comment -->