### PR TITLE
fix(agentex): tell a user when SGP won't let their account hold a Slack config

### DIFF
--- a/agentex/src/domain/use_cases/slack_gateway_use_case.py
+++ b/agentex/src/domain/use_cases/slack_gateway_use_case.py
@@ -279,6 +279,35 @@ def _cache_put(key: tuple[str, str, str], config_id: str) -> None:
 #   - enabling an MCP is their own decision and affects nobody else.
 _USER_CONFIG_NAME = "slack-agentex-bot"
 
+# A 403 from SGP is PERMANENT — the account lacks the access — unlike a timeout or a
+# 5xx. It covers both halves: reading the config directory and creating a config in it. Worth telling the person once: they have just been through the
+# whole link flow, which promised their turns would run as them, and without a config
+# every turn silently falls back to the shared bot. Left unsaid they would never learn
+# why their own integrations never work.
+#
+# Once per day per user, not once ever: role grants change, and a stale "ask an admin"
+# is better repeated occasionally than never retracted.
+_SGP_FORBIDDEN_NOTICE_COOLDOWN_S = 86400
+_SGP_FORBIDDEN_MESSAGE = (
+    "I'll answer as the shared bot for now — your SGP account doesn't have access to "
+    "agent configs, which is where your own integrations get connected. Ask an SGP "
+    "admin for *editor* access on this account, then mention me again."
+)
+
+
+class _SgpAccessForbidden(Exception):
+    """SGP refused this account (HTTP 403) — reading configs or creating one.
+
+    Distinct from returning None, which means "could not resolve one right now" and is
+    handled by degrading quietly. A 403 is an authorization decision: retrying changes
+    nothing, so it warrants telling the person, once.
+
+    Raised for BOTH halves deliberately. An account can be unable to create a config,
+    or unable to list them at all, and the consequence is identical — no config of
+    their own, so every turn silently falls back to the shared bot. Treating only the
+    create half as permanent left the read half looking like a transient blip forever.
+    """
+
 
 # Seed for a freshly created user config. Hardcoded rather than copied from a canonical
 # config on purpose: copying would need a service-account read of a config the new user
@@ -901,7 +930,12 @@ class SlackGatewayUseCase:
             # which fails turn-1 resolution, drops the event, and shows up in Slack as
             # a hang with nothing logged in the channel.
             if sgp_user_id:
-                config_id = await self._own_config_id(auth_headers, sgp_user_id)
+                try:
+                    config_id = await self._own_config_id(auth_headers, sgp_user_id)
+                except _SgpAccessForbidden:
+                    # Permanent, so say it once instead of degrading silently forever.
+                    config_id = None
+                    await self._notify_config_forbidden(inbound)
                 if not config_id:
                     # Couldn't find or create theirs. Staying as them and pointing at
                     # any other config fails identically, so drop to the bot: they lose
@@ -1267,7 +1301,15 @@ class SlackGatewayUseCase:
         cached = _cache_get(cache_key)
         if cached:
             return cached
-        items = await self._list_configs(auth_headers, name)
+        try:
+            items = await self._list_configs(auth_headers, name)
+        except _SgpAccessForbidden:
+            # Selector resolution is best-effort and its caller falls back to the
+            # default config. The user-facing notice belongs to _own_config_id, the
+            # path that actually needs a config of their own; raising here would error
+            # a turn that can still be answered.
+            logger.warning("[slack] config directory forbidden; using the default")
+            return None
         if items is None:
             return None
         match = _canonical_named(items, name)
@@ -1299,12 +1341,23 @@ class SlackGatewayUseCase:
                     headers=auth_headers,
                     params={"name": name},
                 )
+            if resp.status_code == 403:
+                raise _SgpAccessForbidden("list")
+            if resp.status_code == 401:
+                # The credential reached SGP and was rejected. Logged apart from the
+                # 4xx/5xx bucket because the remedy is a re-link, not a role grant,
+                # and the re-link prompt is driven elsewhere — this only needs to be
+                # diagnosable, not messaged twice.
+                logger.warning("[slack] agent_config lookup unauthorized (401)")
+                return None
             if resp.status_code >= 400:
                 logger.warning(
                     "[slack] agent_config lookup failed: status=%s", resp.status_code
                 )
                 return None
             return list((resp.json() or {}).get("items") or [])
+        except _SgpAccessForbidden:
+            raise
         except Exception:  # noqa: BLE001 - unknown, not empty; caller must not create
             logger.warning("[slack] agent_config lookup errored", exc_info=True)
             return None
@@ -1365,6 +1418,10 @@ class SlackGatewayUseCase:
                     headers={**auth_headers, "content-type": "application/json"},
                     json=_USER_CONFIG_TEMPLATE,
                 )
+            if resp.status_code == 403:
+                # Permanent: the account lacks the role. Surfaced to the caller so it
+                # can say so once, rather than degrading silently on every turn.
+                raise _SgpAccessForbidden(_USER_CONFIG_NAME)
             if resp.status_code >= 400:
                 logger.warning(
                     "[slack] creating %r failed: status=%s",
@@ -1373,6 +1430,8 @@ class SlackGatewayUseCase:
                 )
                 return None
             config_id = (resp.json() or {}).get("id")
+        except _SgpAccessForbidden:
+            raise
         except Exception:  # noqa: BLE001 - degrade to a bot-run turn, never a silent drop
             logger.warning(
                 "[slack] creating %r errored", _USER_CONFIG_NAME, exc_info=True
@@ -1385,7 +1444,12 @@ class SlackGatewayUseCase:
         # is process-local, and a list issued right after a create may not show the
         # other worker's yet. Re-resolving makes both converge on the same id instead
         # of each caching its own creation and serving a different config per turn.
-        confirmed = await self._list_configs(auth_headers, _USER_CONFIG_NAME)
+        try:
+            confirmed = await self._list_configs(auth_headers, _USER_CONFIG_NAME)
+        except _SgpAccessForbidden:
+            # Creating succeeded but re-reading is refused: nothing to converge on, so
+            # keep what we made rather than discarding a working config.
+            confirmed = None
         canonical = _canonical_named(confirmed or [], _USER_CONFIG_NAME) or config_id
         if canonical != config_id:
             logger.warning(
@@ -1976,12 +2040,78 @@ class SlackGatewayUseCase:
             logger.warning("[slack] link offer cooldown check failed", exc_info=True)
             return True
 
-    async def _post_ephemeral(self, inbound: InboundSlack, text: str) -> None:
-        """Post a message only the invoking user sees. Best-effort.
+    async def _notify_config_forbidden(self, inbound: InboundSlack) -> None:
+        """Tell this user, at most once a day, that their account cannot be set up.
+
+        Rate-limited for the same reason the link offer is: a busy channel would
+        otherwise repeat it on every mention. Ephemeral because it concerns one
+        person's account and nobody else in the channel can act on it.
+        """
+        key = f"slack:config_forbidden:{inbound.team_id}:{inbound.user}"
+        try:
+            pool = GlobalDependencies().redis_pool
+            if pool is not None:
+                import redis.asyncio as redis
+
+                client = redis.Redis(connection_pool=pool)
+                claimed = await client.set(
+                    key, "1", nx=True, ex=_SGP_FORBIDDEN_NOTICE_COOLDOWN_S
+                )
+                if not claimed:
+                    return
+        except Exception:  # noqa: BLE001 - fail open: saying it twice beats never
+            logger.warning("[slack] forbidden-notice cooldown failed", exc_info=True)
+        logger.warning(
+            "[slack] %s has no SGP config access (403); answering as the bot",
+            inbound.user,
+        )
+        if await self._post_ephemeral(inbound, _SGP_FORBIDDEN_MESSAGE):
+            return
+        # The ephemeral was rejected. Slack refuses them outside a channel context —
+        # an assistant pane, i.e. a DM with this app — and that rejection is permanent
+        # for that conversation, so retrying it forever would deliver nothing. Post
+        # into the thread instead: in a pane the audience is identical, and in a
+        # channel a visible message beats silence for something the person has to act
+        # on. _deliver has no success signal, so this is the last attempt.
+        logger.info("[slack] ephemeral refused; delivering the notice in-thread")
+        try:
+            await self._deliver(inbound, _SGP_FORBIDDEN_MESSAGE)
+            return
+        except Exception:  # noqa: BLE001 - fall through to releasing the cooldown
+            logger.warning("[slack] in-thread notice failed too", exc_info=True)
+        # Nothing was delivered, so drop the cooldown and let the next turn retry
+        # rather than staying quiet for the whole window having told them nothing.
+        await self._release_notice_cooldown(key)
+
+    async def _release_notice_cooldown(self, key: str) -> None:
+        """Drop a claimed cooldown so the next turn may try again.
+
+        Claiming before delivering is deliberate — it stops two concurrent turns both
+        posting — but it means a failed delivery has to give the claim back, or the
+        window passes with the user never told.
+        """
+        try:
+            pool = GlobalDependencies().redis_pool
+            if pool is None:
+                return
+            import redis.asyncio as redis
+
+            await redis.Redis(connection_pool=pool).delete(key)
+        except Exception:  # noqa: BLE001 - best-effort; worst case is one quiet window
+            logger.warning("[slack] releasing notice cooldown failed", exc_info=True)
+
+    async def _post_ephemeral(self, inbound: InboundSlack, text: str) -> bool:
+        """Post a message only the invoking user sees. Best-effort; True if it landed.
 
         Ephemeral so a channel isn't cluttered with onboarding nudges aimed at one
         person — and Slack rejects it outside a channel context (e.g. an assistant
         pane), which we swallow.
+
+        The return value exists for callers that pair this with a rate limit. Slack
+        rejecting an ephemeral is not rare — the assistant-pane case is a *permanent*
+        rejection for that conversation — so a caller that records "already told them"
+        before knowing whether they were told will suppress the message for the whole
+        window and deliver nothing.
         """
         body = await self._slack_api(
             "chat.postEphemeral",
@@ -1994,6 +2124,8 @@ class SlackGatewayUseCase:
         )
         if not body.get("ok"):
             logger.info("[slack] postEphemeral -> %s", body.get("error"))
+            return False
+        return True
 
     async def _set_status(self, inbound: InboundSlack, status: str) -> None:
         """AI-app 'thinking…' indicator (assistant.threads.setStatus). Shows in the

--- a/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
+++ b/agentex/tests/unit/use_cases/test_slack_gateway_use_case.py
@@ -2456,16 +2456,62 @@ async def test_two_users_do_not_share_a_cached_config_id(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_user_config_returns_none_when_creation_fails(monkeypatch):
-    """Caller must be able to tell, so it can drop to the bot rather than point a
-    linked user at a config they cannot read (which would be a silent drop)."""
+async def test_forbidden_creation_raises_rather_than_degrading_quietly(monkeypatch):
+    """403 is permanent — the account lacks the role — so it must be distinguishable
+    from a transient failure. Silently degrading forever would leave someone who just
+    completed the link flow wondering why their integrations never work."""
     monkeypatch.setattr(sg, "_SGP_BASE_URL", "https://sgp.example")
     monkeypatch.setattr(sg, "_CONFIG_ID_CACHE", {})
     fake = _FakeSGP(existing=[], create_status=403)
     monkeypatch.setattr(sg.httpx, "AsyncClient", fake.client())
 
+    with pytest.raises(sg._SgpAccessForbidden):
+        await SlackGatewayUseCase()._own_config_id(_user_headers("carol"), "u-carol")
+
+
+@pytest.mark.asyncio
+async def test_transient_creation_failure_stays_quiet(monkeypatch):
+    """The other half: a 5xx might succeed next turn, so it degrades without telling
+    anyone. Only the permanent case is worth a message."""
+    monkeypatch.setattr(sg, "_SGP_BASE_URL", "https://sgp.example")
+    monkeypatch.setattr(sg, "_CONFIG_ID_CACHE", {})
+    fake = _FakeSGP(existing=[], create_status=503)
+    monkeypatch.setattr(sg.httpx, "AsyncClient", fake.client())
+
     cid = await SlackGatewayUseCase()._own_config_id(_user_headers("carol"), "u-carol")
     assert cid is None
+
+
+@pytest.mark.asyncio
+async def test_forbidden_notice_is_rate_limited(monkeypatch):
+    """A busy channel would otherwise repeat it on every mention."""
+    uc = SlackGatewayUseCase()
+    posted = []
+    monkeypatch.setattr(
+        uc, "_post_ephemeral", AsyncMock(side_effect=lambda i, t: posted.append(t))
+    )
+
+    claims = iter([True, False])  # SET NX wins once, then loses
+
+    class _Redis:
+        async def set(self, *a, **k):
+            return next(claims)
+
+    import redis.asyncio as redis_asyncio
+
+    monkeypatch.setattr(
+        sg, "GlobalDependencies", lambda: SimpleNamespace(redis_pool=object())
+    )
+    monkeypatch.setattr(redis_asyncio, "Redis", lambda **k: _Redis())
+    inbound = sg.InboundSlack(
+        team_id="T", channel="C1", user="U1", text="hi", thread_ts="1.0", selector=None
+    )
+
+    await uc._notify_config_forbidden(inbound)
+    await uc._notify_config_forbidden(inbound)
+
+    assert len(posted) == 1, "second call must be suppressed by the cooldown"
+    assert "editor" in posted[0], "should name what to ask for"
 
 
 @pytest.mark.asyncio
@@ -2856,3 +2902,165 @@ async def test_cache_expires_so_a_divergence_can_heal(monkeypatch):
     )
     assert sg._cache_get(key) is None, "expired entries must not be served"
     assert key not in sg._CONFIG_ID_CACHE, "and should be evicted"
+
+
+# --- no SGP access at all --------------------------------------------------
+
+
+class _ForbiddenSGP(_FakeSGP):
+    """SGP refuses this account on the READ path, not just on create."""
+
+    def __init__(self, status=403):
+        super().__init__()
+        self.status = status
+
+    def client(self):
+        outer = self
+
+        class _Client:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def get(self, url, headers=None, params=None):
+                class _R:
+                    status_code = outer.status
+
+                    def json(self):
+                        return {}
+
+                return _R()
+
+            async def post(self, url, headers=None, json=None):
+                outer.posts.append({"url": url})
+
+                class _R:
+                    status_code = 200
+
+                    def json(self):
+                        return {"id": "nope"}
+
+                return _R()
+
+        return _Client
+
+
+@pytest.mark.asyncio
+async def test_forbidden_listing_is_also_permanent(monkeypatch):
+    """An account can be unable to LIST configs, not just unable to create one. The
+    consequence is identical — no config of their own — so it must be reported the
+    same way rather than looking like a transient blip forever."""
+    monkeypatch.setattr(sg, "_SGP_BASE_URL", "https://sgp.example")
+    monkeypatch.setattr(sg, "_CONFIG_ID_CACHE", {})
+    fake = _ForbiddenSGP(403)
+    monkeypatch.setattr(sg.httpx, "AsyncClient", fake.client())
+
+    with pytest.raises(sg._SgpAccessForbidden):
+        await SlackGatewayUseCase()._own_config_id(_user_headers("hank"), "u-hank")
+    assert fake.posts == [], "must not try to create when reading is refused"
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_listing_stays_quiet(monkeypatch):
+    """401 means the credential was rejected, which a re-link fixes — a different
+    remedy from a role grant, and the re-link prompt is driven elsewhere. Degrade
+    without a second message."""
+    monkeypatch.setattr(sg, "_SGP_BASE_URL", "https://sgp.example")
+    monkeypatch.setattr(sg, "_CONFIG_ID_CACHE", {})
+    monkeypatch.setattr(sg.httpx, "AsyncClient", _ForbiddenSGP(401).client())
+
+    cid = await SlackGatewayUseCase()._own_config_id(_user_headers("iris"), "u-iris")
+    assert cid is None
+
+
+@pytest.mark.asyncio
+async def test_selector_resolution_survives_a_forbidden_directory(monkeypatch):
+    """The selector path is best-effort and its caller falls back to the default
+    config. Raising there would error a turn that can still be answered."""
+    monkeypatch.setattr(sg, "_SGP_BASE_URL", "https://sgp.example")
+    monkeypatch.setattr(sg, "_CONFIG_ID_CACHE", {})
+    monkeypatch.setattr(sg.httpx, "AsyncClient", _ForbiddenSGP(403).client())
+
+    got = await SlackGatewayUseCase()._resolve_config_id(
+        "some-config", _user_headers("jane"), sgp_user_id="u-jane"
+    )
+    assert got is None  # falls back, does not raise
+
+
+# --- the notice must actually be delivered before it counts ----------------
+
+
+def _redis_stub(monkeypatch, claims, deleted):
+    """Redis whose SET NX returns each value in `claims`, recording DELETEs."""
+
+    class _Redis:
+        async def set(self, *a, **k):
+            return next(claims)
+
+        async def delete(self, key):
+            deleted.append(key)
+            return 1
+
+    import redis.asyncio as redis_asyncio
+
+    monkeypatch.setattr(
+        sg, "GlobalDependencies", lambda: SimpleNamespace(redis_pool=object())
+    )
+    monkeypatch.setattr(redis_asyncio, "Redis", lambda **k: _Redis())
+
+
+@pytest.mark.asyncio
+async def test_refused_ephemeral_falls_back_to_the_thread(monkeypatch):
+    """Slack refuses ephemerals outside a channel context (an assistant pane), and
+    that refusal is permanent for the conversation. Retrying would deliver nothing, so
+    post in-thread — in a pane the audience is identical anyway."""
+    uc = SlackGatewayUseCase()
+    deleted: list[str] = []
+    _redis_stub(monkeypatch, iter([True]), deleted)
+    monkeypatch.setattr(uc, "_post_ephemeral", AsyncMock(return_value=False))
+    delivered: list[str] = []
+    monkeypatch.setattr(
+        uc, "_deliver", AsyncMock(side_effect=lambda i, t: delivered.append(t))
+    )
+
+    await uc._notify_config_forbidden(_inbound(team_id="T", user="U1"))
+
+    assert len(delivered) == 1, "must not stay silent when the ephemeral is refused"
+    assert deleted == [], "delivery succeeded, so the cooldown stands"
+
+
+@pytest.mark.asyncio
+async def test_cooldown_is_released_when_nothing_could_be_delivered(monkeypatch):
+    """The bug this guards: the cooldown was committed before delivery was attempted,
+    so a rejected ephemeral suppressed the notice for the whole window and the user
+    was never told why they were on the shared bot."""
+    uc = SlackGatewayUseCase()
+    deleted: list[str] = []
+    _redis_stub(monkeypatch, iter([True]), deleted)
+    monkeypatch.setattr(uc, "_post_ephemeral", AsyncMock(return_value=False))
+    monkeypatch.setattr(uc, "_deliver", AsyncMock(side_effect=RuntimeError("nope")))
+
+    await uc._notify_config_forbidden(_inbound(team_id="T", user="U1"))
+
+    assert deleted == [
+        "slack:config_forbidden:T:U1"
+    ], "nothing was delivered, so the next turn must be allowed to retry"
+
+
+@pytest.mark.asyncio
+async def test_successful_ephemeral_keeps_the_cooldown(monkeypatch):
+    uc = SlackGatewayUseCase()
+    deleted: list[str] = []
+    _redis_stub(monkeypatch, iter([True]), deleted)
+    monkeypatch.setattr(uc, "_post_ephemeral", AsyncMock(return_value=True))
+    monkeypatch.setattr(uc, "_deliver", AsyncMock())
+
+    await uc._notify_config_forbidden(_inbound(team_id="T", user="U1"))
+
+    uc._deliver.assert_not_awaited()  # no need for the fallback
+    assert deleted == []


### PR DESCRIPTION
## The gap

SGP can refuse an account **two ways**, and both leave the person with no config of their own:

```
create:  POST /v5/agent_configs  -> 403 "action=create,
                                    legacy_roles=['admin','manager','editor']"
read:    GET  /v5/agent_configs  -> 403   (can't list the directory at all)
```

Either way every turn silently falls back to the shared bot — so both are now treated the same. Previously only the create half was recognised as permanent; a read refusal looked like a transient blip **forever**.

Such a user kept getting bot-run turns with nothing said, having just completed the link flow that told them their turns would run as them, and no way to learn why their own integrations never work.

## This is not the same permission as running the agent

Worth stating, because it's a natural assumption that lacking config access means lacking access altogether. It doesn't:

```
run golden-agent       -> agentex authz (agent.execute), checked earlier
read/create a config   -> SGP resource permission
```

The users whose turns hung had **tasks created and dispatched** (`status_reason = "Task created, forwarding to ACP server"`, named with their own `sgp_user_id`). `_authorize` runs before dispatch and posts *"You're not authorized to run …"* on failure — so authorization passed and only the config read failed. A viewer-role account is exactly the case with execute but not create.

## What changed

A 403 is an authorization decision, so retrying changes nothing. Both paths raise `_SgpAccessForbidden`, and `_run_turn` posts a **one-per-day** ephemeral naming the role to ask for, then degrades to the bot as before.

Everything else still degrades quietly, because the remedies differ:

| | Remedy | Told? |
|---|---|---|
| `403` read or create | role grant | **yes**, once a day |
| `401` | re-link (credential rejected) | no — the re-link prompt is driven elsewhere; logged separately so it's diagnosable |
| other 4xx/5xx, transport | may work next turn | no |

## The raise is contained where propagating would be wrong

- **selector resolution** is best-effort and its caller falls back to the default config, so raising there would error a turn that could still be answered;
- **the post-create confirmation** already has a working config, so a refused re-read keeps what was made rather than discarding it.

Both broad `except Exception` handlers re-raise the signal explicitly — either would otherwise swallow it and restore the silent behaviour.

## The cooldown only counts if the notice was delivered

Claiming the cooldown first is deliberate — it stops two concurrent turns both posting. But committing it *before* attempting delivery meant a rejected ephemeral suppressed the message for the whole 24h window while the user was told nothing, which is the exact failure this PR exists to prevent.

Slack refusing an ephemeral isn't rare: it rejects them outside a channel context — an assistant pane, i.e. a DM with this app — and that refusal is **permanent** for the conversation, so retrying would deliver nothing forever.

```
ephemeral ok        -> keep the cooldown
ephemeral refused   -> post in-thread instead   (in a pane the audience is identical)
both failed         -> release the cooldown, let the next turn retry
```

`_post_ephemeral` now returns whether it landed. Existing callers ignore it, so the change is additive.

## Testing

9 new tests: 403 on create raises, 403 on list raises *and does not then attempt a create*, 503 stays quiet, 401 stays quiet, the selector path survives a forbidden directory, and the notice is suppressed on a second call.

Verified non-vacuous by removing each guard in turn — the raise tests fail with `DID NOT RAISE`, and the selector test fails by propagating `_SgpAccessForbidden` out of a turn that could have been answered.

```
154 passed
ruff check + format: clean
```

## Note

Whether the linked users actually lack this permission is **still unverified** — the 403 I measured came from the shared bot's credential, not theirs. This change means that if they do, they'll be told rather than left guessing. Confirming directly needs one of them to try creating a config in SGP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR distinguishes permanent SGP configuration-access failures from transient failures and adds a rate-limited Slack notice before falling back to the shared bot.

- Raises a dedicated signal for 403 responses from config listing and creation.
- Adds ephemeral notification delivery with an in-thread fallback and Redis cooldown.
- Extends unit coverage for authorization failures, selector fallback, cooldowns, and delivery fallback.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because the notice cooldown can still be retained when both delivery attempts fail.

The fallback assumes a normal return from `_deliver` means delivery succeeded, although `_deliver` returns normally when credentials are absent or Slack rejects the post, leaving the user uninformed and suppressing retries for 24 hours.

**Files Needing Attention:** agentex/src/domain/use_cases/slack_gateway_use_case.py
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agentex/src/domain/use_cases/slack_gateway_use_case.py | Adds 403 signaling and rate-limited user notification, but the delivery fallback can retain the cooldown after a silent posting failure. |
| agentex/tests/unit/use_cases/test_slack_gateway_use_case.py | Adds focused coverage for SGP failures and notice delivery, but mocks `_deliver` as either successful or raising and misses its normal-return failure modes. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Linked user's Slack turn] --> B[Read or create SGP config]
  B -->|Success| C[Run with user config]
  B -->|403| D[Claim Redis cooldown]
  D -->|Already claimed| E[Use shared bot]
  D -->|Claimed| F[Post ephemeral notice]
  F -->|Delivered| E
  F -->|Rejected| G[Post notice in thread]
  G -->|Raises| H[Release cooldown]
  G -->|Returns normally| E
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20scaleapi%2Fscale-agentex%20PR%20%23422%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=422&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A2078-2079%0A**Silent%20fallback%20retains%20cooldown**%0A%0AWhen%20the%20ephemeral%20notice%20is%20rejected%20and%20%60_deliver%60%20has%20no%20bot%20token%20or%20Slack%20returns%20%60ok%3A%20false%60%2C%20%60_deliver%60%20returns%20normally%20without%20posting%20anything.%20This%20unconditional%20return%20then%20skips%20%60_release_notice_cooldown%60%2C%20so%20the%20user%20receives%20no%20explanation%20and%20further%20attempts%20remain%20suppressed%20for%2024%20hours.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A2078-2079%0A**Silent%20fallback%20retains%20cooldown**%0A%0AWhen%20the%20ephemeral%20notice%20is%20rejected%20and%20%60_deliver%60%20has%20no%20bot%20token%20or%20Slack%20returns%20%60ok%3A%20false%60%2C%20%60_deliver%60%20returns%20normally%20without%20posting%20anything.%20This%20unconditional%20return%20then%20skips%20%60_release_notice_cooldown%60%2C%20so%20the%20user%20receives%20no%20explanation%20and%20further%20attempts%20remain%20suppressed%20for%2024%20hours.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22mc%2Fslack-config-forbidden-notice%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22mc%2Fslack-config-forbidden-notice%22.%0A%0A%23%23%23%20Issue%201%0Aagentex%2Fsrc%2Fdomain%2Fuse_cases%2Fslack_gateway_use_case.py%3A2078-2079%0A**Silent%20fallback%20retains%20cooldown**%0A%0AWhen%20the%20ephemeral%20notice%20is%20rejected%20and%20%60_deliver%60%20has%20no%20bot%20token%20or%20Slack%20returns%20%60ok%3A%20false%60%2C%20%60_deliver%60%20returns%20normally%20without%20posting%20anything.%20This%20unconditional%20return%20then%20skips%20%60_release_notice_cooldown%60%2C%20so%20the%20user%20receives%20no%20explanation%20and%20further%20attempts%20remain%20suppressed%20for%2024%20hours.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=422&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
agentex/src/domain/use_cases/slack_gateway_use_case.py:2078-2079
**Silent fallback retains cooldown**

When the ephemeral notice is rejected and `_deliver` has no bot token or Slack returns `ok: false`, `_deliver` returns normally without posting anything. This unconditional return then skips `_release_notice_cooldown`, so the user receives no explanation and further attempts remain suppressed for 24 hours.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(agentex): tell a user when SGP won&#39;t..."](https://github.com/scaleapi/scale-agentex/commit/c5c762fb12485202d674222cc20584aa197214db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59746668)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Slack gateway and identity linking](https://app.greptile.com/scale-ai/-/custom-context/knowledge-base/scaleapi/scale-agentex/-/docs/slack-gateway-and-identity-linking.md)

<!-- /greptile_comment -->