### PR TITLE
chore(stainless): add stlc workspace config and custom-code tracking

### DIFF
--- a/stainless/.gitignore
+++ b/stainless/.gitignore
@@ -1,0 +1,2 @@
+sdks/
+builds/

--- a/stainless/custom-code/python/2026-09-02T18-57-23-317Z-custom-code.json
+++ b/stainless/custom-code/python/2026-09-02T18-57-23-317Z-custom-code.json
@@ -1,0 +1,6 @@
+{
+  "base": "08bb48c2fad4ba7e45f524e77a47e12cd302aad4",
+  "integrated": "f394ce7f1dfd0088eb63e7cdf64ff37307990706",
+  "branch": "main",
+  "filename": "2026-09-02T18-57-23-317Z-custom-code.json"
+}

--- a/stainless/custom-code/python/2026-09-02T22-00-32-303Z-custom-code.json
+++ b/stainless/custom-code/python/2026-09-02T22-00-32-303Z-custom-code.json
@@ -1,0 +1,6 @@
+{
+  "base": "0752bd3dd078d307f0cc91cafba04e58132f209d",
+  "integrated": "dc4c7f7b373cec154a3d2314a901dbe9c36bfc0a",
+  "filename": "2026-09-02T22-00-32-303Z-custom-code.json",
+  "branch": "aringuyen/add-stlc"
+}

--- a/stainless/custom-code/python/2026-09-02T22-00-32-303Z-custom-code.json
+++ b/stainless/custom-code/python/2026-09-02T22-00-32-303Z-custom-code.json
@@ -1,6 +1,6 @@
 {
-  "base": "0752bd3dd078d307f0cc91cafba04e58132f209d",
-  "integrated": "dc4c7f7b373cec154a3d2314a901dbe9c36bfc0a",
+  "base": "ad9a0a7e9f91af40133c0eba6c42fc5cf2eeca69",
+  "integrated": "7d654c64371222b6a37a0602309d1a0c2f36d171",
   "filename": "2026-09-02T22-00-32-303Z-custom-code.json",
   "branch": "aringuyen/add-stlc"
 }

--- a/stainless/custom-code/typescript/2026-09-02T18-57-22-747Z-custom-code.json
+++ b/stainless/custom-code/typescript/2026-09-02T18-57-22-747Z-custom-code.json
@@ -1,0 +1,6 @@
+{
+  "base": "821e5dbeb4f943017eb57aa3eefd2677c4c1636f",
+  "integrated": "e0e33cd9b1f4de7f3544b7bd2407c065b2fe69b2",
+  "branch": "main",
+  "filename": "2026-09-02T18-57-22-747Z-custom-code.json"
+}

--- a/stainless/stainless.yml
+++ b/stainless/stainless.yml
@@ -1,0 +1,314 @@
+# yaml-language-server: $schema=https://app.stainless.com/config-internal.schema.json
+
+organization:
+  # Name of your organization or company, used to determine the name of the client
+  # and headings.
+  name: agentex
+  # Link to your API documentation.
+  docs: https://docs.gp.scale.com
+  # Contact email for bug reports, questions, and support requests.
+  contact: roxanne.farhad@scale.com
+
+# `targets` define the output targets and their customization options, such as
+# whether to emit the Node SDK and what it's package name should be.
+targets:
+  typescript:
+    package_name: agentex
+    production_repo: scaleapi/scale-agentex-typescript
+    publish:
+      npm: true
+    staging_repo: scaleapi/agentex-sdk-typescript
+  python:
+    keep_files:
+      - "adk/**"
+    edition: python.2025-11-20
+    package_name: agentex
+    production_repo: scaleapi/scale-agentex-python
+    publish:
+      pypi: true
+    project_name: agentex-client
+    staging_repo: scaleapi/agentex-sdk-python
+
+# `environments` are a map of the name of the environment (e.g. "sandbox",
+# "production") to the corresponding url to use.
+environments:
+  production: http://localhost:5003
+  development: http://localhost:5003
+
+# `resources` define the structure and organization for your API, such as how
+# methods and models are grouped together and accessed. See the [configuration
+# guide] for more information.
+#
+# [configuration guide]: https://www.stainless.com/docs/guides/configure#resources
+resources:
+
+  $shared:
+    models:
+      delete_response: DeleteResponse
+
+  agents:
+    # Configure the models--named types--defined in the resource. Each key in the
+    # object is the name of the model and the value is either the name of a schema in
+    # `#/components/schemas` or an object with more detail.
+    #
+    # [reference]: https://www.stainless.com/docs/reference/config#model
+    models:
+      acp_type: '#/components/schemas/ACPType'
+      agent: '#/components/schemas/Agent'
+      agent_rpc_request: '#/components/schemas/AgentRPCRequest'
+      # agent_rpc_params: '#/components/schemas/AgentRPCParams'
+      task_message_content: '#/components/schemas/TaskMessageContent'
+      agent_rpc_response: '#/components/schemas/AgentRPCResponse'
+      agent_rpc_result: 'AgentRPCResult'
+      task_message_update:
+        openapi_uri: 'TaskMessageUpdate'
+        force_generation: true
+      text_delta: 'TextDelta'
+      data_delta: 'DataDelta'
+      reasoning_summary_delta: 'ReasoningSummaryDelta'
+      reasoning_content_delta: 'ReasoningContentDelta'
+      tool_request_delta: 'ToolRequestDelta'
+      tool_response_delta: 'ToolResponseDelta'
+      task_message_delta: 'TaskMessageDelta'
+    methods:
+      retrieve: get /agents/{agent_id}
+      delete: delete /agents/{agent_id}
+      list: get /agents
+      # register: post /agents/register
+      rpc: post /agents/{agent_id}/rpc
+
+      retrieve_by_name: get /agents/name/{agent_name}
+      delete_by_name: delete /agents/name/{agent_name}
+      rpc_by_name: post /agents/name/{agent_name}/rpc
+      register_build: post /agents/register-build
+      # handle_rpc:
+      #   endpoint: post /agents/{agent_id}/rpc
+      #   type: http
+      #   streaming:
+      #     type: jsonl
+      #     param_discriminator: TODO_UNSUPPORTED
+      # Subresources define resources that are nested within another for more powerful
+      # logical groupings, e.g. `cards.payments`.
+      # subresources:
+      #   name:
+      #     methods:
+      #       retrieve: get /agents/name/{agent_name}
+      #       delete: delete /agents/name/{agent_name}
+      #       rpc: post /agents/name/{agent_name}/rpc
+      #       handle_rpc:
+      #         endpoint: post /agents/name/{agent_name}/rpc
+      #         type: http
+      # streaming:
+      #   type: jsonl
+      #   param_discriminator: TODO_UNSUPPORTED
+
+    subresources:
+      deployments:
+        methods:
+          create: post /agents/{agent_id}/deployments
+          list: get /agents/{agent_id}/deployments
+          retrieve: get /agents/{agent_id}/deployments/{deployment_id}
+          delete: delete /agents/{agent_id}/deployments/{deployment_id}
+          promote: post /agents/{agent_id}/deployments/{deployment_id}/promote
+          preview_rpc: post /agents/{agent_id}/deployments/{deployment_id}/rpc
+      schedules:
+        methods:
+          create: post /agents/{agent_id}/schedules
+          list: get /agents/{agent_id}/schedules
+
+          retrieve: get /agents/{agent_id}/schedules/{schedule_id}
+          update: patch /agents/{agent_id}/schedules/{schedule_id}
+          delete: delete /agents/{agent_id}/schedules/{schedule_id}
+          pause: post /agents/{agent_id}/schedules/{schedule_id}/pause
+          resume: post /agents/{agent_id}/schedules/{schedule_id}/resume
+          trigger: post /agents/{agent_id}/schedules/{schedule_id}/trigger
+          skip: post /agents/{agent_id}/schedules/{schedule_id}/skip
+          unskip: post /agents/{agent_id}/schedules/{schedule_id}/unskip
+
+          retrieve_by_name: get /agents/{agent_id}/schedules/name/{name}
+          update_by_name: patch /agents/{agent_id}/schedules/name/{name}
+          delete_by_name: delete /agents/{agent_id}/schedules/name/{name}
+          pause_by_name: post /agents/{agent_id}/schedules/name/{name}/pause
+          resume_by_name: post /agents/{agent_id}/schedules/name/{name}/resume
+          trigger_by_name: post /agents/{agent_id}/schedules/name/{name}/trigger
+  tasks:
+    models:
+      task: '#/components/schemas/Task'
+    methods:
+      retrieve: get /tasks/{task_id}
+      delete: delete /tasks/{task_id}
+      list: get /tasks
+      stream_events:
+        endpoint: get /tasks/{task_id}/stream
+        type: http
+        streaming:
+          type: sse
+          param_discriminator: null
+      retrieve_by_name: get /tasks/name/{task_name}
+      delete_by_name: delete /tasks/name/{task_name}
+      stream_events_by_name:
+        endpoint: get /tasks/name/{task_name}/stream
+        type: http
+        streaming:
+          type: sse
+          param_discriminator: null
+      update_by_id: put /tasks/{task_id}
+      update_by_name: put /tasks/name/{task_name}
+      complete: post /tasks/{task_id}/complete
+      fail: post /tasks/{task_id}/fail
+      cancel: post /tasks/{task_id}/cancel
+      terminate: post /tasks/{task_id}/terminate
+      timeout: post /tasks/{task_id}/timeout
+      query_workflow: get /tasks/{task_id}/query/{query_name}
+      interrupt: post /tasks/{task_id}/interrupt
+    # subresources:
+    #   name:
+    #     methods:
+    #       retrieve: get /tasks/name/{task_name}
+    #       delete: delete /tasks/name/{task_name}
+    #       stream_events:
+    #         endpoint: get /tasks/name/{task_name}/stream
+    #         type: http
+    #         streaming:
+    #           type: sse
+    #           param_discriminator: null
+
+  messages:
+    models:
+      data_content: '#/components/schemas/DataContent'
+      message_author: '#/components/schemas/MessageAuthor'
+      message_style: '#/components/schemas/MessageStyle'
+      # streaming_status: '#/components/schemas/StreamingStatus'
+      task_message: '#/components/schemas/TaskMessage'
+      text_content: '#/components/schemas/TextContent'
+      text_format: '#/components/schemas/TextFormat'
+      reasoning_content: '#/components/schemas/ReasoningContent'
+      tool_request_content: '#/components/schemas/ToolRequestContent'
+      tool_response_content: '#/components/schemas/ToolResponseContent'
+    methods:
+      create: post /messages
+      list: get /messages
+      update: put /messages/{message_id}
+      retrieve: get /messages/{message_id}
+      list_paginated: get /messages/paginated
+    subresources:
+      batch:
+        methods:
+          update: put /messages/batch
+          create: post /messages/batch
+
+  spans:
+    models:
+      span: '#/components/schemas/Span'
+    methods:
+      create: post /spans
+      list: get /spans
+      update: patch /spans/{span_id}
+      retrieve: get /spans/{span_id}
+
+  states:
+    models:
+      state: '#/components/schemas/State'
+    methods:
+      create: post /states
+      list: get /states
+      retrieve: get /states/{state_id}
+      update: put /states/{state_id}
+      delete: delete /states/{state_id}
+
+  events:
+    models:
+      event: '#/components/schemas/Event'
+    methods:
+      retrieve: get /events/{event_id}
+      list: get /events
+
+  tracker:
+    models:
+      agent_task_tracker: '#/components/schemas/AgentTaskTracker'
+    methods:
+      retrieve: get /tracker/{tracker_id}
+      update: put /tracker/{tracker_id}
+      list: get /tracker
+  deployment_history:
+    methods:
+      retrieve: get /deployment-history/{deployment_id}
+      list: get /deployment-history
+    models:
+      deployment_history: '#/components/schemas/DeploymentHistory'
+  checkpoints:
+    methods:
+      get_tuple: post /checkpoints/get-tuple
+      put: post /checkpoints/put
+      put_writes: post /checkpoints/put-writes
+      list: post /checkpoints/list
+      delete_thread: post /checkpoints/delete-thread
+  webhooks:
+    methods:
+      create_webhook_trigger: post /agent_api_keys/webhook-trigger
+
+settings:
+  # All generated integration tests that hit the prism mock http server are marked
+  # as skipped. Removing this setting or setting it to false enables tests, but
+  # doing so may result in test failures due to bugs in the test server.
+  #
+  # [prism mock http server]: https://stoplight.io/open-source/prism
+  disable_mock_tests: true
+  license: Apache-2.0
+
+# `client_settings` define settings for the API client, such as extra constructor
+# arguments (used for authentication), retry behavior, idempotency, etc.
+client_settings:
+  opts:
+    api_key:
+      type: string
+      read_env: AGENTEX_SDK_API_KEY
+      nullable: true
+      auth:
+        security_scheme: bearerAuth
+
+security_schemes:
+  bearerAuth:
+    type: http
+    scheme: bearer
+
+security:
+  - bearerAuth: []
+  - {}
+
+# `readme` is used to configure the code snippets that will be rendered in the
+# README.md of various SDKs. In particular, you can change the `headline`
+# snippet's endpoint and the arguments to call it with.
+readme:
+  example_requests:
+    default:
+      type: request
+      endpoint: get /tasks
+      params: {}
+    headline:
+      type: request
+      endpoint: get /tasks
+      params: {}
+
+openapi:
+  transforms:
+    - reason: For better names
+      command: extractToRefs
+      args:
+        ref:
+          target: $.components.schemas.SendMessageRequest.properties.content
+          name: '#/components/schemas/AnishsCoolSchema'
+unspecified_endpoints:
+  - post /agents/register
+  - get /agents/forward/name/{agent_name}/{path}
+  - post /agents/forward/name/{agent_name}/{path}
+  - get /agent_api_keys
+  - post /agent_api_keys
+  - get /agent_api_keys/name/{name}
+  - get /agent_api_keys/{id}
+  - delete /agent_api_keys/{id}
+  - delete /agent_api_keys/name/{api_key_name}
+  - get /tasks/{task_id}/export
+  - post /tasks/{task_id}/export
+  - post /tasks/{task_id}/clean
+  - post /tasks/{task_id}/rehydrate

--- a/stainless/workspace.json
+++ b/stainless/workspace.json
@@ -1,0 +1,5 @@
+{
+  "openapi_spec": "../agentex/openapi.yaml",
+  "stainless_config": "stainless.yml",
+  "output_path": "./sdks"
+}


### PR DESCRIPTION
Commits the `stlc` workspace so SDK generation is reproducible from this repo.

The workspace directory existed locally but had never been checked in, so `stlc status` reported the Python target as unable to seal its custom-code integration state.

## What's added

| File | Purpose |
| --- | --- |
| `stainless/workspace.json` | Points at the OpenAPI spec (`../agentex/openapi.yaml`), the config, and the SDK output dir |
| `stainless/stainless.yml` | The SDK generation config — resources, models, pagination, auth, and the language targets |
| `stainless/.gitignore` | Excludes generated SDK output (`sdks/`) and build manifests (`builds/`) |
| `stainless/custom-code/**` | Per-target tracking files that record the seal points custom code is replayed against |

The tracking files are how hand-written SDK code survives regeneration — without them in version control, a later `stlc build` can't tell which commits its patches apply on top of. The Python tracking file is updated to the current seal.

## Scope

No application code, no spec changes, no migrations. Everything is under `stainless/`, and generated output stays ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Commits the Stainless workspace, generation configuration, ignored output paths, and custom-code replay seals for reproducible Python and TypeScript SDK generation.
- Defines SDK resources, models, authentication, pagination, environments, and language targets.
- Tracks Python and TypeScript custom-code integration baselines.
- Ignores generated SDK and build output.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The production endpoint and bearer-credential routing need to be corrected before merging; the identifying employee metadata should also be replaced.

Generated clients can route nominal production requests and their configured bearer credentials to localhost rather than the deployed AgentEx service.

**Files Needing Attention:** stainless/stainless.yml and stainless/custom-code/python/2026-09-02T22-00-32-303Z-custom-code.json
</details>


<details open><summary><h3>Security Review</h3></summary>

The production SDK environment is configured to use localhost while generated clients can attach an environment-provided bearer credential. A default production request can therefore fail locally or expose the credential to an unrelated process listening on port 5003. **How this was verified:** The production URL was traced from the new environments map to the generated client's bearer-auth configuration, and repository deployment documentation identifies localhost:5003 as development-only.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| stainless/stainless.yml | Adds the complete generation contract, but incorrectly maps the production environment to localhost and includes an individual employee contact. |
| stainless/workspace.json | Correctly connects the checked-in OpenAPI specification and Stainless configuration to the ignored SDK output directory. |
| stainless/custom-code/python/2026-09-02T22-00-32-303Z-custom-code.json | Tracks the refreshed Python custom-code seal but includes an identifying personal branch handle. |
| stainless/custom-code/python/2026-09-02T18-57-23-317Z-custom-code.json | Adds an earlier Python custom-code integration seal with no independently established functional defect. |
| stainless/custom-code/typescript/2026-09-02T18-57-22-747Z-custom-code.json | Adds the TypeScript custom-code integration seal with no independently established defect. |
| stainless/.gitignore | Excludes generated SDK and build directories as intended. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Workspace[workspace.json] --> Spec[agentex/openapi.yaml]
  Workspace --> Config[stainless.yml]
  Config --> Python[Generated Python SDK]
  Config --> TypeScript[Generated TypeScript SDK]
  Seals[custom-code tracking seals] --> Python
  Seals --> TypeScript
  Python --> Localhost[production: localhost:5003]
  TypeScript --> Localhost
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20scaleapi%2Fscale-agentex%20PR%20%23423%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=423&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Astainless%2Fstainless.yml%3A35-36%0A**Production%20SDK%20targets%20localhost**%0A%0AWhen%20a%20generated%20client%20uses%20the%20production%20environment%20without%20overriding%20its%20base%20URL%2C%20it%20sends%20requests%20to%20%60http%3A%2F%2Flocalhost%3A5003%60%20rather%20than%20the%20deployed%20AgentEx%20service%2C%20causing%20connection%20failures%20or%20requests%20to%20an%20unrelated%20local%20process%3B%20when%20%60AGENTEX_SDK_API_KEY%60%20is%20configured%2C%20that%20process%20also%20receives%20the%20bearer%20credential.%0A%0A**How%20this%20was%20verified%3A**%20The%20production%20URL%20was%20traced%20from%20the%20new%20environments%20map%20to%20the%20generated%20client's%20bearer-auth%20configuration%2C%20while%20repository%20deployment%20documentation%20identifies%20localhost%3A5003%20as%20development-only.%0A%0A%23%23%23%20Issue%202%0Astainless%2Fstainless.yml%3A10%0A**Employee%20identity%20enters%20public%20metadata**%0A%0AThe%20checked-in%20SDK%20configuration%20exposes%20an%20individual%20employee's%20internal%20email%20address%2C%20while%20the%20Python%20seal%20also%20records%20a%20personal%20branch%20handle.%20Replace%20these%20with%20team-owned%2C%20non-identifying%20metadata%20to%20avoid%20publishing%20employee%20details.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Astainless%2Fstainless.yml%3A35-36%0A**Production%20SDK%20targets%20localhost**%0A%0AWhen%20a%20generated%20client%20uses%20the%20production%20environment%20without%20overriding%20its%20base%20URL%2C%20it%20sends%20requests%20to%20%60http%3A%2F%2Flocalhost%3A5003%60%20rather%20than%20the%20deployed%20AgentEx%20service%2C%20causing%20connection%20failures%20or%20requests%20to%20an%20unrelated%20local%20process%3B%20when%20%60AGENTEX_SDK_API_KEY%60%20is%20configured%2C%20that%20process%20also%20receives%20the%20bearer%20credential.%0A%0A**How%20this%20was%20verified%3A**%20The%20production%20URL%20was%20traced%20from%20the%20new%20environments%20map%20to%20the%20generated%20client's%20bearer-auth%20configuration%2C%20while%20repository%20deployment%20documentation%20identifies%20localhost%3A5003%20as%20development-only.%0A%0A%23%23%23%20Issue%202%0Astainless%2Fstainless.yml%3A10%0A**Employee%20identity%20enters%20public%20metadata**%0A%0AThe%20checked-in%20SDK%20configuration%20exposes%20an%20individual%20employee's%20internal%20email%20address%2C%20while%20the%20Python%20seal%20also%20records%20a%20personal%20branch%20handle.%20Replace%20these%20with%20team-owned%2C%20non-identifying%20metadata%20to%20avoid%20publishing%20employee%20details.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fscale-agentex%22%20on%20the%20existing%20branch%20%22aringuyen%2Fadd-stlc%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22aringuyen%2Fadd-stlc%22.%0A%0A%23%23%23%20Issue%201%0Astainless%2Fstainless.yml%3A35-36%0A**Production%20SDK%20targets%20localhost**%0A%0AWhen%20a%20generated%20client%20uses%20the%20production%20environment%20without%20overriding%20its%20base%20URL%2C%20it%20sends%20requests%20to%20%60http%3A%2F%2Flocalhost%3A5003%60%20rather%20than%20the%20deployed%20AgentEx%20service%2C%20causing%20connection%20failures%20or%20requests%20to%20an%20unrelated%20local%20process%3B%20when%20%60AGENTEX_SDK_API_KEY%60%20is%20configured%2C%20that%20process%20also%20receives%20the%20bearer%20credential.%0A%0A**How%20this%20was%20verified%3A**%20The%20production%20URL%20was%20traced%20from%20the%20new%20environments%20map%20to%20the%20generated%20client's%20bearer-auth%20configuration%2C%20while%20repository%20deployment%20documentation%20identifies%20localhost%3A5003%20as%20development-only.%0A%0A%23%23%23%20Issue%202%0Astainless%2Fstainless.yml%3A10%0A**Employee%20identity%20enters%20public%20metadata**%0A%0AThe%20checked-in%20SDK%20configuration%20exposes%20an%20individual%20employee's%20internal%20email%20address%2C%20while%20the%20Python%20seal%20also%20records%20a%20personal%20branch%20handle.%20Replace%20these%20with%20team-owned%2C%20non-identifying%20metadata%20to%20avoid%20publishing%20employee%20details.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=scaleapi%2Fscale-agentex&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
stainless/stainless.yml:35-36
**Production SDK targets localhost**

When a generated client uses the production environment without overriding its base URL, it sends requests to `http://localhost:5003` rather than the deployed AgentEx service, causing connection failures or requests to an unrelated local process; when `AGENTEX_SDK_API_KEY` is configured, that process also receives the bearer credential.

**How this was verified:** The production URL was traced from the new environments map to the generated client's bearer-auth configuration, while repository deployment documentation identifies localhost:5003 as development-only.

### Issue 2
stainless/stainless.yml:10
**Employee identity enters public metadata**

The checked-in SDK configuration exposes an individual employee's internal email address, while the Python seal also records a personal branch handle. Replace these with team-owned, non-identifying metadata to avoid publishing employee details.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(stainless): commit stlc workspace ..."](https://github.com/scaleapi/scale-agentex/commit/ff51ede8de38c070e41ff4a23524ef253fd32258) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59752342)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/scaleapi/scale-agentex/blob/main/CLAUDE.md))

<!-- /greptile_comment -->