### PR TITLE
fix(agentex): /agents left a stray `{}` in the channel

### DIFF
--- a/agentex/openapi.yaml
+++ b/agentex/openapi.yaml
@@ -2563,10 +2563,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                additionalProperties: true
-                type: object
-                title: Response Slack Commands Slack Commands Post
+              schema: {}
   /slack/interactions:
     post:
       tags:
@@ -2578,10 +2575,7 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema:
-                additionalProperties: true
-                type: object
-                title: Response Slack Interactions Slack Interactions Post
+              schema: {}
   /tracker/{tracker_id}:
     get:
       tags:

--- a/agentex/src/api/routes/slack.py
+++ b/agentex/src/api/routes/slack.py
@@ -6,11 +6,26 @@ is the auth, verified in the use case against the app's signing secret from the
 secrets microservice. Delegates all logic to SlackGatewayUseCase.
 """
 
-from fastapi import APIRouter, BackgroundTasks, Request
+from fastapi import APIRouter, BackgroundTasks, Request, Response
+from fastapi.responses import JSONResponse
 
 from src.domain.use_cases.slack_gateway_use_case import DSlackGatewayUseCase
 
 router = APIRouter(prefix="/slack", tags=["Slack"])
+
+
+def _slack_ack(payload: dict) -> Response:
+    """Turn a use-case result into what Slack actually expects on the wire.
+
+    Slack renders a slash-command / interaction response body verbatim, and "show
+    nothing" has to be a genuinely EMPTY 200 — an empty dict is still a body, which
+    FastAPI serializes to `{}`, and Slack prints that literally in the channel
+    (`/agents` opened its modal and left a stray `{}` behind). A non-empty payload
+    is a real message and is passed through as JSON.
+    """
+    if not payload:
+        return Response(status_code=200)
+    return JSONResponse(payload)
 
 
 @router.post("/events", summary="Slack Events API ingress for the @agent app")
@@ -31,13 +46,15 @@ async def slack_events(
 async def slack_commands(
     request: Request,
     use_case: DSlackGatewayUseCase,
-) -> dict:
+) -> Response:
     # Slash commands are application/x-www-form-urlencoded, not JSON. Read the raw
     # body first (needed for signature verification), then parse the form.
     body = await request.body()
     form = dict(await request.form())
     headers = {k.lower(): v for k, v in request.headers.items()}
-    return await use_case.handle_slash_command(body=body, headers=headers, form=form)
+    return _slack_ack(
+        await use_case.handle_slash_command(body=body, headers=headers, form=form)
+    )
 
 
 @router.post("/interactions", summary="Slack interactivity ingress (modals, shortcuts)")
@@ -45,12 +62,14 @@ async def slack_interactions(
     request: Request,
     background: BackgroundTasks,
     use_case: DSlackGatewayUseCase,
-) -> dict:
+) -> Response:
     # Interactions are form-encoded with a JSON `payload` field. Raw body first (for
     # signature verification), then the form. The turn runs out-of-band like events.
     body = await request.body()
     form = dict(await request.form())
     headers = {k.lower(): v for k, v in request.headers.items()}
-    return await use_case.handle_interaction(
-        body=body, headers=headers, form=form, background=background
+    return _slack_ack(
+        await use_case.handle_interaction(
+            body=body, headers=headers, form=form, background=background
+        )
     )

--- a/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
+++ b/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
@@ -2310,3 +2310,30 @@ class TestOfferLinkSuppression:
 
         await uc._run_turn(_inbound(), offer_link=True)
         assert len(offered) == 1
+
+
+# --- route-level ack shape -------------------------------------------------
+#
+# Slack renders a slash-command / interaction response body verbatim, so "show
+# nothing" has to be an EMPTY body. Returning {} from the route made FastAPI
+# serialize a literal `{}`, which Slack printed in the channel after /agents had
+# already opened its modal.
+
+
+def test_slack_ack_empty_payload_sends_no_body():
+    from src.api.routes.slack import _slack_ack
+
+    resp = _slack_ack({})
+    assert resp.status_code == 200
+    assert resp.body == b""
+
+
+def test_slack_ack_passes_through_a_real_message():
+    from src.api.routes.slack import _slack_ack
+
+    resp = _slack_ack({"response_type": "ephemeral", "text": "Unsupported command: /x"})
+    assert resp.status_code == 200
+    assert json.loads(resp.body) == {
+        "response_type": "ephemeral",
+        "text": "Unsupported command: /x",
+    }


### PR DESCRIPTION
## The bug

Running `/agents` opens the picker modal and then leaves a literal `{}` sitting in the channel.

The intent in the use case is right:

```python
if trigger_id and await self._open_agents_modal(trigger_id, channel_id):
    return {}  # empty 200: Slack shows nothing; the modal is already open
```

The wire format isn't. The route was typed `-> dict`, so FastAPI serialized that empty dict into a response body of literally `{}` with `Content-Type: application/json`.

Slack renders a slash-command response body verbatim, and its contract for "show nothing" is an **empty body** — not an empty JSON object. Given `{}` it finds no `text` and no `blocks`, and prints the raw payload.

**`views.open` was succeeding the whole time; this was never a failure path.** `_open_agents_modal` already checks `ok` and logs a warning when it is false, and no such warning appears in the logs. My first guess was that it was ignoring `ok` — it isn't.

## The fix

At the HTTP layer, so the use case keeps its dict contract and the domain layer stays free of HTTP concerns:

```python
def _slack_ack(payload: dict) -> Response:
    if not payload:
        return Response(status_code=200)   # genuinely empty
    return JSONResponse(payload)
```

Applied to `/commands` and `/interactions` — both render to the user, and `handle_interaction` has four more `return {}` sites carrying the same latent problem. `/events` is deliberately left alone, since Slack ignores that response body.

## What's in the diff

| File | Why |
|---|---|
| `src/api/routes/slack.py` | the fix |
| `tests/unit/use_cases/test_slack_gateway_use_case.py` | 2 tests, +1 incidental line (see below) |
| `openapi.yaml` | regenerated by the pre-commit hook; the two routes' response schema follows the `-> dict` → `-> Response` change |

## Two notes for the reviewer

**One unrelated line comes along in the test file.** The pre-commit `ruff-format` hook pins `v0.3.4`, while `pyproject.toml` only floors ruff at `>=0.3.4` (the project venv resolves to `0.13.2`). The two disagree on how to wrap an `assert` with a message, so the hook rewrites a pre-existing line for anyone who touches this file. There is no ruff step in CI, so the hook is the only enforcement point. Pinning the version in `pyproject.toml` would stop this from recurring — happy to do that separately.

**I have not observed the fixed behavior end-to-end.** The diagnosis is from the deployed code plus Slack's documented contract; the `{}` disappearing is inferred, not watched. Once deployed, `/agents` should show the picker and nothing else.

## Testing

```
124 passed
ruff check + format: clean
```

The new test is non-vacuous — `JSONResponse({}).body` is `b'{}'`, so the empty-body assertion fails against the old route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes Slack slash-command and interaction acknowledgements by translating empty use-case results into genuinely bodyless HTTP 200 responses while preserving non-empty JSON messages.

- Adds a shared HTTP-layer acknowledgement helper for Slack commands and interactions.
- Adds focused tests for empty and non-empty acknowledgement payloads.
- Regenerates the affected OpenAPI response schemas.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or compatibility defects identified.

The new response conversion matches every reachable command and interaction result, and the concrete responses remain compatible with the service’s middleware.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agentex/src/api/routes/slack.py | Correctly converts empty command and interaction results into bodyless acknowledgements while preserving non-empty JSON responses. |
| agentex/tests/unit/use_cases/test_slack_gateway_use_case.py | Adds focused, non-vacuous coverage for both acknowledgement response shapes. |
| agentex/openapi.yaml | Reflects FastAPI’s generated unconstrained response schema after the routes begin returning concrete Response objects. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agentex): /agents left a stray \`{}\` ..."](https://github.com/scaleapi/scale-agentex/commit/bb3d8cf68392cb8229d8bb34157901375ba59acc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59252027)</sub>

**Context used:**

- Knowledge Base — [Slack gateway and identity linking](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/slack-gateway-and-identity-linking.md)
- Knowledge Base — [Service API and authentication](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/service-api-and-authentication.md)

<!-- /greptile_comment -->