### PR TITLE
docs: fix stale paths in CLAUDE.md and the UI README's transport description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ Check `agentex/docker-compose.yml` for default values.
 ### Database Migrations
 
 Always create migrations when changing models:
-1. Modify SQLAlchemy models in `database/models/`
+1. Modify the SQLAlchemy models in `src/adapters/orm.py`
 2. Run `make migration NAME="description"` from `agentex/`
 3. Review generated migration in `database/migrations/versions/`
 4. Apply with `make apply-migrations`
@@ -380,7 +380,7 @@ Use the escape hatch for "this needs a maintenance window with traffic shifted a
 
 ##### Anti-pattern → linter rule reference
 
-The migration linter at `agentex/scripts/lint_migrations.py` enforces these rules at PR time via `.github/workflows/migration-lint.yml`. It only checks files changed vs the PR base, so existing migrations are not retro-flagged. The mapping below is what the linter catches:
+The migration linter at `agentex/scripts/ci_tools/migration_lint.py` enforces these rules at PR time via `.github/workflows/migration-lint.yml`. It only checks files changed vs the PR base, so existing migrations are not retro-flagged. The mapping below is what the linter catches:
 
 | Anti-pattern | Linter rule |
 |---|---|
@@ -393,7 +393,7 @@ The migration linter at `agentex/scripts/lint_migrations.py` enforces these rule
 Run the linter locally before pushing:
 
 ```bash
-agentex/scripts/lint_migrations.py --base-ref origin/main
+python3 agentex/scripts/ci_tools/migration_lint.py --base origin/main
 ```
 
 ##### Other rules
@@ -443,7 +443,7 @@ sudo systemctl stop redis-server
 
 ### Adding Database Tables
 
-1. Create SQLAlchemy model in `database/models/`
+1. Add the SQLAlchemy model to `src/adapters/orm.py`
 2. Generate migration: `make migration NAME="add_table_name"`
 3. Review and edit migration file if needed
 4. Apply migration: `make apply-migrations`

--- a/agentex-ui/README.md
+++ b/agentex-ui/README.md
@@ -42,7 +42,7 @@ A modern web interface for building, testing, and monitoring intelligent agents.
 
 ### Developer Experience
 
-- **Real-time Updates** - Live task and message updates via WebSocket subscriptions
+- **Real-time Updates** - Live task and message updates streamed over HTTP (`GET /tasks/{id}/stream`, server-sent events)
 - **Optimistic UI** - Instant feedback with automatic cache updates
 - **Error Handling** - User-friendly error messages with toast notifications
 - **Dark Mode** - WCAG-compliant dark mode with proper contrast ratios
@@ -53,7 +53,7 @@ A modern web interface for building, testing, and monitoring intelligent agents.
 - **Styling**: Tailwind CSS v4, shadcn/ui components
 - **State Management**: React Query for server state
 - **Data Fetching**: Agentex SDK (`agentex`) for API client + RPC helpers
-- **Real-time**: WebSocket subscriptions for live updates
+- **Real-time**: streaming HTTP subscriptions (server-sent events) for live updates
 
 ## Prerequisites
 
@@ -177,7 +177,7 @@ For Docker-related commands, see the Docker section in `build.ps1 help`.
 - `hooks/use-agents.ts` - Fetches all agents via React Query
 - `hooks/use-tasks.ts` - Task list with infinite scroll pagination
 - `hooks/use-task-messages.ts` - Message fetching and sending with message streaming for sync agents
-- `hooks/use-task-subscription.ts` - Real-time task updates via WebSocket for async agents
+- `hooks/use-task-subscription.ts` - Real-time task updates via the HTTP event stream for async agents
 - `hooks/use-spans.ts` - Execution trace data
 
 **Components:**


### PR DESCRIPTION
## What
- `CLAUDE.md` pointed at `agentex/scripts/lint_migrations.py` and a `--base-ref` flag; the migration linter lives at `agentex/scripts/ci_tools/migration_lint.py` (what `migration-lint.yml` runs) and its flag is `--base`.
- `CLAUDE.md` told contributors to edit SQLAlchemy models in `database/models/`, which does not exist; the models live in `src/adapters/orm.py`.
- `agentex-ui/README.md` described live updates as WebSocket subscriptions. The dev UI subscribes over the HTTP event stream (`GET /tasks/{id}/stream` via the `agentex` client with `stream: true`, proxied by the BFF route); there is no WebSocket in the UI.

## Why
These are the first places a new contributor is sent by the repo's own instructions, and each one currently points somewhere that does not exist or describes the wrong mechanism.

## Test
Docs-only. Paths verified against the tree and `.github/workflows/migration-lint.yml`; transport verified in `hooks/custom-subscribe-task-state.tsx` and `node_modules/agentex/resources/tasks.js`.

https://claude.ai/code/session_01HCVKnA7LeJZ44nxZz1uzF3


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62687923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation corrections appear safe to merge.

<h3>Summary</h3>

- Directs relational model changes to `agentex/src/adapters/orm.py`.
- Aligns the documented migration-lint command with the script and CI workflow.
- Updates UI architecture and hook descriptions to identify the HTTP task event stream.

<sub>Reviews (1) · Last reviewed commit: ["docs: fix stale paths in CLAUDE.md and t..."](https://github.com/scaleapi/scale-agentex/commit/c511e64afd9ffffd322fcaf39835e37c00dc766e)</sub>

<!-- /greptile_comment -->